### PR TITLE
Add local handoff watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## 0.28.0
 
 - Added `codexpro execute-handoff` as an opt-in local executor for `.ai-bridge/current-plan.md`.
+- Added `codexpro watch-handoff` as an opt-in local watcher that executes new handoff plans by content hash without exposing execution as a remote MCP tool.
 - Added built-in local adapters for `opencode`, `pi`, and `codex`, plus a restricted `--command` template path for custom agents.
 - Added `--dry-run`, `--yes`, timeout handling, stdout/stderr capture, `agent-status.md`, `implementation-diff.patch`, and `execution-log.jsonl` output.
 - Kept `handoff_to_agent` planning-only; local execution is not exposed as a remote MCP tool.
-- Added smoke coverage for dry-run previews, custom command validation, execution status, diff collection, and structured execution logging.
 - Fixed Windows release-gate coverage for symlink-escape smoke tests, Bash lookup, and custom executor paths containing spaces.
+- Added smoke coverage for dry-run previews, custom command validation, execution status, diff collection, duplicate watch-plan skipping, and structured execution logging.
 - Clarified that CodexPro is an official Developer Mode/MCP workflow, not a rate-limit bypass or model access provider.
 
 ## 0.27.2

--- a/README.md
+++ b/README.md
@@ -120,6 +120,41 @@ ChatGPT can do MCP-backed agentic coding in your local repo, while Codex remains
 Local-only companion command:
 
 - `codexpro execute-handoff` — run a previously written `.ai-bridge/current-plan.md` through a local agent, then collect status, logs, and git diff. This is intentionally a CLI command, not a remote MCP tool.
+- `codexpro watch-handoff` — watch `.ai-bridge/current-plan.md` locally and run a new plan through a configured agent when its content hash changes. This is also CLI-only and is not exposed as a remote MCP tool.
+
+The watcher is the safer way to automate handoff execution from ChatGPT Web. ChatGPT writes the plan through `handoff_to_agent`; the user-started local watcher notices the new plan and runs Pi, OpenCode, Codex, or a restricted custom command from the terminal:
+
+```bash
+codexpro start --mode handoff
+codexpro watch-handoff --agent opencode --model provider/model --yes
+```
+
+For custom local agents:
+
+```bash
+codexpro watch-handoff \
+  --agent custom \
+  --command "node ./agent.js --task-file {{plan_file}}" \
+  --yes
+```
+
+Useful watcher flags:
+
+```text
+--once                  check one new plan and exit
+--dry-run               show the command without executing it
+--poll-interval-ms 2000 polling interval
+--debounce-ms 500       wait for the plan file to become stable
+--state-file <path>     duplicate-run state, default .ai-bridge/watch-handoff-state.json
+```
+
+The watcher writes the same review files as `execute-handoff`:
+
+```text
+.ai-bridge/agent-status.md
+.ai-bridge/implementation-diff.patch
+.ai-bridge/execution-log.jsonl
+```
 
 ## Visual ChatGPT cards
 

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -22,6 +22,7 @@ Usage:
   codexpro settings
   codexpro doctor
   codexpro execute-handoff --agent opencode --model provider/model
+  codexpro watch-handoff --agent opencode --model provider/model
   codexpro --root /path/to/repo
   codexpro ngrok --hostname your-domain.ngrok-free.dev
   codexpro stable --hostname codexpro.example.com --tunnel-name codexpro
@@ -95,6 +96,16 @@ Execute handoff options:
   --context-dir <dir>       Handoff directory. Default: .ai-bridge.
   --yes                     Run without interactive confirmation.
 
+Watch handoff options:
+  codexpro watch-handoff --agent opencode --model provider/model
+  codexpro watch-handoff --agent pi --model provider/model
+  codexpro watch-handoff --agent custom --command "my-agent --task-file {{plan_file}}"
+  --once                    Exit after checking/running one new plan.
+  --poll-interval-ms <ms>   Poll interval. Default: 2000.
+  --debounce-ms <ms>        Wait for plan file stability. Default: 500.
+  --state-file <path>       Watch state file. Default: .ai-bridge/watch-handoff-state.json.
+  --yes                     Start automatic local execution without startup confirmation.
+
 Default agent mode:
   codexpro start --root /path/to/repo
 
@@ -122,6 +133,10 @@ Execute a local handoff after ChatGPT writes .ai-bridge/current-plan.md:
   codexpro execute-handoff --agent opencode --model provider/model
   codexpro execute-handoff --agent pi --model provider/model
   codexpro execute-handoff --agent custom --command "node ./agent.js --task-file {{plan_file}}" --yes
