### PR TITLE
Fix Windows release gate for 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `--dry-run`, `--yes`, timeout handling, stdout/stderr capture, `agent-status.md`, `implementation-diff.patch`, and `execution-log.jsonl` output.
 - Kept `handoff_to_agent` planning-only; local execution is not exposed as a remote MCP tool.
 - Added smoke coverage for dry-run previews, custom command validation, execution status, diff collection, and structured execution logging.
+- Fixed Windows release-gate coverage for symlink-escape smoke tests, Bash lookup, and custom executor paths containing spaces.
 - Clarified that CodexPro is an official Developer Mode/MCP workflow, not a rate-limit bypass or model access provider.
 
 ## 0.27.2

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -882,15 +882,17 @@ function splitCommandTemplate(input) {
   const tokens = [];
   let current = '';
   let quote = '';
-  let escaping = false;
-  for (const char of String(input)) {
-    if (escaping) {
-      current += char;
-      escaping = false;
-      continue;
-    }
+  const text = String(input);
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
     if (char === '\\') {
-      escaping = true;
+      const next = text[i + 1];
+      if (next && (next === quote || next === '\\' || (!quote && /\s|["']/.test(next)))) {
+        current += next;
+        i += 1;
+      } else {
+        current += char;
+      }
       continue;
     }
     if (quote) {
@@ -911,7 +913,6 @@ function splitCommandTemplate(input) {
     }
     current += char;
   }
-  if (escaping) current += '\\';
   if (quote) throw new Error('Custom command has an unterminated quote.');
   if (current) tokens.push(current);
   return tokens;

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -19,6 +19,10 @@ function requireSuccess(result, label) {
   }
 }
 
+function quoteArg(value) {
+  return `"${String(value).replaceAll('"', '\\"')}"`;
+}
+
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-execute-handoff-'));
 await fs.mkdir(path.join(root, '.ai-bridge'), { recursive: true });
 await fs.writeFile(path.join(root, '.ai-bridge', 'current-plan.md'), '# Test plan\n\nAppend the implementation marker.\n', 'utf8');
@@ -60,7 +64,7 @@ const missingPlaceholder = run([
   '--agent',
   'custom',
   '--command',
-  `${process.execPath} fake-agent.mjs`,
+  `${quoteArg(process.execPath)} fake-agent.mjs`,
   '--yes'
 ]);
 if (missingPlaceholder.status === 0 || !missingPlaceholder.stderr.includes('must include {{plan_file}} or {{plan_text}}')) {
@@ -74,7 +78,7 @@ const executed = run([
   '--agent',
   'custom',
   '--command',
-  `${process.execPath} fake-agent.mjs --model {{model}} --task-file {{plan_file}}`,
+  `${quoteArg(process.execPath)} fake-agent.mjs --model {{model}} --task-file {{plan_file}}`,
   '--model',
   'local/test-model',
   '--yes'

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -65,7 +65,14 @@ await fs.writeFile(path.join(tmp, 'config.txt'), 'OPENAI_API_KEY=sk-realSecretVa
 await fs.writeFile(path.join(tmp, 'AGENTS.md'), '# Smoke Agents\n\n- Preserve demo.txt.\n', 'utf8');
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-outside-'));
 await fs.writeFile(path.join(outside, 'secret.txt'), 'do-not-read', 'utf8');
-await fs.symlink(path.join(outside, 'secret.txt'), path.join(tmp, 'secret-link.txt'));
+let symlinkEscapePath = 'secret-link.txt';
+try {
+  await fs.symlink(path.join(outside, 'secret.txt'), path.join(tmp, symlinkEscapePath));
+} catch (error) {
+  if (process.platform !== 'win32' || error?.code !== 'EPERM') throw error;
+  symlinkEscapePath = 'secret-link-dir/secret.txt';
+  await fs.symlink(outside, path.join(tmp, 'secret-link-dir'), 'junction');
+}
 
 const client = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'], {
   cwd: path.resolve('.'),
@@ -146,7 +153,7 @@ const envRefPayload = JSON.stringify(envRefRead);
 if (envRefPayload.includes('[REDACTED_SECRET]')) {
   throw new Error('env-var token references were incorrectly redacted as literal secrets');
 }
-const symlinkRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'secret-link.txt' } });
+const symlinkRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: symlinkEscapePath } });
 if (!symlinkRead.isError) throw new Error('symlink escape read was not blocked');
 await client.request('tools/call', { name: 'edit', arguments: { workspace_id: ws, path: 'demo.txt', old_text: 'read\nread', new_text: 'read\nwrite' } });
 const codexContext = await client.request('tools/call', { name: 'codex_context', arguments: { workspace_id: ws, target_path: 'demo.txt' } });

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
@@ -160,6 +161,10 @@ function makeEnv(config: CodexProConfig): NodeJS.ProcessEnv {
   };
 }
 
+function bashExecutable(): string {
+  return fs.existsSync("/bin/bash") ? "/bin/bash" : "bash";
+}
+
 function trimOutput(value: string, maxBytes: number): { value: string; truncated: boolean } {
   const buffer = Buffer.from(value, "utf8");
   if (buffer.byteLength <= maxBytes) return { value, truncated: false };
@@ -182,7 +187,7 @@ export async function runBash(
   const start = Date.now();
 
   return new Promise((resolve, reject) => {
-    const child = spawn("/bin/bash", ["-lc", command], {
+    const child = spawn(bashExecutable(), ["-lc", command], {
       cwd,
       env: makeEnv(config),
       stdio: ["ignore", "pipe", "pipe"]

--- a/src/server.ts
+++ b/src/server.ts
@@ -385,7 +385,7 @@ function getSharedWorkspaceManager(config: CodexProConfig): WorkspaceManager {
 export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = getSharedWorkspaceManager(config);
   const guard = new PathGuard(config);
-  const server = new McpServer({ name: "CodexPro", version: "0.27.2" });
+  const server = new McpServer({ name: "CodexPro", version: "0.28.0" });
   registerToolCardResource(server);
 
   registerToolCompat(


### PR DESCRIPTION
## Summary
- keep safe-bash usable on Windows by falling back from /bin/bash to PATH bash
- keep symlink escape smoke coverage on Windows by falling back to a junction when file symlinks require elevation
- preserve Windows executable paths in custom execute-handoff command parsing and smoke coverage
- sync MCP server version to 0.28.0 and document the release-gate fix

## Verification
- npm run build
- npm run smoke
- npm pack --dry-run --json
- npm publish --dry-run
- node scripts/codexpro.mjs doctor --tunnel none
- packed tarball install + codexpro doctor
- dist/http.js /healthz local startup check
- git diff --check