### PR TITLE
[codex] Add generic agent handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.27.2
+
+- Added `handoff_to_agent` for file-based handoffs to Codex, OpenCode, Pi, or custom local implementation agents without executing local commands.
+- Extended `.ai-bridge` with generic `agent-status.md`, `implementation-diff.patch`, and `execution-log.jsonl` files.
+- Updated `read_handoff`, `codex_context`, Pro apply logging, docs, and smoke coverage for generic agent handoffs.
+
 ## 0.27.1
 
 - Fail closed when HTTP MCP auth is required but `CODEXPRO_HTTP_TOKEN` is missing, including public tunnel mode and non-loopback binds.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ What it gives you:
 
 ```text
 Normal coding mode  ChatGPT reads, writes, edits, searches, and verifies directly.
-Handoff mode        ChatGPT writes .ai-bridge/current-plan.md for Codex to execute.
+Handoff mode        ChatGPT writes .ai-bridge/current-plan.md for a local implementation agent.
 Pro planning mode   Export a durable context bundle for sessions that cannot call MCP tools.
 Stable URLs         Use an ngrok free dev domain or Cloudflare named tunnel so the ChatGPT app URL stays fixed.
 ```
@@ -110,7 +110,8 @@ CodexPro does not bypass, increase, or modify ChatGPT, Codex, or OpenAI rate lim
 - `read_handoff` — read `.ai-bridge` files.
 - `codex_context` — load Codex-style context in one call: AGENTS instructions for a target path, `.ai-bridge` files, and optional git status/diff.
 - `export_pro_context` — write `.ai-bridge/pro-context.md` for models that cannot call MCP tools directly.
-- `handoff_to_codex` — write `.ai-bridge/current-plan.md` and append `.ai-bridge/session-log.jsonl`.
+- `handoff_to_agent` — write `.ai-bridge/current-plan.md` for Codex, OpenCode, Pi, or a custom local implementation agent without executing local commands.
+- `handoff_to_codex` — compatibility wrapper for `handoff_to_agent` with `agent=codex`.
 
 ## Visual ChatGPT cards
 
@@ -436,6 +437,23 @@ codexpro start \
   --tunnel cloudflare
 ```
 
+In handoff mode, ChatGPT can create a plan for a local implementation agent without getting direct source-write access. Use `handoff_to_agent` from ChatGPT with `agent=opencode`, `agent=pi`, `agent=codex`, or a custom agent id. CodexPro writes:
+
+```text
+.ai-bridge/current-plan.md
+.ai-bridge/agent-status.md
+.ai-bridge/implementation-diff.patch
+.ai-bridge/execution-log.jsonl
+```
+
+Then run your local agent manually against `.ai-bridge/current-plan.md`, for example:
+
+```bash
+opencode run --model provider/cheap-model "$(cat .ai-bridge/current-plan.md)"
+```
+
+Have the implementation agent update `.ai-bridge/agent-status.md`, write the final review diff to `.ai-bridge/implementation-diff.patch` when practical, and then let ChatGPT review those files through `read_handoff` or `codex_context`.
+
 For debugging whether ChatGPT is actually reaching the local server, add:
 
 ```bash
@@ -492,9 +510,12 @@ Then it adds:
 
 ```text
 .ai-bridge/current-plan.md
+.ai-bridge/agent-status.md
+.ai-bridge/implementation-diff.patch
 .ai-bridge/codex-status.md
 .ai-bridge/decisions.md
 .ai-bridge/open-questions.md
+.ai-bridge/execution-log.jsonl
 git status
 optional git diff
 ```
@@ -561,7 +582,7 @@ codexpro pro-bundle \
   --copy
 ```
 
-Paste the bundle into any model that cannot call MCP tools directly and ask it to produce a narrow Codex plan. Save the returned plan to a file, then apply it:
+Paste the bundle into any model that cannot call MCP tools directly and ask it to produce a narrow implementation plan. Save the returned plan to a file, then apply it:
 
 ```bash
 codexpro pro-apply --root /absolute/path/to/your/repo --file plan.md
@@ -579,7 +600,7 @@ That writes:
 .ai-bridge/current-plan.md
 ```
 
-Then run Codex with the normal handoff prompt.
+Then run Codex, OpenCode, Pi, or another local implementation agent against `.ai-bridge/current-plan.md`.
 
 ## Cloudflare options
 
@@ -834,7 +855,7 @@ Example MCP config:
 `CODEXPRO_WRITE_MODE=workspace` is the default normal coding mode. Use `handoff` when you want planning-only behavior and do not want ChatGPT to edit source files directly.
 
 ```text