+
+Watch for new handoff plans and execute them locally:
+  codexpro watch-handoff --agent opencode --model provider/model --yes
+  codexpro watch-handoff --agent custom --command "node ./agent.js --task-file {{plan_file}}" --yes
 
 Stable URL mode after one-time Cloudflare tunnel setup:
   codexpro stable --root /path/to/repo --hostname codexpro.example.com --tunnel-name codexpro
@@ -231,6 +246,9 @@ function parseArgs(argv) {
     else if (key === 'copy-url') out.copyUrl = true;
     else if (key === 'no-copy-url') out.noCopyUrl = true;
     else if (key === 'dry-run') out.dryRun = true;
+    else if (key === 'once') out.once = true;
+    else if (key === 'confirm') out.confirm = true;
+    else if (key === 'no-confirm') out.noConfirm = true;
     else if (key === 'open-chatgpt') out.openChatgpt = true;
     else if (key === 'no-profile') out.noProfile = true;
     else if (key === 'save-config') out.saveConfig = true;
@@ -1130,12 +1148,7 @@ async function confirmLocalExecution(args, root, commandInfo) {
   }
 }
 
-async function runExecuteHandoff(argv) {
-  const args = parseArgs(argv);
-  if (args.help) {
-    usage();
-    return;
-  }
+function loadHandoffExecution(args) {
   const root = realDir(args.root ?? process.env.CODEXPRO_ROOT ?? process.cwd());
   const contextDir = contextDirFromArgs(args);
   const bridgeDir = resolveWorkspaceFile(root, contextDir);
@@ -1149,42 +1162,252 @@ async function runExecuteHandoff(argv) {
   const planText = readTextFileBounded(planPath, maxReadBytes);
   const commandInfo = buildExecutorCommand(args, root, planPath, planText);
   const commandText = executorCommandPreview(commandInfo);
+  return {
+    root,
+    contextDir,
+    bridgeDir,
+    planPath,
+    planText,
+    commandInfo,
+    commandText,
+    maxOutputBytes,
+    timeoutMs
+  };
+}
 
-  if (args.dryRun) {
-    printBox('CodexPro execute-handoff dry run', [
-      labelValue('Workspace', root),
-      labelValue('Plan', path.relative(root, planPath)),
-      labelValue('Agent', commandInfo.agent),
-      ...(commandInfo.model ? [labelValue('Model', commandInfo.model)] : []),
-      labelValue('Command', commandText),
-      'No command was executed and no .ai-bridge result files were changed.'
-    ]);
-    return;
-  }
+function printHandoffDryRun(request, title = 'CodexPro execute-handoff dry run') {
+  printBox(title, [
+    labelValue('Workspace', request.root),
+    labelValue('Plan', path.relative(request.root, request.planPath)),
+    labelValue('Agent', request.commandInfo.agent),
+    ...(request.commandInfo.model ? [labelValue('Model', request.commandInfo.model)] : []),
+    labelValue('Command', request.commandText),
+    'No command was executed and no .ai-bridge result files were changed.'
+  ]);
+}
 
-  const confirmed = await confirmLocalExecution(args, root, commandInfo);
+async function executeHandoffRequest(request, args, options = {}) {
+  const confirmed = options.skipConfirmation ? true : await confirmLocalExecution(args, request.root, request.commandInfo);
   if (!confirmed) {
     statusLine('warn', 'Execution cancelled.');
+    return { cancelled: true, result: null, outputs: null };
+  }
+
+  if (!commandAvailableFromRoot(request.commandInfo.command, request.root)) {
+    throw new Error(`${request.commandInfo.command} was not found. Install it, add it to PATH, pass an absolute path, or use --command.`);
+  }
+
+  statusLine('wait', `Running ${request.commandInfo.agent}: ${request.commandText}`);
+  const result = await runProcessCaptured(request.commandInfo.command, request.commandInfo.args, {
+    cwd: request.root,
+    timeoutMs: request.timeoutMs,
+    maxOutputBytes: request.maxOutputBytes
+  });
+  const diffText = readGitDiff(request.root, request.maxOutputBytes);
+  const outputs = writeExecutionOutputs(request.root, request.contextDir, request.commandInfo, result, diffText);
+  statusLine(result.exitCode === 0 ? 'ok' : 'warn', `Agent exited with code ${result.exitCode ?? 'null'}${result.signal ? ` signal=${result.signal}` : ''}`);
+  console.log(`Status: ${path.relative(request.root, outputs.statusPath)}`);
+  console.log(`Diff:   ${path.relative(request.root, outputs.diffPath)}`);
+  console.log(`Log:    ${path.relative(request.root, outputs.logPath)}`);
+  return { cancelled: false, result, outputs };
+}
+
+async function runExecuteHandoff(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    usage();
+    return;
+  }
+  const request = loadHandoffExecution(args);
+
+  if (args.dryRun) {
+    printHandoffDryRun(request);
     return;
   }
 
-  if (!commandAvailableFromRoot(commandInfo.command, root)) {
-    throw new Error(`${commandInfo.command} was not found. Install it, add it to PATH, pass an absolute path, or use --command.`);
+  const execution = await executeHandoffRequest(request, args);
+  if (execution.result?.exitCode && execution.result.exitCode !== 0) process.exitCode = execution.result.exitCode;
+}
+
+function planHash(planText) {
+  return createHash('sha256').update(planText).digest('hex');
+}
+
+function isScaffoldedHandoffPlan(planText) {
+  return String(planText).trim() === '# Current Plan\n\nNo plan written yet.';
+}
+
+function readWatchState(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeWatchState(statePath, state) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+}
+
+function appendBridgeLog(root, contextDir, event) {
+  const bridgeDir = resolveWorkspaceFile(root, contextDir);
+  fs.mkdirSync(bridgeDir, { recursive: true, mode: 0o700 });
+  const logPath = path.join(bridgeDir, 'execution-log.jsonl');
+  fs.appendFileSync(logPath, `${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`, { mode: 0o600 });
+}
+
+async function waitForStablePlan(planPath, debounceMs) {
+  try {
+    const before = fs.statSync(planPath);
+    await sleep(debounceMs);
+    const after = fs.statSync(planPath);
+    return before.isFile() && after.isFile() && before.size === after.size && before.mtimeMs === after.mtimeMs;
+  } catch {
+    return false;
+  }
+}
+
+async function confirmWatchHandoff(args, root) {
+  if (args.yes || args.noConfirm) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error('Use --yes to start watch-handoff in non-interactive shells.');
+  }
+  printBox('Confirm handoff watcher', [
+    labelValue('Workspace', root),
+    labelValue('Agent', args.agent ?? 'opencode'),
+    ...(args.model ? [labelValue('Model', args.model)] : []),
+    'This starts a local-only watcher. Each new .ai-bridge/current-plan.md hash runs through the configured local agent.',
+    'ChatGPT only writes the handoff plan; this terminal-owned process performs execution.'
+  ]);
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await ask(rl, 'Start automatic local handoff execution?', 'no');
+    return ['y', 'yes'].includes(answer.trim().toLowerCase());
+  } finally {
+    rl.close();
+  }
+}
+
+async function runWatchHandoff(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    usage();
+    return;
+  }
+  const root = realDir(args.root ?? process.env.CODEXPRO_ROOT ?? process.cwd());
+  const contextDir = contextDirFromArgs(args);
+  const bridgeDir = resolveWorkspaceFile(root, contextDir);
+  const planPath = path.join(bridgeDir, 'current-plan.md');
+  const statePath = resolveWorkspaceFile(root, args.stateFile ?? path.posix.join(contextDir, 'watch-handoff-state.json'));
+  const pollIntervalMs = numberOption(args.pollIntervalMs ?? args.pollInterval, 2000, 250, 60_000);
+  const debounceMs = numberOption(args.debounceMs, 500, 0, 30_000);
+  let state = readWatchState(statePath);
+  let lastDryRunHash = state.lastPlanHash ?? '';
+  let lastSkippedHash = '';
+  let stopped = false;
+
+  if (!args.dryRun) {
+    const approved = await confirmWatchHandoff(args, root);
+    if (!approved) {
+      statusLine('warn', 'Watcher cancelled.');
+      return;
+    }
   }
 
