### PR TITLE
[codex] Harden CodexPro MCP outputs and sessions

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -61,6 +61,7 @@ class McpStdioClient {
 
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-smoke-'));
 await fs.writeFile(path.join(tmp, 'demo.txt'), 'alpha\nread\nread\nomega\n', 'utf8');
+await fs.writeFile(path.join(tmp, 'config.txt'), 'OPENAI_API_KEY=sk-realSecretValue123\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'AGENTS.md'), '# Smoke Agents\n\n- Preserve demo.txt.\n', 'utf8');
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-outside-'));
 await fs.writeFile(path.join(outside, 'secret.txt'), 'do-not-read', 'utf8');
@@ -126,6 +127,12 @@ if (inventory.structuredContent.codexpro_tool !== 'codexpro_inventory') throw ne
 const opened = await client.request('tools/call', { name: 'open_workspace', arguments: { root: tmp, include_tree: true } });
 const ws = opened.structuredContent.workspace_id;
 await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'demo.txt' } });
+const secretRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'config.txt' } });
+const secretPayload = JSON.stringify(secretRead);
+if (secretPayload.includes('sk-realSecretValue123') || !secretPayload.includes('[REDACTED_SECRET]')) {
+  throw new Error('read did not redact secret-looking content');
+}
+await expectToolError('write', { workspace_id: ws, path: 'notes.md', content: 'OPENAI_API_KEY=sk-realSecretValue123\n' }, /Secret-looking content is blocked/);
 const symlinkRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'secret-link.txt' } });
 if (!symlinkRead.isError) throw new Error('symlink escape read was not blocked');
 await client.request('tools/call', { name: 'edit', arguments: { workspace_id: ws, path: 'demo.txt', old_text: 'read\nread', new_text: 'read\nwrite' } });

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
+import { redactSensitiveText } from "./redact.js";
 
 export interface BashResult {
   command: string;
@@ -214,8 +215,8 @@ export async function runBash(
       if (killedByTimeout) {
         stderr += `\n[codexpro] Command timed out after ${timeoutMs} ms.`;
       }
-      const out = trimOutput(stdout, config.maxOutputBytes);
-      const err = trimOutput(stderr, config.maxOutputBytes);
+      const out = trimOutput(redactSensitiveText(stdout), config.maxOutputBytes);
+      const err = trimOutput(redactSensitiveText(stderr), config.maxOutputBytes);
       resolve({
         command,
         cwd: path.relative(workspace.root, cwd) || ".",

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,8 @@ export interface CodexProConfig {
   maxWriteBytes: number;
   maxOutputBytes: number;
   maxSearchResults: number;
+  maxHttpSessions: number;
+  httpSessionTtlMs: number;
   blockedGlobs: string[];
   contextDir: string;
 }
@@ -197,6 +199,8 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     maxWriteBytes: numberFrom(process.env.CODEXPRO_MAX_WRITE_BYTES, 1_000_000, 1_000, 10_000_000),
     maxOutputBytes: numberFrom(process.env.CODEXPRO_MAX_OUTPUT_BYTES, 120_000, 4_000, 2_000_000),
     maxSearchResults: numberFrom(process.env.CODEXPRO_MAX_SEARCH_RESULTS, 200, 5, 2_000),
+    maxHttpSessions: numberFrom(process.env.CODEXPRO_MAX_HTTP_SESSIONS, 64, 1, 512),
+    httpSessionTtlMs: numberFrom(process.env.CODEXPRO_HTTP_SESSION_TTL_MS, 30 * 60_000, 60_000, 24 * 60 * 60_000),
     blockedGlobs: [...DEFAULT_BLOCKED_GLOBS, ...extraBlockedGlobs],
     contextDir: process.env.CODEXPRO_CONTEXT_DIR ?? ".ai-bridge"
   };

--- a/src/fsOps.ts
+++ b/src/fsOps.ts
@@ -6,6 +6,7 @@ import { minimatch } from "minimatch";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, displayPath, normalizeRelPath, PathGuard } from "./guard.js";
+import { hasSecretValue, redactSensitiveText } from "./redact.js";
 
 export interface TreeOptions {
   path?: string;
@@ -96,7 +97,7 @@ export function makeUnifiedDiff(oldText: string, newText: string, relPath: strin
   if (diff.length > maxChars) {
     diff = diff.slice(0, maxChars) + `\n...[diff truncated to ${maxChars} chars]`;
   }
-  return { diff, additions, deletions, changed: true };
+  return { diff: redactSensitiveText(diff), additions, deletions, changed: true };
 }
 
 function isHiddenName(name: string): boolean {
@@ -241,6 +242,9 @@ export async function writeTextFile(
   if (contentBytes > config.maxWriteBytes) {
     throw new CodexProError(`Write content is too large (${contentBytes} bytes). Limit: ${config.maxWriteBytes} bytes.`);
   }
+  if (hasSecretValue(content)) {
+    throw new CodexProError("Secret-looking content is blocked from write. Use placeholders such as [REDACTED_SECRET] in handoff files.");
+  }
 
   let oldText = "";
   let existed = false;
@@ -303,6 +307,9 @@ export async function editTextFile(
   const afterBytes = Buffer.byteLength(after, "utf8");
   if (afterBytes > config.maxWriteBytes) {
     throw new CodexProError(`Edited file would be too large (${afterBytes} bytes). Limit: ${config.maxWriteBytes} bytes.`);
+  }
+  if (hasSecretValue(after)) {
+    throw new CodexProError("Secret-looking content is blocked from edit. Use placeholders such as [REDACTED_SECRET] in handoff files.");
   }
 
   const diff = makeUnifiedDiff(before, after, resolved.relPath);

--- a/src/gitOps.ts
+++ b/src/gitOps.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
+import { redactSensitiveText } from "./redact.js";
 
 function runGit(workspace: Workspace, args: string[], maxOutputBytes: number): string {
   const result = spawnSync("git", args, {
@@ -18,7 +19,7 @@ function runGit(workspace: Workspace, args: string[], maxOutputBytes: number): s
     const stdout = result.stdout?.trim() || "";
     return stderr || stdout || `git exited with status ${result.status}`;
   }
-  return result.stdout.trim() || "(no output)";
+  return redactSensitiveText(result.stdout.trim() || "(no output)");
 }
 
 export function gitStatus(config: CodexProConfig, workspace: Workspace): string {
@@ -26,7 +27,7 @@ export function gitStatus(config: CodexProConfig, workspace: Workspace): string 
 }
 
 export function gitDiff(config: CodexProConfig, guard: PathGuard, workspace: Workspace, filePath?: string, staged = false): string {
-  const args = ["diff", "--no-color"];
+  const args = ["diff", "--no-color", "--no-ext-diff", "--no-textconv"];
   if (staged) args.push("--staged");
   if (filePath?.trim()) {
     const resolved = guard.resolve(workspace, filePath);

--- a/src/http.ts
+++ b/src/http.ts
@@ -293,7 +293,46 @@ async function main(): Promise<void> {
   });
   app.use(express.json({ limit: "20mb" }));
 
-  const transports: Record<string, StreamableHTTPServerTransport> = {};
+  type TransportRecord = {
+    transport: StreamableHTTPServerTransport;
+    createdAt: number;
+    lastSeenAt: number;
+  };
+
+  const transports = new Map<string, TransportRecord>();
+  const sessionIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  function closeTransport(record: TransportRecord): void {
+    void record.transport.close?.();
+  }
+
+  function pruneTransports(): void {
+    const now = Date.now();
+    for (const [sessionId, record] of transports) {
+      if (now - record.lastSeenAt > config.httpSessionTtlMs) {
+        transports.delete(sessionId);
+        closeTransport(record);
+      }
+    }
+    while (transports.size > config.maxHttpSessions) {
+      const oldest = [...transports.entries()].sort((a, b) => a[1].lastSeenAt - b[1].lastSeenAt)[0];
+      if (!oldest) break;
+      transports.delete(oldest[0]);
+      closeTransport(oldest[1]);
+    }
+  }
+
+  function getTransport(sessionId: string | undefined): StreamableHTTPServerTransport | undefined {
+    if (!sessionId || !sessionIdPattern.test(sessionId)) return undefined;
+    pruneTransports();
+    const record = transports.get(sessionId);
+    if (!record) return undefined;
+    record.lastSeenAt = Date.now();
+    return record.transport;
+  }
+
+  const pruneTimer = setInterval(pruneTransports, Math.min(config.httpSessionTtlMs, 60_000));
+  pruneTimer.unref();
 
   app.get("/", (_req, res) => {
     res.type("html").send(onboardingPage(config));
@@ -322,19 +361,26 @@ async function main(): Promise<void> {
       const sessionId = req.headers["mcp-session-id"] as string | undefined;
       let transport: StreamableHTTPServerTransport;
 
-      if (sessionId && transports[sessionId]) {
-        transport = transports[sessionId];
+      const existingTransport = getTransport(sessionId);
+      if (existingTransport) {
+        transport = existingTransport;
       } else if (!sessionId && isInitializeRequest(req.body)) {
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (newSessionId: string) => {
-            transports[newSessionId] = transport;
+            pruneTransports();
+            transports.set(newSessionId, {
+              transport,
+              createdAt: Date.now(),
+              lastSeenAt: Date.now()
+            });
+            pruneTransports();
           }
         } as any);
 
         (transport as any).onclose = () => {
           const closedSessionId = (transport as any).sessionId;
-          if (closedSessionId) delete transports[closedSessionId];
+          if (closedSessionId) transports.delete(closedSessionId);
         };
 
         const server = createCodexProServer(config);
@@ -363,11 +409,11 @@ async function main(): Promise<void> {
 
   const handleSessionRequest = async (req: express.Request, res: express.Response) => {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
-    if (!sessionId || !transports[sessionId]) {
+    const transport = getTransport(sessionId);
+    if (!transport) {
       res.status(400).send("Invalid or missing MCP session id");
       return;
     }
-    const transport = transports[sessionId];
     await transport.handleRequest(req, res);
   };
 

--- a/src/proContext.ts
+++ b/src/proContext.ts
@@ -8,6 +8,7 @@ import { CodexProError, PathGuard, normalizeRelPath } from "./guard.js";
 import { listFiles, readTextFile, repoTree, writeTextFile, ensureAiBridge } from "./fsOps.js";
 import { gitDiff, gitLog, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext } from "./workspaceOps.js";
+import { redactSensitiveText } from "./redact.js";
 
 export interface ProContextOptions {
   title?: string;
@@ -297,6 +298,7 @@ export async function exportProContext(
 ): Promise<ProContextResult> {
   await ensureAiBridge(config, guard, workspace);
   const built = await buildProContext(config, guard, workspace, options);
+  built.markdown = redactSensitiveText(built.markdown);
   const relPath = `${config.contextDir}/pro-context.md`;
   const write = await writeTextFile(config, guard, workspace, relPath, built.markdown, {
     createDirs: true,

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,40 @@
+const SECRET_VALUE_PATTERN = /\b(?:sk-[A-Za-z0-9_-]+|[A-Za-z0-9_]*(?:TOKEN|SECRET|PASSWORD|PRIVATE_KEY)[A-Za-z0-9_]*\s*=\s*[^\s]+)/gi;
+
+export function hasSecretValue(text: string): boolean {
+  SECRET_VALUE_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SECRET_VALUE_PATTERN.exec(text)) !== null) {
+    if (!isPlaceholderSecret(match[0])) return true;
+  }
+  return false;
+}
+
+export function redactSensitiveText(text: string): string {
+  SECRET_VALUE_PATTERN.lastIndex = 0;
+  return text.replace(SECRET_VALUE_PATTERN, (match) => isPlaceholderSecret(match) ? match : "[REDACTED_SECRET]");
+}
+
+export function redactStructured<T>(value: T, depth = 0): T {
+  if (depth > 8) return value;
+  if (typeof value === "string") return redactSensitiveText(value) as T;
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => redactStructured(item, depth + 1)) as T;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    out[key] = redactStructured(item, depth + 1);
+  }
+  return out as T;
+}
+
+function isPlaceholderSecret(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return (
+    normalized.includes("[redacted_secret]") ||
+    normalized.includes("replace-me") ||
+    normalized.includes("your-api-key-here") ||
+    normalized.includes("<openai_api_key>") ||
+    normalized === "sk-..." ||
+    normalized.endsWith("=sk-...")
+  );
+}

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -5,6 +5,7 @@ import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
 import { listFiles } from "./fsOps.js";
+import { redactSensitiveText } from "./redact.js";
 
 export interface SearchOptions {
   query: string;
@@ -70,7 +71,7 @@ async function runRipgrep(config: CodexProConfig, guard: PathGuard, workspace: W
         const rel = path.relative(workspace.root, absPath).split(path.sep).join("/");
         if (rel.startsWith("..")) continue;
         if (guard.isBlockedRelativePath(rel)) continue;
-        matches.push({ path: rel || ".", line: Number(match[2]), text: truncateLine(match[3]) });
+        matches.push({ path: rel || ".", line: Number(match[2]), text: redactSensitiveText(truncateLine(match[3])) });
         if (matches.length >= options.maxResults) break;
       }
       const text = matches.map((m) => `${m.path}:${m.line}: ${m.text}`).join("\n") || "No matches.";
@@ -101,7 +102,7 @@ async function runNodeSearch(config: CodexProConfig, guard: PathGuard, workspace
         const line = lines[i];
         const hit = matcher ? matcher.test(line) : line.includes(options.query);
         if (hit) {
-          matches.push({ path: rel, line: i + 1, text: truncateLine(line) });
+          matches.push({ path: rel, line: i + 1, text: redactSensitiveText(truncateLine(line)) });
           if (matches.length >= options.maxResults) break;
         }
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,16 +12,17 @@ import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./works
 import { exportProContext } from "./proContext.js";
 import { codexproInventory } from "./capabilitiesOps.js";
 import { TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
+import { redactSensitiveText, redactStructured } from "./redact.js";
 
 function errorText(error: unknown): string {
-  if (error instanceof Error) return `${error.name}: ${error.message}`;
-  return String(error);
+  if (error instanceof Error) return redactSensitiveText(`${error.name}: ${error.message}`);
+  return redactSensitiveText(String(error));
 }
 
 function textResult(text: string, structuredContent: Record<string, unknown> = {}, meta: Record<string, unknown> = {}): any {
   return {
-    content: [{ type: "text", text }],
-    structuredContent,
+    content: [{ type: "text", text: redactSensitiveText(text) }],
+    structuredContent: redactStructured(structuredContent),
     _meta: meta
   };
 }


### PR DESCRIPTION
## Summary

Hardens CodexPro's local MCP security boundaries without changing the public package version:

- add centralized secret-looking value redaction for MCP text and structured payloads
- redact search results, git output, bash output, generated diffs, and exported Pro context bundles
- block write/edit attempts that would introduce realistic secret-looking values
- add HTTP MCP session TTL/cap handling and UUID-shaped session id validation
- add smoke coverage proving redaction and secret-write blocking

## Package note

This PR does not bump `package.json` from `0.27.1`. There are no dependency or lockfile changes. A patch bump should happen in the release/publish PR when we are ready to ship to npm.

## Validation

- `npm run build`
- `npm run smoke`
- `npm audit --omit=dev`

All passed locally; production audit reports 0 vulnerabilities.