-off        write/edit tools are disabled; handoff_to_codex still writes .ai-bridge/current-plan.md
+off        write/edit tools are disabled; handoff_to_agent and handoff_to_codex still write .ai-bridge/current-plan.md
 handoff    write/edit can only write inside .ai-bridge/
 workspace  write/edit can write workspace files, except blocked paths
 ```
@@ -897,15 +918,15 @@ Call codexpro_inventory only when you need local skill or MCP server names.
 
 Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and git_diff or git_status when useful.
 
-Keep changes scoped to the request. Do not use handoff_to_codex unless I explicitly ask for planning-only handoff.
+Keep changes scoped to the request. Do not use handoff_to_agent or handoff_to_codex unless I explicitly ask for planning-only handoff.
 ```
 
-## Prompt for Codex
+## Prompt for a local agent
 
 ```text
 Read .ai-bridge/current-plan.md and execute it in small, reviewable steps.
 
-After each meaningful change, update .ai-bridge/codex-status.md with:
+After each meaningful change, update .ai-bridge/agent-status.md with:
 
 - what changed
 - files touched
@@ -914,7 +935,7 @@ After each meaningful change, update .ai-bridge/codex-status.md with:
 - blockers or questions
 - what ChatGPT or another reviewer should review next
 
-Keep .ai-bridge/decisions.md aligned with implementation choices. Do not overwrite .ai-bridge/current-plan.md unless asked.
+Keep .ai-bridge/decisions.md aligned with implementation choices. Save the final review diff to .ai-bridge/implementation-diff.patch when practical. Do not overwrite .ai-bridge/current-plan.md unless asked.
 ```
 
 ## Demo prompt matching the screenshots
@@ -944,7 +965,7 @@ Narrate which CodexPro tool you are using before each call.
 2. Connect the printed endpoint in ChatGPT Developer Mode.
 3. Ask ChatGPT to inspect the repo, edit files directly, and verify the work with search/read/bash/git tools.
 4. If your chosen ChatGPT model cannot call tools, run `codexpro pro-bundle --root /repo --copy`, paste the bundle into that model, then apply its plan with `codexpro pro-apply --root /repo --file plan.md`.
-5. Use `codexpro start --mode handoff` only when you want ChatGPT to write `.ai-bridge/current-plan.md` for Codex instead of editing source files itself.
+5. Use `codexpro start --mode handoff` only when you want ChatGPT to write `.ai-bridge/current-plan.md` for Codex, OpenCode, Pi, or another local implementation agent instead of editing source files itself.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexpro",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexpro",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexpro",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "A local MCP/App SDK-style connector that lets ChatGPT inspect, edit, and hand off work to Codex inside a local dev workspace.",
   "type": "module",
   "license": "MIT",

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -38,7 +38,7 @@ Options:
   --mode <agent|handoff|pro>
                              Default: agent.
                              agent = ChatGPT can read, write/edit files, search, and run safe bash.
-                             handoff = ChatGPT writes .ai-bridge plans for Codex to execute.
+                             handoff = ChatGPT writes .ai-bridge plans for a local implementation agent.
                              pro = export context for models that cannot call MCP tools.
   --agent                   Shortcut for --mode agent.
   --handoff                 Shortcut for --mode handoff.

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -182,13 +182,13 @@ try {
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);
   const queryToolNames = toolNames(queryTools);
-  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'codex_context', 'handoff_to_codex', 'export_pro_context']) {
+  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
     if (!queryToolNames.includes(expected)) {
       throw new Error(`URL-token MCP tools/list missing ${expected}; got ${queryToolNames.join(', ')}`);
     }
   }
   const toolCardUri = 'ui://widget/codexpro-tool-card-v5.html';