-  statusLine('wait', `Running ${commandInfo.agent}: ${commandText}`);
-  const result = await runProcessCaptured(commandInfo.command, commandInfo.args, {
-    cwd: root,
-    timeoutMs,
-    maxOutputBytes
-  });
-  const diffText = readGitDiff(root, maxOutputBytes);
-  const outputs = writeExecutionOutputs(root, contextDir, commandInfo, result, diffText);
-  statusLine(result.exitCode === 0 ? 'ok' : 'warn', `Agent exited with code ${result.exitCode ?? 'null'}${result.signal ? ` signal=${result.signal}` : ''}`);
-  console.log(`Status: ${path.relative(root, outputs.statusPath)}`);
-  console.log(`Diff:   ${path.relative(root, outputs.diffPath)}`);
-  console.log(`Log:    ${path.relative(root, outputs.logPath)}`);
-  if (result.exitCode && result.exitCode !== 0) process.exitCode = result.exitCode;
+  printBox('CodexPro watch-handoff', [
+    labelValue('Workspace', root),
+    labelValue('Plan', path.relative(root, planPath)),
+    labelValue('State', path.relative(root, statePath)),
+    labelValue('Agent', args.agent ?? 'opencode'),
+    ...(args.model ? [labelValue('Model', args.model)] : []),
+    labelValue('Poll', `${pollIntervalMs} ms`),
+    labelValue('Debounce', `${debounceMs} ms`),
+    args.once ? 'Mode: check once and exit.' : 'Mode: watching until Ctrl+C.'
+  ]);
+
+  const stop = () => {
+    stopped = true;
+    statusLine('warn', 'Stopping handoff watcher...');
+  };
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+
+  while (!stopped) {
+    if (!fs.existsSync(planPath)) {
+      if (args.once) throw new Error(`No handoff plan found at ${path.relative(root, planPath)}.`);
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    const stable = await waitForStablePlan(planPath, debounceMs);
+    if (!stable) {
+      if (args.once) throw new Error(`Handoff plan did not become stable at ${path.relative(root, planPath)}.`);
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    const request = loadHandoffExecution({ ...args, root, contextDir });
+    const currentHash = planHash(request.planText);
+    if (isScaffoldedHandoffPlan(request.planText)) {
+      if (lastSkippedHash !== currentHash) statusLine('wait', 'Ignoring scaffolded empty handoff plan.');
+      lastSkippedHash = currentHash;
+      if (args.once) return;
+      await sleep(pollIntervalMs);
+      continue;
+    }
+    if (state.lastPlanHash === currentHash || lastDryRunHash === currentHash) {
+      statusLine(args.once ? 'ok' : 'wait', `No new handoff plan: ${currentHash.slice(0, 12)}`);
+      if (args.once) return;
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    if (args.dryRun) {
+      printHandoffDryRun(request, 'CodexPro watch-handoff dry run');
+      lastDryRunHash = currentHash;
+      if (args.once) return;
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    appendBridgeLog(root, contextDir, {
+      event: 'watch_handoff_started',
+      plan_hash: currentHash,
+      agent: request.commandInfo.agent,
+      model: request.commandInfo.model || undefined,
+      plan_path: path.posix.join(contextDir, 'current-plan.md')
+    });
+
+    const execution = await executeHandoffRequest(request, { ...args, yes: true }, { skipConfirmation: true });
+    const exitCode = execution.result?.exitCode ?? null;
+    state = {
+      lastPlanHash: currentHash,
+      lastRanAt: new Date().toISOString(),
+      agent: request.commandInfo.agent,
+      model: request.commandInfo.model || undefined,
+      exitCode,
+      planPath: path.posix.join(contextDir, 'current-plan.md')
+    };
+    writeWatchState(statePath, state);
+    appendBridgeLog(root, contextDir, {
+      event: 'watch_handoff_finished',
+      plan_hash: currentHash,
+      agent: request.commandInfo.agent,
+      model: request.commandInfo.model || undefined,
+      exit_code: exitCode,
+      status_path: path.posix.join(contextDir, 'agent-status.md'),
+      diff_path: path.posix.join(contextDir, 'implementation-diff.patch')
+    });
+
+    if (args.once) {
+      if (exitCode && exitCode !== 0) process.exitCode = exitCode;
+      return;
+    }
+
+    await sleep(pollIntervalMs);
+  }
 }
 
 function createConnectorDetails(endpoint, token, localBase = '') {
@@ -2034,6 +2257,10 @@ async function main() {
   }
   if (subcommand === 'execute-handoff' || subcommand === 'execute' || subcommand === 'run-handoff') {
     await runExecuteHandoff(argv.slice(1));
+    return;
+  }
+  if (subcommand === 'watch-handoff' || subcommand === 'watch') {
+    await runWatchHandoff(argv.slice(1));
     return;
   }
   if (subcommand === 'pro-bundle' || subcommand === 'bundle') {

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -103,4 +103,66 @@ if (!app.includes('implemented with local/test-model: yes')) {
   throw new Error(`fake agent did not edit app.txt\n${app}`);
 }
 
-console.log('✓ execute-handoff smoke test passed');
+const watchRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-watch-handoff-'));
+await fs.mkdir(path.join(watchRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(watchRoot, '.ai-bridge', 'current-plan.md'), '# Current Plan\n\nNo plan written yet.\n', 'utf8');
+await fs.writeFile(path.join(watchRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(watchRoot, 'watch-agent.mjs'), `
+import fs from 'node:fs';
+
+const taskIndex = process.argv.indexOf('--task-file');
+if (taskIndex < 0) throw new Error('missing --task-file');
+const plan = fs.readFileSync(process.argv[taskIndex + 1], 'utf8');
+fs.appendFileSync('app.txt', \`watch implemented: \${plan.split('\\n')[0]}\\n\`);
+console.log('watch agent completed');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: watchRoot, encoding: 'utf8' }), 'watch git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: watchRoot, encoding: 'utf8' }), 'watch git add');
+
+const watchCommand = [
+  'watch-handoff',
+  '--root',
+  watchRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${process.execPath} watch-agent.mjs --task-file {{plan_file}}`,
+  '--once',
+  '--yes',
+  '--debounce-ms',
+  '0'
+];
+
+requireSuccess(run(watchCommand), 'watch-handoff scaffold skip');
+let watchApp = await fs.readFile(path.join(watchRoot, 'app.txt'), 'utf8');
+if (watchApp !== 'start\n') {
+  throw new Error(`watch executed scaffolded empty plan\n${watchApp}`);
+}
+
+await fs.writeFile(path.join(watchRoot, '.ai-bridge', 'current-plan.md'), '# Watch plan 1\n\nAppend watch marker.\n', 'utf8');
+requireSuccess(run(watchCommand), 'watch-handoff first run');
+watchApp = await fs.readFile(path.join(watchRoot, 'app.txt'), 'utf8');
+if ((watchApp.match(/watch implemented/g) ?? []).length !== 1) {
+  throw new Error(`watch first run did not execute exactly once\n${watchApp}`);
+}
+
+requireSuccess(run(watchCommand), 'watch-handoff duplicate skip');
+watchApp = await fs.readFile(path.join(watchRoot, 'app.txt'), 'utf8');
+if ((watchApp.match(/watch implemented/g) ?? []).length !== 1) {
+  throw new Error(`watch duplicate plan was executed again\n${watchApp}`);
+}
+
+await fs.writeFile(path.join(watchRoot, '.ai-bridge', 'current-plan.md'), '# Watch plan 2\n\nAppend second watch marker.\n', 'utf8');
+requireSuccess(run(watchCommand), 'watch-handoff changed plan');
+watchApp = await fs.readFile(path.join(watchRoot, 'app.txt'), 'utf8');
+if ((watchApp.match(/watch implemented/g) ?? []).length !== 2 || !watchApp.includes('# Watch plan 2')) {
+  throw new Error(`watch changed plan did not execute\n${watchApp}`);
+}
+
+const watchState = await fs.readFile(path.join(watchRoot, '.ai-bridge', 'watch-handoff-state.json'), 'utf8');
+const watchLog = await fs.readFile(path.join(watchRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!watchState.includes('lastPlanHash') || !watchLog.includes('"event":"watch_handoff_started"') || !watchLog.includes('"event":"watch_handoff_finished"')) {
+  throw new Error(`watch did not write state/log\nstate:\n${watchState}\nlog:\n${watchLog}`);
+}
+
+console.log('✓ execute-handoff and watch-handoff smoke test passed');


### PR DESCRIPTION
## Summary

Adds a local-only `codexpro watch-handoff` command for the workflow requested in #6.

The issue is that ChatGPT Web can safely create handoff plans through MCP, but asking ChatGPT to execute local shell commands can be blocked before the request reaches CodexPro. The watcher keeps that boundary intact: ChatGPT writes `.ai-bridge/current-plan.md`, and a user-started terminal process watches for new plan content and executes the configured local agent.

## What changed

- Added `codexpro watch-handoff` and `codexpro watch` aliases.
- Reused the existing `execute-handoff` command building, validation, output capture, status writing, and diff collection path.
- Added content-hash state at `.ai-bridge/watch-handoff-state.json` so unchanged plans are not run twice.
- Added structured watcher events to `.ai-bridge/execution-log.jsonl`.
- Added `--once`, `--dry-run`, `--poll-interval-ms`, `--debounce-ms`, `--state-file`, and `--yes` support.
- Documented the watcher flow in `README.md` and `CHANGELOG.md`.
- Added smoke coverage for first execution, duplicate-plan skip, changed-plan execution, state writing, and watcher log events.

This remains local-only. It does not expose local agent execution as a remote MCP tool.

Closes #6.

## Verification

- `npm run build`
- `npm run smoke`
- `npm pack --dry-run`
- `git diff --check`