-  for (const visualTool of ['write', 'edit', 'export_pro_context', 'handoff_to_codex']) {
+  for (const visualTool of ['write', 'edit', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
     if (!hasWidgetMeta(queryTools, visualTool, toolCardUri)) {
       throw new Error(`${visualTool} should render the CodexPro widget`);
     }

--- a/scripts/pro-apply.mjs
+++ b/scripts/pro-apply.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 function usage() {
-  console.log(`Apply a planning-model response to the Codex handoff file
+  console.log(`Apply a planning-model response to the agent handoff file
 
 Usage:
   codexpro pro-apply --root /path/to/repo --file plan.md
@@ -110,17 +110,22 @@ async function main() {
   });
 
   const logRel = `${config.contextDir}/session-log.jsonl`;
+  const executionLogRel = `${config.contextDir}/execution-log.jsonl`;
   const logResolved = guard.resolve(workspace, logRel, { forWrite: true });
-  await fsp.appendFile(logResolved.absPath, jsonlEvent('pro_apply', {
+  const executionLogResolved = guard.resolve(workspace, executionLogRel, { forWrite: true });
+  const event = jsonlEvent('pro_apply', {
     plan_path: planPath,
     source_file: args.file ? path.resolve(args.file) : 'stdin',
     append: Boolean(args.append)
-  }), 'utf8');
+  });
+  await fsp.appendFile(logResolved.absPath, event, 'utf8');
+  await fsp.appendFile(executionLogResolved.absPath, event, 'utf8');
 
   console.log(`Wrote ${path.join(workspace.root, planPath)}`);
   console.log(`Bytes: ${result.bytes}`);
   console.log(`Diff stats: +${result.diff.additions} -${result.diff.deletions}`);
   console.log(`Session log: ${path.join(workspace.root, logRel)}`);
+  console.log(`Execution log: ${path.join(workspace.root, executionLogRel)}`);
 }
 
 main().catch((error) => {

--- a/scripts/pro-smoke.mjs
+++ b/scripts/pro-smoke.mjs
@@ -32,5 +32,9 @@ const currentPlan = await fs.readFile(path.join(root, '.ai-bridge', 'current-pla
 if (!currentPlan.includes('Smoke Pro Plan') || !currentPlan.includes('Inspect demo.txt')) {
   throw new Error('pro apply did not write expected current-plan content');
 }
+const executionLog = await fs.readFile(path.join(root, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!executionLog.includes('"event":"pro_apply"')) {
+  throw new Error('pro apply did not append execution-log event');
+}
 
 console.log('✓ pro CLI smoke test passed');

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -80,7 +80,7 @@ await client.request('initialize', {
 client.notify('notifications/initialized');
 const tools = await client.request('tools/list', {});
 const toolNames = tools.tools.map((tool) => tool.name);
-for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'codex_context', 'handoff_to_codex', 'export_pro_context']) {
+for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
   if (!toolNames.includes(expected)) throw new Error(`missing tool: ${expected}`);
 }
 const toolCardUri = 'ui://widget/codexpro-tool-card-v5.html';
@@ -99,7 +99,7 @@ async function expectToolError(name, args, pattern) {
     throw new Error(`${name} error did not match ${pattern}: ${text}`);
   }
 }
-for (const visualTool of ['write', 'edit', 'export_pro_context', 'handoff_to_codex']) {
+for (const visualTool of ['write', 'edit', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
   if (!hasWidgetMeta(visualTool)) throw new Error(`${visualTool} should render the CodexPro widget`);
 }
 for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
@@ -148,6 +148,26 @@ await expectToolError('bash', { workspace_id: ws, command: 'ls $HOME' }, /blocke
 const exported = await client.request('tools/call', { name: 'export_pro_context', arguments: { workspace_id: ws, selected_paths: ['demo.txt'], max_files: 4, max_total_bytes: 80000 } });
 if (exported.structuredContent.path !== '.ai-bridge/pro-context.md') throw new Error('export_pro_context wrote an unexpected path');
 await fs.stat(path.join(tmp, '.ai-bridge', 'pro-context.md'));
-await client.request('tools/call', { name: 'handoff_to_codex', arguments: { workspace_id: ws, title: 'Smoke plan', plan: '- Verify demo.txt contains write.' } });
+const agentHandoff = await client.request('tools/call', {
+  name: 'handoff_to_agent',
+  arguments: {
+    workspace_id: ws,
+    agent: 'opencode',
+    model: 'provider/cheap-model',
+    title: 'Smoke agent plan',
+    plan: '- Verify demo.txt contains write.'
+  }
+});
+if (agentHandoff.structuredContent.agent !== 'opencode') throw new Error('handoff_to_agent did not preserve target agent');
+for (const bridgeFile of ['agent-status.md', 'implementation-diff.patch', 'execution-log.jsonl']) {
+  await fs.stat(path.join(tmp, '.ai-bridge', bridgeFile));
+}
+const handoffContext = await client.request('tools/call', { name: 'read_handoff', arguments: { workspace_id: ws } });
+for (const expectedFile of ['.ai-bridge/agent-status.md', '.ai-bridge/implementation-diff.patch', '.ai-bridge/execution-log.jsonl']) {
+  if (!handoffContext.structuredContent.files.includes(expectedFile)) {
+    throw new Error(`read_handoff did not include ${expectedFile}`);
+  }
+}
+await client.request('tools/call', { name: 'handoff_to_codex', arguments: { workspace_id: ws, title: 'Smoke Codex plan', plan: '- Verify demo.txt contains write.', append: true } });
 client.close();
 console.log('✓ smoke test passed');

--- a/src/fsOps.ts
+++ b/src/fsOps.ts
@@ -319,11 +319,14 @@ export async function editTextFile(
 
 export async function ensureAiBridge(config: CodexProConfig, guard: PathGuard, workspace: Workspace): Promise<string[]> {
   const files: Record<string, string> = {
-    "README.md": `# AI Bridge\n\nShared planning context for ChatGPT, other planning models, and Codex.\n\n- current-plan.md: plan produced by ChatGPT or another planning model for Codex to execute.\n- codex-status.md: implementation notes and test results from Codex.\n- decisions.md: architectural decisions that should remain stable.\n- open-questions.md: unresolved questions.\n- session-log.jsonl: append-only session events.\n`,
+    "README.md": `# AI Bridge\n\nShared planning context for ChatGPT, other planning models, Codex, OpenCode, Pi, or another local implementation agent.\n\n- current-plan.md: plan produced by ChatGPT or another planning model for the implementation agent.\n- agent-status.md: generic implementation notes, touched files, test results, blockers, and review notes.\n- implementation-diff.patch: final review diff from the implementation agent when practical.\n- codex-status.md: legacy Codex-specific status file, kept for existing workflows.\n- decisions.md: architectural decisions that should remain stable.\n- open-questions.md: unresolved questions.\n- execution-log.jsonl: append-only generic agent handoff and execution events.\n- session-log.jsonl: append-only legacy session events.\n`,
     "current-plan.md": "# Current Plan\n\nNo plan written yet.\n",
+    "agent-status.md": "# Agent Status\n\nNo implementation agent status written yet.\n",
+    "implementation-diff.patch": "",
     "codex-status.md": "# Codex Status\n\nNo Codex status written yet.\n",
     "decisions.md": "# Decisions\n\n",
     "open-questions.md": "# Open Questions\n\n",
+    "execution-log.jsonl": "",
     "session-log.jsonl": ""
   };
   const created: string[] = [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CodexProConfig } from "./config.js";
-import { WorkspaceManager, PathGuard, CodexProError } from "./guard.js";
+import { WorkspaceManager, PathGuard, CodexProError, type Workspace } from "./guard.js";
 import { repoTree, readTextFile, writeTextFile, editTextFile, ensureAiBridge } from "./fsOps.js";
 import { searchWorkspace } from "./searchOps.js";
 import { runBash } from "./bashOps.js";
@@ -117,10 +117,10 @@ function assertWriteToolAllowed(config: CodexProConfig, relPath: string): void {
   if (config.writeMode === "handoff") {
     throw new CodexProError(
       `Source writes are disabled because CODEXPRO_WRITE_MODE=handoff. ` +
-        `Use handoff_to_codex, or write/edit only inside ${config.contextDir}/.`
+        `Use handoff_to_agent or handoff_to_codex, or write/edit only inside ${config.contextDir}/.`
     );
   }
-  throw new CodexProError("write/edit tools are disabled because CODEXPRO_WRITE_MODE=off. handoff_to_codex is still available for planning.");
+  throw new CodexProError("write/edit tools are disabled because CODEXPRO_WRITE_MODE=off. handoff_to_agent and handoff_to_codex are still available for planning.");
 }
 
 function registerToolCompat(
@@ -186,6 +186,167 @@ function jsonlEvent(event: string, data: Record<string, unknown>): string {
   return JSON.stringify({ ts: new Date().toISOString(), event, ...data }) + "\n";
 }
 
+function cleanOneLine(value: unknown, fallback: string, maxLength = 120): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return (text || fallback).slice(0, maxLength);
+}
+
+function normalizeAgentId(value: unknown): string {
+  const agent = cleanOneLine(value, "custom", 64).toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(agent)) {
+    throw new CodexProError("agent must use only lowercase letters, numbers, dots, underscores, or hyphens.");
+  }
+  return agent;
+}
+
+function displayAgentName(agent: string, agentName?: unknown): string {
+  const explicit = cleanOneLine(agentName, "", 80);
+  if (explicit) return explicit;
+  if (agent === "codex") return "Codex";
+  if (agent === "opencode") return "OpenCode";
+  if (agent === "pi") return "Pi";
+  return agent;
+}
+
+function agentCommandHint(agent: string, planPath: string, model?: string): string {
+  const modelArg = model ? ` --model ${model}` : " --model <provider/model>";
+  if (agent === "opencode") return `opencode run${modelArg} "$(cat ${planPath})"`;
+  if (agent === "pi") return `pi run${modelArg} "$(cat ${planPath})"`;
+  if (agent === "codex") return `Read ${planPath} and execute it in small, reviewable steps.`;
+  return `Run your local implementation agent manually with ${planPath} as the task input.`;
+}
+
+function buildAgentPlanBody(options: {
+  title: string;
+  plan: string;
+  workspace: Workspace;
+  agent: string;
+  agentName: string;
+  model?: string;
+  statusPath: string;
+  diffPath: string;
+  executionLogPath: string;
+}): string {
+  const modelLine = options.model ? `Model: ${options.model}\n` : "";
+  return `# ${options.title}
+
+Updated: ${new Date().toISOString()}
+Workspace: ${options.workspace.root}
+Target agent: ${options.agentName} (${options.agent})
+${modelLine}
+## Plan
+
+${options.plan.trim()}
+
+## Implementation contract
+
+- Work from this plan in small, reviewable steps.
+- Keep edits scoped to the requested task and existing project conventions.
+- Run focused verification before handing work back.
+- Update ${options.statusPath} with files touched, checks run, results, blockers, and review notes.
+- Save the final review diff to ${options.diffPath} when practical.
+- Append notable execution events to ${options.executionLogPath} when the implementation agent supports logging.
+`;
+}
+
+async function writeAgentHandoff(
+  config: CodexProConfig,
+  guard: PathGuard,
+  workspace: Workspace,
+  options: {
+    agent: string;
+    agentName?: string;
+    model?: string;
+    title: string;
+    plan: string;
+    append: boolean;
+    eventName: string;
+  }
+): Promise<{
+  agent: string;
+  agentName: string;
+  model?: string;
+  title: string;
+  planPath: string;
+  statusPath: string;
+  diffPath: string;
+  logPath: string;
+  executionLogPath: string;
+  prompt: string;
+  writeResult: Awaited<ReturnType<typeof writeTextFile>>;
+}> {
+  await ensureAiBridge(config, guard, workspace);
+  const agent = normalizeAgentId(options.agent);
+  const agentName = displayAgentName(agent, options.agentName);
+  const model = options.model ? cleanOneLine(options.model, "", 120) : undefined;
+  const plan = String(options.plan ?? "").trim();
+  if (!plan) throw new CodexProError("plan must not be empty.");
+  const planPath = `${config.contextDir}/current-plan.md`;
+  const statusPath = `${config.contextDir}/agent-status.md`;
+  const legacyCodexStatusPath = `${config.contextDir}/codex-status.md`;
+  const diffPath = `${config.contextDir}/implementation-diff.patch`;
+  const logPath = `${config.contextDir}/session-log.jsonl`;
+  const executionLogPath = `${config.contextDir}/execution-log.jsonl`;
+  const body = buildAgentPlanBody({
+    title: options.title,
+    plan,
+    workspace,
+    agent,
+    agentName,
+    model,
+    statusPath,
+    diffPath,
+    executionLogPath
+  });
+
+  let content = body;
+  if (options.append) {
+    const resolved = guard.resolve(workspace, planPath);
+    const raw = await fsp.readFile(resolved.absPath, "utf8");
+    content = `${raw.trimEnd()}\n\n---\n\n${body}`;
+  }
+
+  const writeResult = await writeTextFile(config, guard, workspace, planPath, content, { createDirs: true, overwrite: true });
+  const event = {
+    agent,
+    agent_name: agentName,
+    model,
+    title: options.title,
+    plan_path: planPath,
+    status_path: statusPath,
+    diff_path: diffPath
+  };
+  const logResolved = guard.resolve(workspace, logPath, { forWrite: true });
+  const executionLogResolved = guard.resolve(workspace, executionLogPath, { forWrite: true });
+  await fsp.appendFile(logResolved.absPath, jsonlEvent(options.eventName, event), "utf8");
+  await fsp.appendFile(executionLogResolved.absPath, jsonlEvent(options.eventName, event), "utf8");
+
+  const promptLines = [
+    `Read ${planPath} and execute it in small, reviewable steps.`,
+    `After each meaningful change, update ${statusPath} with files touched, checks run, results, blockers, and the next review focus.`,
+    `Before review, write the final diff to ${diffPath} when practical.`,
+    agentCommandHint(agent, planPath, model)
+  ];
+  if (agent === "codex") {
+    promptLines.splice(2, 0, `For legacy Codex handoffs, mirror key status notes to ${legacyCodexStatusPath} if your workflow expects that file.`);
+  }
+  const prompt = promptLines.join("\n");
+
+  return {
+    agent,
+    agentName,
+    model,
+    title: options.title,
+    planPath,
+    statusPath,
+    diffPath,
+    logPath,
+    executionLogPath,
+    prompt,
+    writeResult
+  };
+}
+
 const READ_ONLY_ANNOTATIONS = { readOnlyHint: true, openWorldHint: false, destructiveHint: false };
 const SESSION_READ_ANNOTATIONS = { readOnlyHint: true, openWorldHint: false, destructiveHint: false, idempotentHint: false };
 const LOCAL_WRITE_ANNOTATIONS = { readOnlyHint: false, openWorldHint: false, destructiveHint: true, idempotentHint: false };
@@ -214,7 +375,7 @@ function getSharedWorkspaceManager(config: CodexProConfig): WorkspaceManager {
 export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = getSharedWorkspaceManager(config);
   const guard = new PathGuard(config);
-  const server = new McpServer({ name: "CodexPro", version: "0.27.0" });
+  const server = new McpServer({ name: "CodexPro", version: "0.27.2" });
   registerToolCardResource(server);
 
   registerToolCompat(
@@ -364,7 +525,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth. Default: 3."),
         include_skills: z.boolean().optional().describe("Discover repo-local skills. Default: false for speed."),
         include_global_skills: z.boolean().optional().describe("Also scan home-level skill folders when include_skills=true. Default: false."),
-        bootstrap_context: z.boolean().optional().describe("Deprecated and ignored. Use handoff_to_codex to create .ai-bridge files.")
+        bootstrap_context: z.boolean().optional().describe("Deprecated and ignored. Use handoff_to_agent to create .ai-bridge files.")
       },
       annotations: SESSION_READ_ANNOTATIONS,
       _meta: {
@@ -691,14 +852,14 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     "read_handoff",
     {
       title: "Read Handoff",
-      description: "Read the shared .ai-bridge planning files used for ChatGPT-to-Codex coordination.",
+      description: "Read the shared .ai-bridge planning files used for ChatGPT-to-agent coordination.",
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
-        "openai/toolInvocation/invoking": "Reading Codex handoff context...",
-        "openai/toolInvocation/invoked": "Codex handoff context ready"
+        "openai/toolInvocation/invoking": "Reading agent handoff context...",
+        "openai/toolInvocation/invoked": "Agent handoff context ready"
       }
     },
     async (args) => {
@@ -718,7 +879,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         target_path: z.string().optional().describe("Workspace-relative file or directory whose AGENTS instruction chain should be loaded. Default: ."),
-        include_ai_bridge: z.boolean().optional().describe("Include .ai-bridge/current-plan.md, codex-status.md, decisions.md, and open-questions.md. Default: true."),
+        include_ai_bridge: z.boolean().optional().describe("Include .ai-bridge plan, agent status, diff, decisions, questions, and execution log. Default: true."),
         include_git: z.boolean().optional().describe("Include git status. Default: true."),
         include_diff: z.boolean().optional().describe("Include full git diff. Default: false for speed/noise."),
         max_agent_bytes: z.number().int().min(1000).max(200000).optional().describe("Maximum bytes per AGENTS file. Default: 60000.")
@@ -804,10 +965,77 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
 
   registerToolCompat(
     server,
+    "handoff_to_agent",
+    {
+      title: "Handoff To Agent",
+      description:
+        "Write .ai-bridge/current-plan.md for Codex, OpenCode, Pi, or another local implementation agent. This only creates handoff files; it does not execute local agent commands.",
+      inputSchema: {
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
+        agent: z.string().optional().describe("Target agent id, for example codex, opencode, pi, or custom. Default: custom."),
+        agent_name: z.string().optional().describe("Human-readable agent name for custom agents."),
+        model: z.string().optional().describe("Optional model identifier to include in the handoff plan."),
+        title: z.string().optional().describe("Short task title."),
+        plan: z.string().describe("Detailed implementation plan for the local agent."),
+        append: z.boolean().optional().describe("Append to existing current-plan.md instead of overwriting. Default: false.")
+      },
+      annotations: HANDOFF_WRITE_ANNOTATIONS,
+      _meta: {
+        ...toolCardMeta(),
+        "openai/toolInvocation/invoking": "Writing agent handoff plan...",
+        "openai/toolInvocation/invoked": "Agent handoff plan written"
+      }
+    },
+    async (args) => {
+      const workspace = workspaces.getWorkspace(args.workspace_id);
+      const result = await writeAgentHandoff(config, guard, workspace, {
+        agent: args.agent ?? "custom",
+        agentName: args.agent_name,
+        model: args.model,
+        title: cleanOneLine(args.title, "Agent implementation plan"),
+        plan: String(args.plan ?? ""),
+        append: parseBool(args.append, false),
+        eventName: "handoff_to_agent"
+      });
+
+      const text = `# Handoff To Agent
+
+Agent: ${result.agentName} (${result.agent})
+${result.model ? `Model: ${result.model}\n` : ""}Wrote ${result.planPath}.
+Status path: ${result.statusPath}
+Diff path: ${result.diffPath}
+Execution log: ${result.executionLogPath}
+Diff stats: +${result.writeResult.diff.additions} -${result.writeResult.diff.deletions}
+
+Agent prompt:
+
+\`\`\`text
+${result.prompt}
+\`\`\`${diffBlock(result.writeResult.diff.diff)}`;
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        agent: result.agent,
+        agent_name: result.agentName,
+        model: result.model,
+        plan_path: result.planPath,
+        status_path: result.statusPath,
+        diff_path: result.diffPath,
+        log_path: result.logPath,
+        execution_log_path: result.executionLogPath,
+        additions: result.writeResult.diff.additions,
+        deletions: result.writeResult.diff.deletions,
+        diff: result.writeResult.diff.diff
+      });
+    }
+  );
+
+  registerToolCompat(
+    server,
     "handoff_to_codex",
     {
       title: "Handoff To Codex",
-      description: "Write .ai-bridge/current-plan.md and append a session-log entry so Codex can execute the plan.",
+      description: "Compatibility wrapper for handoff_to_agent with agent=codex.",
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         title: z.string().optional().describe("Short task title."),
@@ -823,34 +1051,38 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     },
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
-      await ensureAiBridge(config, guard, workspace);
-      const title = String(args.title ?? "Codex implementation plan");
-      const body = `# ${title}\n\nUpdated: ${new Date().toISOString()}\nWorkspace: ${workspace.root}\n\n${String(args.plan ?? "").trim()}\n`;
-      const planPath = `${config.contextDir}/current-plan.md`;
-      let content = body;
-      if (parseBool(args.append, false)) {
-        const current = await readTextFile(config, guard, workspace, planPath, { maxBytes: config.maxReadBytes });
-        content = `${current.text}\n\n---\n\n${body}`;
-        // current.text is line-numbered, so for append mode use raw file content instead.
-        const resolved = guard.resolve(workspace, planPath);
-        const raw = await fsp.readFile(resolved.absPath, "utf8");
-        content = `${raw.trimEnd()}\n\n---\n\n${body}`;
-      }
-      const writeResult = await writeTextFile(config, guard, workspace, planPath, content, { createDirs: true, overwrite: true });
+      const result = await writeAgentHandoff(config, guard, workspace, {
+        agent: "codex",
+        title: cleanOneLine(args.title, "Codex implementation plan"),
+        plan: String(args.plan ?? ""),
+        append: parseBool(args.append, false),
+        eventName: "handoff_to_codex"
+      });
+      const text = `# Handoff To Codex
 
-      const logRel = `${config.contextDir}/session-log.jsonl`;
-      const logResolved = guard.resolve(workspace, logRel, { forWrite: true });
-      await fsp.appendFile(logResolved.absPath, jsonlEvent("handoff_to_codex", { title, plan_path: planPath }), "utf8");
+Wrote ${result.planPath}.
+Status path: ${result.statusPath}
+Diff path: ${result.diffPath}
+Diff stats: +${result.writeResult.diff.additions} -${result.writeResult.diff.deletions}
 
-      const text = `# Handoff To Codex\n\nWrote ${planPath}.\nDiff stats: +${writeResult.diff.additions} -${writeResult.diff.deletions}\n\nCodex prompt:\n\n\`\`\`text\nRead ${planPath} and execute it in small, reviewable steps. After each meaningful change, update ${config.contextDir}/codex-status.md with files touched, tests run, results, blockers, and the next GPT review focus.\n\`\`\`${diffBlock(writeResult.diff.diff)}`;
+Codex prompt:
+
+\`\`\`text
+${result.prompt}
+\`\`\`${diffBlock(result.writeResult.diff.diff)}`;
       return textResult(text, {
         workspace_id: workspace.id,
         root: workspace.root,
-        plan_path: planPath,
-        log_path: logRel,
-        additions: writeResult.diff.additions,
-        deletions: writeResult.diff.deletions,
-        diff: writeResult.diff.diff
+        agent: result.agent,
+        agent_name: result.agentName,
+        plan_path: result.planPath,
+        status_path: result.statusPath,
+        diff_path: result.diffPath,
+        log_path: result.logPath,
+        execution_log_path: result.executionLogPath,
+        additions: result.writeResult.diff.additions,
+        deletions: result.writeResult.diff.deletions,
+        diff: result.writeResult.diff.diff
       });
     }
   );

--- a/src/toolCardWidget.ts
+++ b/src/toolCardWidget.ts
@@ -317,6 +317,7 @@ export const toolCardWidgetHtml = String.raw`
       edit: "Edit File",
       git_diff: "Git Diff",
       export_pro_context: "Pro Context",
+      handoff_to_agent: "Agent Handoff",
       handoff_to_codex: "Codex Handoff",
       bash: "Terminal",
       search: "Search",
@@ -330,6 +331,7 @@ export const toolCardWidgetHtml = String.raw`
     if (tool === "edit") return "E";
     if (tool === "git_diff") return "G";
     if (tool === "export_pro_context") return "P";
+    if (tool === "handoff_to_agent") return "A";
     if (tool === "handoff_to_codex") return "H";
     if (tool === "bash") return "$";
     if (tool === "search") return "S";
@@ -450,7 +452,7 @@ export const toolCardWidgetHtml = String.raw`
       return;
     }
     const tool = data.codexpro_tool;
-    if (tool === "write" || tool === "edit" || tool === "git_diff" || tool === "export_pro_context" || tool === "handoff_to_codex" || tool === "read") {
+    if (tool === "write" || tool === "edit" || tool === "git_diff" || tool === "export_pro_context" || tool === "handoff_to_agent" || tool === "handoff_to_codex" || tool === "read") {
       root.innerHTML = renderFile(data);
     } else if (tool === "bash") {
       root.innerHTML = renderBash(data);

--- a/src/workspaceOps.ts
+++ b/src/workspaceOps.ts
@@ -179,16 +179,19 @@ export async function readAiBridgeContext(
     const bridgeDir = guard.resolve(workspace, config.contextDir);
     if (!fs.existsSync(bridgeDir.absPath)) {
       return {
-        text: `No ${config.contextDir} handoff context exists yet. Use handoff_to_codex to create it when a plan is ready.`,
+        text: `No ${config.contextDir} handoff context exists yet. Use handoff_to_agent or handoff_to_codex to create it when a plan is ready.`,
         files: []
       };
     }
   }
   const relFiles = [
     `${config.contextDir}/current-plan.md`,
+    `${config.contextDir}/agent-status.md`,
+    `${config.contextDir}/implementation-diff.patch`,
     `${config.contextDir}/codex-status.md`,
     `${config.contextDir}/decisions.md`,
-    `${config.contextDir}/open-questions.md`
+    `${config.contextDir}/open-questions.md`,
+    `${config.contextDir}/execution-log.jsonl`
   ];
   const chunks: string[] = [];
   const files: string[] = [];


### PR DESCRIPTION
## Summary

- Add `handoff_to_agent` for file-based handoffs to Codex, OpenCode, Pi, or custom local agents without executing commands.
- Extend `.ai-bridge` with generic `agent-status.md`, `implementation-diff.patch`, and `execution-log.jsonl` artifacts.
- Keep `handoff_to_codex` as a compatibility wrapper and bump the npm package metadata to `0.27.2`.

Closes #1

## Validation

- `npm run build`
- `npm run smoke`
- `npm audit --omit=dev`