### PR TITLE
[codex] Improve ChatGPT card UX and skill discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Made workspace cards compact by default, moving git details, discovered skills, and optional file tree output behind collapsible disclosure rows.
 - Changed workspace open skill discovery to include workspace, user, and plugin skills by default while still exposing a focused `standard` tool surface.
+- Added read-only `load_skill` so ChatGPT can load bounded `SKILL.md` instructions for discovered workspace, user, or plugin skills without exposing arbitrary path reads.
 - Kept AGENTS detection in the workspace open result but stopped embedding the full AGENTS file in the open response; agents can read it explicitly when needed.
+- Fixed setup propagation for `--widget-domain` and corrected workspace-card git status splitting for multi-file diffs.
 
 ## 0.28.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.28.4
+
+- Made workspace cards compact by default, moving git details, discovered skills, and optional file tree output behind collapsible disclosure rows.
+- Changed workspace open skill discovery to include workspace, user, and plugin skills by default while still exposing a focused `standard` tool surface.
+- Kept AGENTS detection in the workspace open result but stopped embedding the full AGENTS file in the open response; agents can read it explicitly when needed.
+
+## 0.28.3
+
+- Added `CODEXPRO_WIDGET_DOMAIN` and the Apps SDK resource metadata keys `_meta.ui.domain` plus `_meta["openai/widgetDomain"]` so ChatGPT no longer reports that the widget domain is missing.
+- Surfaced the widget domain in server config, HTTP status output, docs, env examples, and smoke tests.
+
+## 0.28.2
+
+- Moved ChatGPT visual cards from `bash` to the workspace open tools so the first call gives a compact project orientation instead of noisy terminal cards.
+- Kept `bash` data-only for focused verification commands and strengthened server instructions to prefer `tree`, `search`, `read`, and `show_changes` for inspection/review.
+- Upgraded the widget to v8 with a workspace summary renderer and a neutral waiting state instead of a stale-looking running card.
+
+## 0.28.1
+
+- Added `CODEXPRO_TOOL_MODE=minimal|standard|full`, with `standard` as the default focused ChatGPT tool surface and `full` preserving the previous advanced toolbox.
+- Added `show_changes` as a review-oriented visual card for git status, diff stats, and optional diff while keeping raw `git_diff` data-only.
+- Upgraded the ChatGPT widget to v7 with compact bash execution summaries, review cards, and cleaner handoff cards.
+- Allowed `open_workspace` to accept `path` as an alias for `root` to reduce client argument mismatch failures.
+- Allowed safe package scripts with colon suffixes such as `npm run build:clients` for build/test verification.
+- Surfaced tool mode in server config, local status, workspace/context exports, launcher output, setup profiles, and docs.
+
 ## 0.28.0
 
 - Added `codexpro execute-handoff` as an opt-in local executor for `.ai-bridge/current-plan.md`.

--- a/README.md
+++ b/README.md
@@ -103,24 +103,44 @@ ChatGPT can do MCP-backed agentic coding in your local repo, while Codex remains
 
 ## Tools exposed to ChatGPT
 
+CodexPro defaults to `CODEXPRO_TOOL_MODE=standard`, which keeps ChatGPT's tool picker focused on the normal coding loop plus handoff/export workflows. Use `--tool-mode minimal` for the tightest demo surface, or `--tool-mode full` when you want every compatibility and debugging tool exposed.
+
+The smaller default tool list is deliberate. ChatGPT behaves better when routine work goes through a few high-signal tools instead of a large action catalog. Installed user/plugin skills are still discovered during workspace open; they are surfaced as context in the workspace card and inventory results, not as dozens of separate ChatGPT actions.
+
+Standard mode exposes:
+
 - `server_config` — show safety modes, limits, blocked globs, and allowed roots.
-- `codexpro_inventory` — list discovered skill names and configured MCP server names without exposing MCP command arguments or secrets.
 - `open_current_workspace` — open the configured default workspace without accepting a path. Fastest/safest first call.
-- `open_workspace` — open a local project directory and return workspace id, git status, AGENTS.md status, optional skill discovery, and optional file tree.
-- `list_workspaces` — show opened workspaces in the current MCP session.
-- `workspace_snapshot` — project status plus `.ai-bridge` handoff context.
+- `open_workspace` — open a local project directory using `root` or `path` and return workspace id, git status, AGENTS.md status, optional skill discovery, and optional file tree.
 - `tree` — inspect files.
 - `search` — search code with ripgrep or a Node fallback.
 - `read` — read text files with line numbers.
 - `write` — create/overwrite files and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
 - `edit` — exact text replacement and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
 - `bash` — run allowlisted shell commands in the workspace. Controlled by `CODEXPRO_BASH_MODE`.
-- `git_status` — inspect git status.
-- `git_diff` — inspect current diff.
+- `show_changes` — one review-oriented summary with git status, diff stats, and optional diff.
 - `read_handoff` — read `.ai-bridge` files.
-- `codex_context` — load Codex-style context in one call: AGENTS instructions for a target path, `.ai-bridge` files, and optional git status/diff.
 - `export_pro_context` — write `.ai-bridge/pro-context.md` for models that cannot call MCP tools directly.
 - `handoff_to_agent` — write `.ai-bridge/current-plan.md` for Codex, OpenCode, Pi, or a custom local implementation agent without executing local commands.
+
+Minimal mode exposes only:
+
+```text
+server_config
+open_current_workspace / open_workspace
+read / write / edit
+bash
+show_changes
+```
+
+Full mode adds:
+
+- `codexpro_inventory` — list discovered skill names and configured MCP server names without exposing MCP command arguments or secrets.
+- `list_workspaces` — show opened workspaces in the current MCP session.
+- `workspace_snapshot` — project status plus `.ai-bridge` handoff context.
+- `git_status` — inspect git status.
+- `git_diff` — inspect current diff.
+- `codex_context` — load Codex-style context in one call: AGENTS instructions for a target path, `.ai-bridge` files, and optional git status/diff.
 - `handoff_to_codex` — compatibility wrapper for `handoff_to_agent` with `agent=codex`.
 
 Local-only companion command:
@@ -167,47 +187,51 @@ The watcher writes the same review files as `execute-handoff`:
 v0.8+ registers a reusable Apps SDK widget resource:
 
 ```text
-ui://widget/codexpro-tool-card-v5.html
+ui://widget/codexpro-tool-card-v8.html
 ```
 
-Only high-signal change tools attach that resource through `_meta.ui.resourceUri` and the ChatGPT compatibility key `_meta["openai/outputTemplate"]`. In ChatGPT Developer Mode this renders compact cards for:
+Only high-signal workflow tools attach that resource through `_meta.ui.resourceUri` and the ChatGPT compatibility key `_meta["openai/outputTemplate"]`. In ChatGPT Developer Mode this renders compact cards for:
 
 ```text
+open_current_workspace / open_workspace project summaries
 write/edit diffs
+show_changes review summaries
 handoff/pro-context exports
 ```
+
+Workspace cards stay compact by default. Git details, discovered skills, and optional file tree output are folded into disclosure rows so the chat does not fill with project inventory unless you open it.
 
 Routine plumbing tools intentionally stay data-only and compact:
 
 ```text
 server_config
 codexpro_inventory
-open_current_workspace / open_workspace
 tree
 search
 read
 bash
-git_status
-git_diff
+git_status / git_diff
 read_handoff
 workspace_snapshot
 codex_context
 ```
 
-`git_diff` is intentionally data-only. Empty or large repo diffs should not create a visual card or trigger a widget fetch just to say there is no output.
+`bash` and `git_diff` are intentionally data-only. Use `bash` for focused verification commands, and use `show_changes` when you want the visual review card. Empty or large raw diffs should not create a visual card or trigger a widget fetch just to say there is no output.
 
 This avoids the noisy "every tool call becomes a card" behavior. It follows the Apps SDK decoupled pattern: data-processing tools return normal tool results, while render-worthy tools attach the widget template.
 
 The visual cards are not unlocked by "normal coding mode" alone; the MCP server has to register an HTML resource with `text/html;profile=mcp-app` and point selected tool descriptors at it.
 
-The widget sets both CSP metadata surfaces:
+The widget sets both domain and CSP metadata surfaces:
 
 ```text
+_meta.ui.domain
+_meta["openai/widgetDomain"]
 _meta.ui.csp
 _meta["openai/widgetCSP"]
 ```
 
-Both are intentionally strict because the widget has no external fetches, fonts, scripts, images, or iframes.
+`CODEXPRO_WIDGET_DOMAIN` defaults to `https://rebel0789.github.io` for this package. For app submission, set it to a dedicated HTTPS origin you control, for example `https://widgets.yourdomain.com`. The CSP lists are intentionally strict because the widget has no external fetches, fonts, scripts, images, or iframes.
 
 After upgrading or changing widget metadata, open the CodexPro app settings in ChatGPT Developer Mode and click `Refresh` / `Refresh actions` so ChatGPT reloads the tool descriptors and resource URI.
 
@@ -573,12 +597,12 @@ For faster ChatGPT runs, keep the first call narrow:
 ```text
 Call open_current_workspace with include_tree=false unless you need the tree immediately.
 Use tree with max_depth=2 and max_entries=100 when you need file structure.
-Call codexpro_inventory when you want ChatGPT to see local skills and MCP server names. Leave global skill scans out of normal open_workspace calls unless you need them.
+Use --tool-mode full and call codexpro_inventory only when you want ChatGPT to see global skill and MCP server names.
 Do not call open_workspace after open_current_workspace unless you are switching to a different root.
-Use one targeted search for verification instead of repeated broad searches.
+Use tree/search/read for inspection, one targeted search plus show_changes for review, and bash only for focused build/test/lint verification.
 ```
 
-`open_current_workspace` discovers repo-local skills by default. `open_workspace` and `workspace_snapshot` skip skill discovery by default for speed. Use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
+`open_current_workspace` and `open_workspace` discover workspace, user, and plugin skills by default. Use `include_global_skills=false` when you only want repo-local instructions, or `include_skills=false` when you want the fastest possible open call. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
 
 ## Codex-style context
 
@@ -956,6 +980,23 @@ workspace  write/edit can write workspace files, except blocked paths
 
 The launcher defaults to `workspace` in normal coding mode and `handoff` in handoff/pro planning modes.
 
+## Tool modes
+
+`CODEXPRO_TOOL_MODE=standard` is the default. It exposes the normal coding loop plus `show_changes`, Pro context export, and generic agent handoff.
+
+```text
+minimal   smallest surface for demos and simple coding: open/read/write/edit/bash/show_changes
+standard  default surface for normal coding plus handoff/export
+full      all tools, including inventory, workspace snapshots, raw git tools, codex_context, and compatibility wrappers
+```
+
+Launcher examples:
+
+```bash
+codexpro start --tool-mode minimal
+codexpro start --tool-mode full
+```
+
 ## Bash modes
 
 `CODEXPRO_BASH_MODE=safe` is the default. It allows common inspection and test commands, including:
@@ -963,7 +1004,7 @@ The launcher defaults to `workspace` in normal coding mode and `handoff` in hand
 ```text
 pwd, ls, find
 git status, git diff, git log, git show, git branch, git rev-parse, git ls-files
-npm/pnpm/yarn/bun test/build/lint/typecheck/check
+npm/pnpm/yarn/bun test/build/lint/typecheck/check, including suffix scripts such as npm run build:clients
 pytest, go test, cargo test, cargo check, cargo clippy, tsc, eslint, biome check
 ```
 
@@ -1008,11 +1049,11 @@ Use CodexPro.
 
 Call server_config first.
 Then call open_current_workspace with include_tree=false.
-Call codexpro_inventory only when you need local skill or MCP server names.
+If you need global skill or MCP server names, ask me to restart CodexPro with --tool-mode full.
 
-Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and git_diff or git_status when useful.
+Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and show_changes when useful.
 
-Keep changes scoped to the request. Do not use handoff_to_agent or handoff_to_codex unless I explicitly ask for planning-only handoff.
+Keep changes scoped to the request. Do not use handoff_to_agent unless I explicitly ask for planning-only handoff.
 ```
 
 ## Prompt for a local agent
@@ -1042,13 +1083,12 @@ Use CodexPro.
 Open ~/tmp/codexpro-example as the active workspace. Demonstrate each tool call while you work:
 
 1. server_config
-2. codexpro_inventory
-3. open_workspace
-4. tree
-5. read the relevant HTML/table file
-6. write README.md explaining the demo
-7. edit the repeated table row so each tool appears once
-8. run one final targeted search to verify
+2. open_workspace
+3. tree
+4. read the relevant HTML/table file
+5. write README.md explaining the demo
+6. edit the repeated table row so each tool appears once
+7. run one final targeted search and show_changes to verify
 
 Narrate which CodexPro tool you are using before each call.
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ChatGPT can do MCP-backed agentic coding in your local repo, while Codex remains
 
 CodexPro defaults to `CODEXPRO_TOOL_MODE=standard`, which keeps ChatGPT's tool picker focused on the normal coding loop plus handoff/export workflows. Use `--tool-mode minimal` for the tightest demo surface, or `--tool-mode full` when you want every compatibility and debugging tool exposed.
 
-The smaller default tool list is deliberate. ChatGPT behaves better when routine work goes through a few high-signal tools instead of a large action catalog. Installed user/plugin skills are still discovered during workspace open; they are surfaced as context in the workspace card and inventory results, not as dozens of separate ChatGPT actions.
+The smaller default tool list is deliberate. ChatGPT behaves better when routine work goes through a few high-signal tools instead of a large action catalog. Installed user/plugin skills are still discovered during workspace open; they are surfaced as context in the workspace card and can be loaded on demand with `load_skill`, not exposed as dozens of separate ChatGPT actions.
 
 Standard mode exposes:
 
@@ -114,6 +114,7 @@ Standard mode exposes:
 - `open_workspace` — open a local project directory using `root` or `path` and return workspace id, git status, AGENTS.md status, optional skill discovery, and optional file tree.
 - `tree` — inspect files.
 - `search` — search code with ripgrep or a Node fallback.
+- `load_skill` — load bounded `SKILL.md` instructions for a discovered workspace, user, or plugin skill by name.
 - `read` — read text files with line numbers.
 - `write` — create/overwrite files and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
 - `edit` — exact text replacement and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
@@ -208,6 +209,7 @@ server_config
 codexpro_inventory
 tree
 search
+load_skill
 read
 bash
 git_status / git_diff
@@ -597,12 +599,13 @@ For faster ChatGPT runs, keep the first call narrow:
 ```text
 Call open_current_workspace with include_tree=false unless you need the tree immediately.
 Use tree with max_depth=2 and max_entries=100 when you need file structure.
-Use --tool-mode full and call codexpro_inventory only when you want ChatGPT to see global skill and MCP server names.
+Use load_skill only for the specific discovered skill needed for the task.
+Use --tool-mode full and call codexpro_inventory only when you want ChatGPT to see full global skill and MCP server inventory.
 Do not call open_workspace after open_current_workspace unless you are switching to a different root.
 Use tree/search/read for inspection, one targeted search plus show_changes for review, and bash only for focused build/test/lint verification.
 ```
 
-`open_current_workspace` and `open_workspace` discover workspace, user, and plugin skills by default. Use `include_global_skills=false` when you only want repo-local instructions, or `include_skills=false` when you want the fastest possible open call. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
+`open_current_workspace` and `open_workspace` discover workspace, user, and plugin skills by default. Use `include_global_skills=false` when you only want repo-local instructions, or `include_skills=false` when you want the fastest possible open call. `load_skill` only accepts a discovered skill name and optional source, then reads that skill's `SKILL.md` with a bounded byte limit; it does not accept arbitrary file paths. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
 
 ## Codex-style context
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -61,7 +61,7 @@ ChatGPT Web 可以看到：
   AGENTS.md
   .ai-bridge 计划、状态和执行记录
   git status
-  git diff
+  show_changes 审查摘要和可选 diff
   文件树、搜索结果、指定源码文件
 
 ChatGPT Web 可以操作：
@@ -70,13 +70,19 @@ ChatGPT Web 可以操作：
   write   在工作区内写文件
   edit    精确替换文本
   bash    运行安全验证命令
-  git_*   查看 git 状态和 diff
+  show_changes 查看当前改动摘要
 
 本地执行器仍然有价值：
   Codex / OpenCode / Pi 执行计划
   终端重任务留在本地
   ChatGPT 回看执行结果和 diff
 ```
+
+默认 `CODEXPRO_TOOL_MODE=standard`，只暴露常用编码循环、`show_changes`、上下文导出和 handoff。演示时可以用 `--tool-mode minimal`，需要完整兼容工具时用 `--tool-mode full`。
+
+默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，但把它们作为上下文显示，而不是变成几十个单独 action。
+
+ChatGPT 里只有关键动作会显示卡片：open workspace 项目摘要、write/edit diff、`show_changes` 审查和 handoff 导出。workspace 卡片默认紧凑，git、skills 和 tree 放在可展开详情里。bash 只用于测试、构建、lint、typecheck 等验证命令，并保持纯数据，避免刷屏。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 
 ## 快速开始
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -80,7 +80,7 @@ ChatGPT Web 可以操作：
 
 默认 `CODEXPRO_TOOL_MODE=standard`，只暴露常用编码循环、`show_changes`、上下文导出和 handoff。演示时可以用 `--tool-mode minimal`，需要完整兼容工具时用 `--tool-mode full`。
 
-默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，但把它们作为上下文显示，而不是变成几十个单独 action。
+默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，并可用 `load_skill` 按名称加载需要的 `SKILL.md`，但不会把几十个 skill 变成单独 action。
 
 ChatGPT 里只有关键动作会显示卡片：open workspace 项目摘要、write/edit diff、`show_changes` 审查和 handoff 导出。workspace 卡片默认紧凑，git、skills 和 tree 放在可展开详情里。bash 只用于测试、构建、lint、typecheck 等验证命令，并保持纯数据，避免刷屏。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 

--- a/config.example.env
+++ b/config.example.env
@@ -5,6 +5,9 @@ CODEXPRO_HOST=127.0.0.1
 CODEXPRO_PORT=8787
 CODEXPRO_BASH_MODE=safe
 CODEXPRO_WRITE_MODE=handoff
+CODEXPRO_TOOL_MODE=standard
+# Dedicated HTTPS origin for ChatGPT widget iframes. Required for app submission.
+CODEXPRO_WIDGET_DOMAIN=https://rebel0789.github.io
 CODEXPRO_HTTP_TOKEN=replace-with-a-long-random-token
 # Require a token even for loopback binds. Non-loopback and tunnel mode require one unless explicitly overridden.
 # CODEXPRO_REQUIRE_HTTP_TOKEN=1

--- a/docs/index.html
+++ b/docs/index.html
@@ -421,26 +421,22 @@ codexpro settings delete --yes</code></pre>
 
         <div class="tool-reference">
           <div>
-            <p class="eyebrow">Tools ChatGPT gets</p>
-            <h3>Local repo actions exposed through MCP.</h3>
+            <p class="eyebrow">Default standard tools</p>
+            <h3>Focused local repo actions exposed through MCP.</h3>
           </div>
           <div class="tool-list">
             <span>server_config</span>
             <span>open_current_workspace</span>
-            <span>codexpro_inventory</span>
-            <span>codex_context</span>
+            <span>open_workspace</span>
             <span>tree</span>
             <span>search</span>
             <span>read</span>
             <span>write</span>
             <span>edit</span>
             <span>bash</span>
-            <span>git_status</span>
-            <span>git_diff</span>
-            <span>workspace_snapshot</span>
+            <span>show_changes</span>
             <span>read_handoff</span>
             <span>export_pro_context</span>
-            <span>handoff_to_codex</span>
             <span>handoff_to_agent</span>
           </div>
         </div>
@@ -459,7 +455,7 @@ codexpro settings delete --yes</code></pre>
           <article>
             <small>Visual widgets</small>
             <h3>Cards only for useful changes</h3>
-            <p>Write/edit diffs and handoff exports get compact cards. Routine reads, searches, and config calls stay data-only to keep ChatGPT clean.</p>
+            <p>Workspace opens, write/edit diffs, show_changes review cards, and handoff exports get compact cards. Skills, git, and tree details stay folded until opened; bash stays data-only.</p>
           </article>
           <article>
             <small>Stable URL rule</small>

--- a/docs/index.html
+++ b/docs/index.html
@@ -455,7 +455,7 @@ codexpro settings delete --yes</code></pre>
           <article>
             <small>Visual widgets</small>
             <h3>Cards only for useful changes</h3>
-            <p>Workspace opens, write/edit diffs, show_changes review cards, and handoff exports get compact cards. Skills, git, and tree details stay folded until opened; bash stays data-only.</p>
+            <p>Workspace opens, write/edit diffs, show_changes review cards, and handoff exports get compact cards. Skills, git, and tree details stay folded until opened; <code>load_skill</code> loads bounded instructions on demand, and bash stays data-only.</p>
           </article>
           <article>
             <small>Stable URL rule</small>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -311,7 +311,7 @@ codexpro start</code></pre>
           <article>
             <small>可视卡片</small>
             <h3>只给关键动作卡片</h3>
-            <p>open workspace 摘要、write/edit diff、show_changes 审查和 handoff 导出会显示紧凑卡片。skills、git 和 tree 详情默认折叠，bash 保持纯数据。</p>
+            <p>open workspace 摘要、write/edit diff、show_changes 审查和 handoff 导出会显示紧凑卡片。skills、git 和 tree 详情默认折叠；<code>load_skill</code> 按需加载有限长度的说明，bash 保持纯数据。</p>
           </article>
           <article>
             <small>上下文持久化</small>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -278,23 +278,20 @@ codexpro start</code></pre>
         </div>
         <div class="tool-reference">
           <div>
-            <p class="eyebrow">Tools</p>
-            <h3>仓库读取、编辑、验证和 handoff。</h3>
+            <p class="eyebrow">Standard tools</p>
+            <h3>默认精简的仓库读取、编辑、验证和 handoff。</h3>
           </div>
           <div class="tool-list">
             <span>server_config</span>
             <span>open_current_workspace</span>
-            <span>codexpro_inventory</span>
-            <span>codex_context</span>
+            <span>open_workspace</span>
             <span>tree</span>
             <span>search</span>
             <span>read</span>
             <span>write</span>
             <span>edit</span>
             <span>bash</span>
-            <span>git_status</span>
-            <span>git_diff</span>
-            <span>workspace_snapshot</span>
+            <span>show_changes</span>
             <span>read_handoff</span>
             <span>export_pro_context</span>
             <span>handoff_to_agent</span>
@@ -310,6 +307,11 @@ codexpro start</code></pre>
             <small>safe bash</small>
             <h3>验证而不是任意 shell</h3>
             <p>safe 模式允许常见检查、git、test、lint、typecheck 和 build 命令。只在信任的本地仓库里使用 full bash。</p>
+          </article>
+          <article>
+            <small>可视卡片</small>
+            <h3>只给关键动作卡片</h3>
+            <p>open workspace 摘要、write/edit diff、show_changes 审查和 handoff 导出会显示紧凑卡片。skills、git 和 tree 详情默认折叠，bash 保持纯数据。</p>
           </article>
           <article>
             <small>上下文持久化</small>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexpro",
-  "version": "0.28.0",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexpro",
-      "version": "0.28.0",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexpro",
-  "version": "0.28.0",
+  "version": "0.28.4",
   "description": "A local MCP/App SDK-style connector that lets ChatGPT inspect, edit, and hand off work to Codex inside a local dev workspace.",
   "type": "module",
   "license": "MIT",

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1883,9 +1883,11 @@ async function runSetupWizard(argv) {
     const bash = optionValue(defaults, profile, 'bash', ['CODEXPRO_BASH_MODE'], '');
     const write = optionValue(defaults, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
     const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
+    const widgetDomain = optionValue(defaults, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
     if (bash) args.push('--bash', bash);
     if (write) args.push('--write', write);
     if (toolMode) args.push('--tool-mode', toolMode);
+    if (widgetDomain) args.push('--widget-domain', widgetDomain);
     if (defaults.noInstallCloudflared) args.push('--no-install-cloudflared');
     if (defaults.openChatgpt) args.push('--open-chatgpt');
     if (defaults.noCopyUrl) args.push('--no-copy-url');
@@ -1959,6 +1961,7 @@ async function runSetupWizard(argv) {
         ...(bash ? { bash } : {}),
         ...(write ? { write } : {}),
         ...(toolMode ? { toolMode } : {}),
+        ...(widgetDomain ? { widgetDomain } : {}),
         ...(defaults.noInstallCloudflared ? { noInstallCloudflared: true } : {})
       });
       statusLine('ok', `Saved workspace profile: ${savedPath}`);

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -51,6 +51,12 @@ Options:
   --write <off|handoff|workspace>
                              Write mode. Default: workspace in agent mode, handoff otherwise.
                              handoff = ChatGPT can write .ai-bridge only; Codex edits source.
+  --tool-mode <minimal|standard|full>
+                             Tool surface exposed to ChatGPT. Default: standard.
+                             minimal = open/read/write/edit/bash/show_changes only.
+                             full = expose every compatibility and advanced tool.
+  --widget-domain <origin>   Dedicated HTTPS origin for ChatGPT widget iframes.
+                             Required for app submission. Default: https://rebel0789.github.io.
   --tunnel <none|cloudflare|cloudflare-named|ngrok>
                              Expose local MCP. Default: cloudflare.
                              cloudflare = quick tunnel with a new URL each restart.
@@ -230,7 +236,7 @@ function printSavedProfileHint(profile) {
   printBox('Saved setup found', [
     summary,
     'From this folder, future launches only need: codexpro start',
-    'Use codexpro setup when you want to change the port, mode, tunnel, hostname, or token.'
+    'Use codexpro setup when you want to change the port, mode, tool mode, tunnel, hostname, or token.'
   ]);
 }
 
@@ -1452,7 +1458,7 @@ function printConnectorBlock(endpoint, token, options = {}) {
   console.log('');
   console.log(paint('bold', 'CodexPro ready'));
   if (options.root) console.log(`  Workspace  ${options.root}`);
-  console.log(`  Mode       ${modeTitle}  write=${options.write ?? 'workspace'}  bash=${options.bash ?? 'safe'}`);
+  console.log(`  Mode       ${modeTitle}  tools=${options.toolMode ?? 'standard'}  write=${options.write ?? 'workspace'}  bash=${options.bash ?? 'safe'}`);
   console.log(`  Connector  ${publicHttps ? 'public HTTPS' : 'local HTTP'}`);
   if (copied.ok) {
     console.log(`  URL        copied with ${copied.command}`);
@@ -1471,7 +1477,7 @@ function printConnectorBlock(endpoint, token, options = {}) {
   console.log('');
   console.log('Next: press Enter to open ChatGPT, paste the copied Server URL, choose Authentication: None.');
   console.log('Keys: Enter open | c copy | o status | h help | q quit');
-  return { ...details, copied, opened, mode };
+  return { ...details, copied, opened, mode, toolMode: options.toolMode ?? 'standard' };
 }
 
 function printControlHelp() {
@@ -1494,6 +1500,8 @@ function printModeHelp() {
   console.log('  codexpro start                 agent mode: read/write/edit/search/bash');
   console.log('  codexpro start --mode handoff  planning-only .ai-bridge handoff');
   console.log('  codexpro start --mode pro      export context for models without MCP tools');
+  console.log('  codexpro start --tool-mode minimal   expose only the tight coding loop');
+  console.log('  codexpro start --tool-mode full      expose every advanced compatibility tool');
   console.log('');
 }
 
@@ -1565,6 +1573,7 @@ async function runDoctor(argv) {
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], 'agent');
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
+  const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const stableHostname = args.hostname
     ?? args.url
     ?? process.env.CODEXPRO_PUBLIC_HOSTNAME
@@ -1591,7 +1600,7 @@ async function runDoctor(argv) {
   console.log('');
   printBox('CodexPro doctor', [
     labelValue('Workspace', root),
-    labelValue('Mode', `${mode}  write=${write}  bash=${bash}`),
+    labelValue('Mode', `${mode}  tools=${toolMode}  write=${write}  bash=${bash}`),
     labelValue('Tunnel', tunnel),
     ...(stableHostname ? [labelValue('Hostname', stableHostname)] : []),
     ...(profile.profilePath ? [labelValue('Profile', profile.profilePath)] : [])
@@ -1738,6 +1747,8 @@ function profileFromPreference(root, args, profile, preference) {
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], '');
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
+  const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
+  const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
   const existingToken = optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], '');
   const token = preference.tunnel === 'none' ? existingToken : stableToken(existingToken);
   return {
@@ -1752,6 +1763,8 @@ function profileFromPreference(root, args, profile, preference) {
     ...(token ? { token } : {}),
     ...(bash ? { bash } : {}),
     ...(write ? { write } : {}),
+    ...(toolMode ? { toolMode } : {}),
+    ...(widgetDomain ? { widgetDomain } : {}),
     ...(args.noInstallCloudflared ? { noInstallCloudflared: true } : {}),
     root
   };
@@ -1869,8 +1882,10 @@ async function runSetupWizard(argv) {
     const args = ['start', '--root', root, '--port', port, '--mode', mode];
     const bash = optionValue(defaults, profile, 'bash', ['CODEXPRO_BASH_MODE'], '');
     const write = optionValue(defaults, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
+    const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
     if (bash) args.push('--bash', bash);
     if (write) args.push('--write', write);
+    if (toolMode) args.push('--tool-mode', toolMode);
     if (defaults.noInstallCloudflared) args.push('--no-install-cloudflared');
     if (defaults.openChatgpt) args.push('--open-chatgpt');
     if (defaults.noCopyUrl) args.push('--no-copy-url');
@@ -1943,6 +1958,7 @@ async function runSetupWizard(argv) {
         ...(profileToken ? { token: profileToken } : {}),
         ...(bash ? { bash } : {}),
         ...(write ? { write } : {}),
+        ...(toolMode ? { toolMode } : {}),
         ...(defaults.noInstallCloudflared ? { noInstallCloudflared: true } : {})
       });
       statusLine('ok', `Saved workspace profile: ${savedPath}`);
@@ -2006,6 +2022,8 @@ function saveSettingsFromArgs(root, args, profile) {
     throw new Error('--hostname is required for ngrok and cloudflare-named settings.');
   }
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], profile.mode ?? 'agent');
+  const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? '');
+  const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], profile.widgetDomain ?? '');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
   const token = tunnel === 'none'
     ? optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], profile.token ?? '')
@@ -2022,6 +2040,8 @@ function saveSettingsFromArgs(root, args, profile) {
     ...(token ? { token } : {}),
     ...(args.bash ?? profile.bash ? { bash: args.bash ?? profile.bash } : {}),
     ...(args.write ?? profile.write ? { write: args.write ?? profile.write } : {}),
+    ...(toolMode ? { toolMode } : {}),
+    ...(widgetDomain ? { widgetDomain } : {}),
     ...(args.noInstallCloudflared ?? profile.noInstallCloudflared ? { noInstallCloudflared: true } : {})
   });
   statusLine('ok', `Saved workspace settings: ${savedPath}`);
@@ -2340,8 +2360,11 @@ async function main() {
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
+  const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
+  const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], 'https://rebel0789.github.io');
   if (!['off', 'safe', 'full'].includes(bash)) throw new Error('--bash must be off, safe, or full');
   if (!['off', 'handoff', 'workspace'].includes(write)) throw new Error('--write must be off, handoff, or workspace');
+  if (!['minimal', 'standard', 'full'].includes(toolMode)) throw new Error('--tool-mode must be minimal, standard, or full');
 
   let token = args.noAuth ? '' : optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], '');
   if (!token && tunnel !== 'none') token = stableToken();
@@ -2354,6 +2377,8 @@ async function main() {
     CODEXPRO_PORT: port,
     CODEXPRO_BASH_MODE: bash,
     CODEXPRO_WRITE_MODE: write,
+    CODEXPRO_TOOL_MODE: toolMode,
+    CODEXPRO_WIDGET_DOMAIN: widgetDomain,
     CODEXPRO_MODE: mode,
     CODEXPRO_TUNNEL_MODE: tunnel === 'none' ? '0' : '1'
   };
@@ -2375,7 +2400,7 @@ async function main() {
 
   printBox('CodexPro start', [
     labelValue('Workspace', root),
-    labelValue('Mode', `${mode}  write=${write}  bash=${bash}`),
+    labelValue('Mode', `${mode}  tools=${toolMode}  write=${write}  bash=${bash}`),
     labelValue('Local URL', `http://${host}:${port}/mcp`),
     labelValue(
       'Tunnel',
@@ -2411,6 +2436,7 @@ async function main() {
       copyUrl: args.copyUrl ? true : args.noCopyUrl ? false : undefined,
       openChatgpt: Boolean(args.openChatgpt),
       mode,
+      toolMode,
       root,
       write,
       bash
@@ -2448,6 +2474,7 @@ async function main() {
       copyUrl: args.noCopyUrl ? false : true,
       openChatgpt: Boolean(args.openChatgpt),
       mode,
+      toolMode,
       root,
       write,
       bash
@@ -2466,6 +2493,7 @@ async function main() {
       copyUrl: args.copyUrl ? true : false,
       openChatgpt: Boolean(args.openChatgpt),
       mode,
+      toolMode,
       root,
       write,
       bash
@@ -2483,6 +2511,7 @@ async function main() {
       copyUrl: args.noCopyUrl ? false : true,
       openChatgpt: Boolean(args.openChatgpt),
       mode,
+      toolMode,
       root,
       write,
       bash
@@ -2545,6 +2574,7 @@ async function main() {
     copyUrl: args.noCopyUrl ? false : true,
     openChatgpt: Boolean(args.openChatgpt),
     mode,
+    toolMode,
     root,
     write,
     bash

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -134,6 +134,16 @@ async function callTool(client, name, args = {}) {
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-smoke-'));
+await fs.mkdir(path.join(root, '.codex', 'skills', 'http-smoke-skill'), { recursive: true });
+await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKILL.md'), [
+  '---',
+  'name: http-smoke-skill',
+  'description: HTTP smoke test skill discovery.',
+  '---',
+  '',
+  '# HTTP Smoke Skill',
+  ''
+].join('\n'), 'utf8');
 const port = await getFreePort();
 const token = 'codexpro-http-smoke-token';
 const child = spawn('node', ['dist/http.js'], {
@@ -145,7 +155,9 @@ const child = spawn('node', ['dist/http.js'], {
     CODEXPRO_PORT: String(port),
     CODEXPRO_HTTP_TOKEN: token,
     CODEXPRO_BASH_MODE: 'safe',
-    CODEXPRO_WRITE_MODE: 'handoff'
+    CODEXPRO_WRITE_MODE: 'handoff',
+    CODEXPRO_TOOL_MODE: 'full',
+    CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test'
   },
   stdio: ['ignore', 'pipe', 'pipe']
 });
@@ -182,18 +194,18 @@ try {
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);
   const queryToolNames = toolNames(queryTools);
-  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
     if (!queryToolNames.includes(expected)) {
       throw new Error(`URL-token MCP tools/list missing ${expected}; got ${queryToolNames.join(', ')}`);
     }
   }
-  const toolCardUri = 'ui://widget/codexpro-tool-card-v5.html';
-  for (const visualTool of ['write', 'edit', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
+  const toolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
+  for (const visualTool of ['open_current_workspace', 'open_workspace', 'write', 'edit', 'show_changes', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
     if (!hasWidgetMeta(queryTools, visualTool, toolCardUri)) {
       throw new Error(`${visualTool} should render the CodexPro widget`);
     }
   }
-  for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
+  for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
     if (hasWidgetMeta(queryTools, quietTool, toolCardUri)) {
       throw new Error(`${quietTool} should stay data-only without widget metadata`);
     }
@@ -216,11 +228,14 @@ try {
     const widget = await client.readResource({ uri: toolCardUri });
     const widgetText = widget.contents?.[0]?.text ?? '';
     const widgetMeta = widget.contents?.[0]?._meta ?? {};
-    if (!widgetText.includes('Working in the workspace') || !widgetText.includes('ui/notifications/tool-result')) {
+    if (!widgetText.includes('Waiting for tool result') || !widgetText.includes('renderWorkspace') || !widgetText.includes('details class="fold"') || !widgetText.includes('ui/notifications/tool-result')) {
       throw new Error('HTTP tool-card widget resource did not include expected Apps bridge code');
     }
     if (!widgetMeta.ui?.csp || !widgetMeta['openai/widgetCSP']) {
       throw new Error('HTTP tool-card widget resource did not expose standard and ChatGPT CSP metadata');
+    }
+    if (widgetMeta.ui?.domain !== 'https://widgets.codexpro.test' || widgetMeta['openai/widgetDomain'] !== 'https://widgets.codexpro.test') {
+      throw new Error('HTTP tool-card widget resource did not expose standard and ChatGPT widget domain metadata');
     }
   });
 
@@ -228,6 +243,12 @@ try {
     const result = await callTool(client, 'open_current_workspace', { include_tree: false });
     if (result.structuredContent.codexpro_tool !== 'open_current_workspace') {
       throw new Error('HTTP tool result was not tagged for widget rendering');
+    }
+    if (result.structuredContent.tool_mode !== 'full') {
+      throw new Error(`open_current_workspace did not expose tool_mode: ${result.structuredContent.tool_mode}`);
+    }
+    if (!result.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'http-smoke-skill')) {
+      throw new Error('HTTP open_current_workspace did not discover workspace skill inventory');
     }
     return result.structuredContent.workspace_id;
   });

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -194,7 +194,7 @@ try {
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);
   const queryToolNames = toolNames(queryTools);
-  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'load_skill', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
     if (!queryToolNames.includes(expected)) {
       throw new Error(`URL-token MCP tools/list missing ${expected}; got ${queryToolNames.join(', ')}`);
     }
@@ -205,7 +205,7 @@ try {
       throw new Error(`${visualTool} should render the CodexPro widget`);
     }
   }
-  for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
+  for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'load_skill', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
     if (hasWidgetMeta(queryTools, quietTool, toolCardUri)) {
       throw new Error(`${quietTool} should stay data-only without widget metadata`);
     }
@@ -260,6 +260,13 @@ try {
     });
     if (inventory.structuredContent.codexpro_tool !== 'codexpro_inventory') {
       throw new Error('HTTP inventory result was not tagged for widget rendering');
+    }
+    const loadedSkill = await callTool(client, 'load_skill', {
+      name: 'http-smoke-skill',
+      source: 'workspace'
+    });
+    if (loadedSkill.structuredContent.skill?.name !== 'http-smoke-skill' || !loadedSkill.structuredContent.text?.includes('# HTTP Smoke Skill')) {
+      throw new Error('HTTP load_skill did not return bounded SKILL.md content');
     }
   });
 

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,6 +14,12 @@ function run(args, env) {
     throw new Error(`codexpro ${args.join(' ')} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
   }
   return `${result.stdout}\n${result.stderr}`;
+}
+
+async function readProfile(root, home) {
+  const realRoot = await fs.realpath(root);
+  const id = createHash('sha256').update(realRoot).digest('hex').slice(0, 24);
+  return JSON.parse(await fs.readFile(path.join(home, 'profiles', `${id}.json`), 'utf8'));
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-root-'));
@@ -38,6 +45,10 @@ const saved = run([
   '19087',
   '--mode',
   'agent',
+  '--tool-mode',
+  'full',
+  '--widget-domain',
+  'https://widgets.codexpro.test',
   '--token',
   'codexpro-settings-token'
 ], env);
@@ -53,6 +64,10 @@ for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '1908
 }
 if (shown.includes('codexpro-settings-token')) {
   throw new Error(`settings show leaked token\n${shown}`);
+}
+const profile = await readProfile(root, home);
+if (profile.toolMode !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
+  throw new Error(`settings profile did not persist tool/widget options: ${JSON.stringify(profile)}`);
 }
 
 const listed = run(['settings', 'list'], env);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -108,7 +108,7 @@ await client.request('initialize', {
 client.notify('notifications/initialized');
 const tools = await client.request('tools/list', {});
 const toolNames = tools.tools.map((tool) => tool.name);
-for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
   if (!toolNames.includes(expected)) throw new Error(`missing tool: ${expected}`);
 }
 const toolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
@@ -130,7 +130,7 @@ async function expectToolError(name, args, pattern) {
 for (const visualTool of ['open_current_workspace', 'open_workspace', 'write', 'edit', 'show_changes', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
   if (!hasWidgetMeta(visualTool)) throw new Error(`${visualTool} should render the CodexPro widget`);
 }
-for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
+for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'load_skill', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
   if (hasWidgetMeta(quietTool)) throw new Error(`${quietTool} should stay data-only without widget metadata`);
 }
 const resources = await client.request('resources/list', {});
@@ -157,6 +157,11 @@ if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_curren
 if (!current.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
   throw new Error('open_current_workspace did not discover workspace skill inventory');
 }
+const loadedSkill = await client.request('tools/call', { name: 'load_skill', arguments: { name: 'smoke-skill', source: 'workspace' } });
+if (loadedSkill.structuredContent.skill?.name !== 'smoke-skill' || !loadedSkill.structuredContent.text?.includes('# Smoke Skill')) {
+  throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
+}
+await expectToolError('load_skill', { name: 'missing-skill' }, /Skill not found/);
 const inventory = await client.request('tools/call', { name: 'codexpro_inventory', arguments: { include_global_skills: false, include_mcp_servers: false } });
 if (inventory.structuredContent.codexpro_tool !== 'codexpro_inventory') throw new Error('inventory result was not tagged for widget rendering');
 const opened = await client.request('tools/call', { name: 'open_workspace', arguments: { root: tmp, include_tree: true } });
@@ -279,8 +284,8 @@ async function assertToolMode(mode, expected, hidden) {
   modeClient.close();
 }
 
-await assertToolMode('', ['server_config', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
-await assertToolMode('minimal', ['server_config', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
+await assertToolMode('', ['server_config', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
+await assertToolMode('minimal', ['server_config', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
 
 const lowerAgentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-lower-agents-'));
 await fs.writeFile(path.join(lowerAgentsRoot, 'agents.md'), '# Lowercase agents\n\n- Lowercase instruction file loaded.\n', 'utf8');

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -63,6 +63,21 @@ const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-smoke-'));
 await fs.writeFile(path.join(tmp, 'demo.txt'), 'alpha\nread\nread\nomega\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'config.txt'), 'OPENAI_API_KEY=sk-realSecretValue123\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'AGENTS.md'), '# Smoke Agents\n\n- Preserve demo.txt.\n', 'utf8');
+await fs.mkdir(path.join(tmp, '.codex', 'skills', 'smoke-skill'), { recursive: true });
+await fs.writeFile(path.join(tmp, '.codex', 'skills', 'smoke-skill', 'SKILL.md'), [
+  '---',
+  'name: smoke-skill',
+  'description: Smoke test skill discovery.',
+  '---',
+  '',
+  '# Smoke Skill',
+  ''
+].join('\n'), 'utf8');
+await fs.writeFile(path.join(tmp, 'package.json'), JSON.stringify({
+  scripts: {
+    'build:clients': "node -e \"console.log('clients ok')\""
+  }
+}, null, 2), 'utf8');
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-outside-'));
 await fs.writeFile(path.join(outside, 'secret.txt'), 'do-not-read', 'utf8');
 let symlinkEscapePath = 'secret-link.txt';
@@ -73,10 +88,16 @@ try {
   symlinkEscapePath = 'secret-link-dir/secret.txt';
   await fs.symlink(outside, path.join(tmp, 'secret-link-dir'), 'junction');
 }
+for (const args of [['init'], ['add', 'demo.txt', 'AGENTS.md', 'package.json']]) {
+  const result = spawnSync('git', args, { cwd: tmp, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  }
+}
 
-const client = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'], {
+const client = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe', '--tool-mode', 'full'], {
   cwd: path.resolve('.'),
-  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp }
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test' }
 });
 
 await client.request('initialize', {
@@ -87,10 +108,10 @@ await client.request('initialize', {
 client.notify('notifications/initialized');
 const tools = await client.request('tools/list', {});
 const toolNames = tools.tools.map((tool) => tool.name);
-for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
   if (!toolNames.includes(expected)) throw new Error(`missing tool: ${expected}`);
 }
-const toolCardUri = 'ui://widget/codexpro-tool-card-v5.html';
+const toolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
 const toolsByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
 function hasWidgetMeta(name) {
   const meta = toolsByName.get(name)?._meta ?? {};
@@ -106,10 +127,10 @@ async function expectToolError(name, args, pattern) {
     throw new Error(`${name} error did not match ${pattern}: ${text}`);
   }
 }
-for (const visualTool of ['write', 'edit', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
+for (const visualTool of ['open_current_workspace', 'open_workspace', 'write', 'edit', 'show_changes', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
   if (!hasWidgetMeta(visualTool)) throw new Error(`${visualTool} should render the CodexPro widget`);
 }
-for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
+for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
   if (hasWidgetMeta(quietTool)) throw new Error(`${quietTool} should stay data-only without widget metadata`);
 }
 const resources = await client.request('resources/list', {});
@@ -119,20 +140,31 @@ if (toolCard.mimeType !== 'text/html;profile=mcp-app') throw new Error(`unexpect
 const widget = await client.request('resources/read', { uri: toolCardUri });
 const widgetText = widget.contents?.[0]?.text ?? '';
 const widgetMeta = widget.contents?.[0]?._meta ?? {};
-if (!widgetText.includes('Working in the workspace') || !widgetText.includes('ui/notifications/tool-result')) {
+if (!widgetText.includes('Waiting for tool result') || !widgetText.includes('renderWorkspace') || !widgetText.includes('details class="fold"') || !widgetText.includes('ui/notifications/tool-result')) {
   throw new Error('tool-card widget resource did not include expected Apps bridge code');
 }
 if (!widgetMeta.ui?.csp || !widgetMeta['openai/widgetCSP']) {
   throw new Error('tool-card widget resource did not expose standard and ChatGPT CSP metadata');
 }
+if (widgetMeta.ui?.domain !== 'https://widgets.codexpro.test' || widgetMeta['openai/widgetDomain'] !== 'https://widgets.codexpro.test') {
+  throw new Error('tool-card widget resource did not expose standard and ChatGPT widget domain metadata');
+}
 const current = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
 const realTmp = await fs.realpath(tmp);
 if (current.structuredContent.root !== realTmp) throw new Error(`open_current_workspace opened ${current.structuredContent.root}, expected ${realTmp}`);
 if (current.structuredContent.codexpro_tool !== 'open_current_workspace') throw new Error('tool result was not tagged for widget rendering');
+if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_current_workspace did not expose tool_mode: ${current.structuredContent.tool_mode}`);
+if (!current.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
+  throw new Error('open_current_workspace did not discover workspace skill inventory');
+}
 const inventory = await client.request('tools/call', { name: 'codexpro_inventory', arguments: { include_global_skills: false, include_mcp_servers: false } });
 if (inventory.structuredContent.codexpro_tool !== 'codexpro_inventory') throw new Error('inventory result was not tagged for widget rendering');
 const opened = await client.request('tools/call', { name: 'open_workspace', arguments: { root: tmp, include_tree: true } });
 const ws = opened.structuredContent.workspace_id;
+const openedByPath = await client.request('tools/call', { name: 'open_workspace', arguments: { path: tmp, include_tree: false } });
+if (openedByPath.structuredContent.workspace_id !== ws) {
+  throw new Error(`open_workspace path alias returned ${openedByPath.structuredContent.workspace_id}, expected ${ws}`);
+}
 await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'demo.txt' } });
 const secretRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'config.txt' } });
 const secretPayload = JSON.stringify(secretRead);
@@ -156,6 +188,10 @@ if (envRefPayload.includes('[REDACTED_SECRET]')) {
 const symlinkRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: symlinkEscapePath } });
 if (!symlinkRead.isError) throw new Error('symlink escape read was not blocked');
 await client.request('tools/call', { name: 'edit', arguments: { workspace_id: ws, path: 'demo.txt', old_text: 'read\nread', new_text: 'read\nwrite' } });
+const changes = await client.request('tools/call', { name: 'show_changes', arguments: { workspace_id: ws } });
+if (!changes.structuredContent.changed || !changes.structuredContent.diff.includes('demo.txt')) {
+  throw new Error('show_changes did not report the edited demo.txt diff');
+}
 const codexContext = await client.request('tools/call', { name: 'codex_context', arguments: { workspace_id: ws, target_path: 'demo.txt' } });
 if (!codexContext.structuredContent.agents_files.includes('AGENTS.md')) throw new Error('codex_context did not include AGENTS.md');
 if (codexContext.structuredContent.agents_files.length !== 1) throw new Error(`codex_context returned duplicate AGENTS files: ${codexContext.structuredContent.agents_files.join(', ')}`);
@@ -165,6 +201,10 @@ await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /block
 await expectToolError('bash', { workspace_id: ws, command: 'find . -fprint leaked.txt' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'git show HEAD:.env' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'ls $HOME' }, /blocked/i);
+const clientBuild = await client.request('tools/call', { name: 'bash', arguments: { workspace_id: ws, command: 'npm run build:clients', timeout_ms: 60000 } });
+if (!clientBuild.content?.[0]?.text?.includes('clients ok')) {
+  throw new Error('safe bash did not run npm run build:clients');
+}
 const exported = await client.request('tools/call', { name: 'export_pro_context', arguments: { workspace_id: ws, selected_paths: ['demo.txt'], max_files: 4, max_total_bytes: 80000 } });
 if (exported.structuredContent.path !== '.ai-bridge/pro-context.md') throw new Error('export_pro_context wrote an unexpected path');
 await fs.stat(path.join(tmp, '.ai-bridge', 'pro-context.md'));
@@ -215,4 +255,57 @@ await expectToolError('handoff_to_agent', {
   append: true
 }, /File is too large/);
 client.close();
+async function assertToolMode(mode, expected, hidden) {
+  const args = ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'];
+  if (mode) args.push('--tool-mode', mode);
+  const modeClient = new McpStdioClient('node', args, {
+    cwd: path.resolve('.'),
+    env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_TOOL_MODE: '' }
+  });
+  await modeClient.request('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: `codexpro-${mode || 'default'}-smoke`, version: '0.1.0' }
+  });
+  modeClient.notify('notifications/initialized');
+  const modeTools = await modeClient.request('tools/list', {});
+  const names = modeTools.tools.map((tool) => tool.name);
+  for (const expectedName of expected) {
+    if (!names.includes(expectedName)) throw new Error(`${mode || 'default'} mode missing ${expectedName}; got ${names.join(', ')}`);
+  }
+  for (const hiddenName of hidden) {
+    if (names.includes(hiddenName)) throw new Error(`${mode || 'default'} mode should hide ${hiddenName}; got ${names.join(', ')}`);
+  }
+  modeClient.close();
+}
+
+await assertToolMode('', ['server_config', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
+await assertToolMode('minimal', ['server_config', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
+
+const lowerAgentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-lower-agents-'));
+await fs.writeFile(path.join(lowerAgentsRoot, 'agents.md'), '# Lowercase agents\n\n- Lowercase instruction file loaded.\n', 'utf8');
+await fs.mkdir(path.join(lowerAgentsRoot, 'src'));
+await fs.writeFile(path.join(lowerAgentsRoot, 'src', 'demo.ts'), 'export const demo = true;\n', 'utf8');
+const lowerClient = new McpStdioClient('node', ['dist/stdio.js', '--root', lowerAgentsRoot, '--allow-root', lowerAgentsRoot, '--tool-mode', 'full'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: lowerAgentsRoot, CODEXPRO_ALLOWED_ROOTS: lowerAgentsRoot }
+});
+await lowerClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-lower-agents-smoke', version: '0.1.0' }
+});
+lowerClient.notify('notifications/initialized');
+const lowerOpened = await lowerClient.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+if (lowerOpened.structuredContent.agents_path !== 'agents.md') {
+  throw new Error(`lowercase agents.md was reported as ${lowerOpened.structuredContent.agents_path}`);
+}
+const lowerContext = await lowerClient.request('tools/call', { name: 'codex_context', arguments: { target_path: 'src/demo.ts', include_ai_bridge: false, include_git: false } });
+if (!lowerContext.structuredContent.agents_files.includes('agents.md')) {
+  throw new Error(`codex_context did not preserve lowercase agents.md: ${lowerContext.structuredContent.agents_files.join(', ')}`);
+}
+if (!lowerContext.content?.[0]?.text?.includes('Lowercase instruction file loaded.')) {
+  throw new Error('codex_context did not include lowercase agents.md content');
+}
+lowerClient.close();
 console.log('✓ smoke test passed');

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -118,7 +118,13 @@ function compact(command: string): string {
 
 function startsWithAllowedPrefix(command: string): boolean {
   const normalized = compact(command);
-  return SAFE_ALLOWED_PREFIXES.some((prefix) => normalized === prefix || normalized.startsWith(`${prefix} `));
+  return isAllowedPackageScript(normalized) || SAFE_ALLOWED_PREFIXES.some((prefix) => normalized === prefix || normalized.startsWith(`${prefix} `));
+}
+
+function isAllowedPackageScript(command: string): boolean {
+  const packageScriptPattern =
+    /^(?:npm|pnpm|yarn|bun)\s+run\s+(?:test|typecheck|lint|build|check)(?::[A-Za-z0-9._-]+)*(?:\s+--\s+[A-Za-z0-9._:= -]+)?$/;
+  return packageScriptPattern.test(command);
 }
 
 function assertSafeCommand(config: CodexProConfig, command: string): void {
@@ -139,7 +145,7 @@ function assertSafeCommand(config: CodexProConfig, command: string): void {
   if (!startsWithAllowedPrefix(normalized)) {
     throw new CodexProError(
       `Command is not in the safe bash allowlist: ${normalized}\n` +
-        "Allowed examples: ls, find, git status, git diff, npm test, npm run typecheck, pytest, go test, cargo test. Use read/search tools for file contents. " +
+        "Allowed examples: ls, find, git status, git diff, npm test, npm run typecheck, npm run build:clients, pytest, go test, cargo test. Use read/search tools for file contents. " +
         "Use CODEXPRO_BASH_MODE=full for trusted local automation."
     );
   }

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -215,6 +215,7 @@ export async function codexproInventory(
 Workspace: ${workspace.root}
 Bash mode: ${config.bashMode}
 Write mode: ${config.writeMode}
+Tool mode: ${config.toolMode}
 
 ## Skill summary
 

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -12,6 +12,18 @@ export interface SkillInventoryItem {
   path: string;
 }
 
+interface SkillInventoryRecord extends SkillInventoryItem {
+  absPath: string;
+}
+
+export interface LoadedSkill {
+  skill: SkillInventoryItem;
+  text: string;
+  bytes: number;
+  totalBytes: number;
+  truncated: boolean;
+}
+
 export interface McpServerInventoryItem {
   name: string;
   source: string;
@@ -36,6 +48,24 @@ async function safeReadText(file: string, maxBytes = 16_000): Promise<string> {
     const buffer = Buffer.alloc(Math.min(stat.size, maxBytes));
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
     return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readTextWithStats(file: string, maxBytes: number): Promise<{ text: string; bytes: number; totalBytes: number; truncated: boolean }> {
+  const stat = await fsp.stat(file);
+  const handle = await fsp.open(file, "r");
+  try {
+    const limit = Math.max(1, Math.min(maxBytes, stat.size));
+    const buffer = Buffer.alloc(limit);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return {
+      text: buffer.subarray(0, bytesRead).toString("utf8"),
+      bytes: bytesRead,
+      totalBytes: stat.size,
+      truncated: stat.size > bytesRead
+    };
   } finally {
     await handle.close();
   }
@@ -69,6 +99,30 @@ function skillSource(skillPath: string, workspaceRoot: string): SkillInventoryIt
   return "other";
 }
 
+function skillSourceRank(source: SkillInventoryItem["source"]): number {
+  if (source === "workspace") return 0;
+  if (source === "user") return 1;
+  if (source === "plugin") return 2;
+  return 3;
+}
+
+function compareSkills(a: SkillInventoryItem, b: SkillInventoryItem): number {
+  return (
+    skillSourceRank(a.source) - skillSourceRank(b.source) ||
+    a.name.localeCompare(b.name) ||
+    a.path.localeCompare(b.path)
+  );
+}
+
+function publicSkill(record: SkillInventoryRecord): SkillInventoryItem {
+  return {
+    name: record.name,
+    description: record.description,
+    source: record.source,
+    path: record.path
+  };
+}
+
 function frontmatterValue(text: string, key: string): string | undefined {
   const match = text.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
   return match?.[1]?.trim().replace(/^["']|["']$/g, "");
@@ -91,10 +145,10 @@ async function findSkillFiles(root: string, maxDepth: number, out: string[], max
   }
 }
 
-export async function discoverSkillInventory(
+async function discoverSkillRecords(
   workspace: Workspace,
   options: { includeGlobal?: boolean; maxSkills?: number } = {}
-): Promise<SkillInventoryItem[]> {
+): Promise<SkillInventoryRecord[]> {
   const maxSkills = Math.max(1, Math.min(options.maxSkills ?? 120, 500));
   const roots = [
     path.join(workspace.root, ".codex", "skills"),
@@ -115,7 +169,7 @@ export async function discoverSkillInventory(
     if (skillFiles.length >= maxSkills) break;
   }
 
-  const items: SkillInventoryItem[] = [];
+  const items: SkillInventoryRecord[] = [];
   for (const file of skillFiles.slice(0, maxSkills)) {
     let text = "";
     try {
@@ -129,13 +183,65 @@ export async function discoverSkillInventory(
       name,
       description,
       source: skillSource(file, workspace.root),
-      path: displayPath(file, workspace.root)
+      path: displayPath(file, workspace.root),
+      absPath: file
     });
   }
 
-  return unique(items, (item) => `${item.source}:${item.name}:${item.path}`).sort((a, b) =>
-    `${a.source}:${a.name}`.localeCompare(`${b.source}:${b.name}`)
-  );
+  return unique(items, (item) => `${item.source}:${item.name}:${item.path}`).sort(compareSkills);
+}
+
+export async function discoverSkillInventory(
+  workspace: Workspace,
+  options: { includeGlobal?: boolean; maxSkills?: number } = {}
+): Promise<SkillInventoryItem[]> {
+  return (await discoverSkillRecords(workspace, options)).map(publicSkill);
+}
+
+export async function loadSkill(
+  workspace: Workspace,
+  options: {
+    name: string;
+    source?: SkillInventoryItem["source"];
+    includeGlobal?: boolean;
+    maxSkills?: number;
+    maxBytes?: number;
+  }
+): Promise<LoadedSkill> {
+  const name = options.name.trim();
+  if (!name) throw new Error("Skill name is required.");
+
+  const records = await discoverSkillRecords(workspace, {
+    includeGlobal: options.includeGlobal !== false,
+    maxSkills: options.maxSkills
+  });
+  const matches = records.filter((skill) => skill.name === name && (!options.source || skill.source === options.source));
+  if (!matches.length) {
+    const near = records
+      .filter((skill) => skill.name.toLowerCase().includes(name.toLowerCase()))
+      .slice(0, 8)
+      .map((skill) => `${skill.name} [${skill.source}]`)
+      .join(", ");
+    throw new Error(`Skill not found: ${name}${near ? `. Similar skills: ${near}` : ""}`);
+  }
+  if (matches.length > 1 && !options.source) {
+    const choices = matches.map((skill) => `${skill.name} [${skill.source}] at ${skill.path}`).join("; ");
+    throw new Error(`Multiple skills named ${name} were found. Pass source to choose one: ${choices}`);
+  }
+
+  const [skill] = matches;
+  if (path.basename(skill.absPath) !== "SKILL.md") {
+    throw new Error(`Refusing to load non-skill file: ${skill.path}`);
+  }
+  const maxBytes = Math.max(1_000, Math.min(options.maxBytes ?? 40_000, 100_000));
+  const loaded = await readTextWithStats(skill.absPath, maxBytes);
+  return {
+    skill: publicSkill(skill),
+    text: loaded.text,
+    bytes: loaded.bytes,
+    totalBytes: loaded.totalBytes,
+    truncated: loaded.truncated
+  };
 }
 
 function parseTomlMcpServers(text: string, source: string): McpServerInventoryItem[] {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,16 +4,19 @@ import path from "node:path";
 
 export type BashMode = "off" | "safe" | "full";
 export type WriteMode = "off" | "handoff" | "workspace";
+export type ToolMode = "minimal" | "standard" | "full";
 
 export interface CodexProConfig {
   defaultRoot: string;
   allowedRoots: string[];
   host: string;
   port: number;
+  widgetDomain: string;
   authToken?: string;
   requireHttpToken: boolean;
   bashMode: BashMode;
   writeMode: WriteMode;
+  toolMode: ToolMode;
   inheritEnv: boolean;
   maxReadBytes: number;
   maxWriteBytes: number;
@@ -142,6 +145,28 @@ function writeModeFrom(value: string | undefined): WriteMode {
   return "workspace";
 }
 
+function toolModeFrom(value: string | undefined): ToolMode {
+  if (value === "minimal" || value === "standard" || value === "full") return value;
+  return "standard";
+}
+
+function widgetDomainFrom(value: string | undefined): string {
+  const raw = value?.trim() || "https://rebel0789.github.io";
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`CODEXPRO_WIDGET_DOMAIN must be a valid origin URL, got: ${raw}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("CODEXPRO_WIDGET_DOMAIN must use https.");
+  }
+  if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    throw new Error("CODEXPRO_WIDGET_DOMAIN must be an origin only, for example https://widgets.example.com.");
+  }
+  return parsed.origin;
+}
+
 function boolFrom(value: string | undefined, fallback = false): boolean {
   if (value === undefined) return fallback;
   return ["1", "true", "yes", "y", "on"].includes(value.toLowerCase());
@@ -176,6 +201,8 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
   const hostArg = typeof args.host === "string" ? args.host : undefined;
   const bashArg = typeof args.bash === "string" ? args.bash : undefined;
   const writeArg = typeof args.write === "string" ? args.write : undefined;
+  const toolModeArg = typeof args["tool-mode"] === "string" ? args["tool-mode"] : undefined;
+  const widgetDomainArg = typeof args["widget-domain"] === "string" ? args["widget-domain"] : undefined;
   const extraBlockedGlobs = splitList(process.env.CODEXPRO_BLOCKED_GLOBS, ",");
   const host = hostArg ?? process.env.HOST ?? process.env.CODEXPRO_HOST ?? "127.0.0.1";
   const authToken = process.env.CODEXPRO_HTTP_TOKEN ?? process.env.CODEBASE_BRIDGE_HTTP_TOKEN;
@@ -190,10 +217,12 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     allowedRoots,
     host,
     port: numberFrom(portArg ?? process.env.PORT ?? process.env.CODEXPRO_PORT, 8787, 1, 65535),
+    widgetDomain: widgetDomainFrom(widgetDomainArg ?? process.env.CODEXPRO_WIDGET_DOMAIN),
     authToken,
     requireHttpToken,
     bashMode: bashModeFrom(bashArg ?? process.env.CODEXPRO_BASH_MODE),
     writeMode: writeModeFrom(writeArg ?? process.env.CODEXPRO_WRITE_MODE),
+    toolMode: toolModeFrom(toolModeArg ?? process.env.CODEXPRO_TOOL_MODE),
     inheritEnv: process.env.CODEXPRO_INHERIT_ENV === "1",
     maxReadBytes: numberFrom(process.env.CODEXPRO_MAX_READ_BYTES, 180_000, 4_000, 2_000_000),
     maxWriteBytes: numberFrom(process.env.CODEXPRO_MAX_WRITE_BYTES, 1_000_000, 1_000, 10_000_000),

--- a/src/http.ts
+++ b/src/http.ts
@@ -225,7 +225,9 @@ function onboardingPage(config: CodexProConfig): string {
           <div class="row"><span class="label">Workspace</span><span class="mono">${escapeHtml(config.defaultRoot)}</span></div>
           <div class="row"><span class="label">Local MCP</span><span class="mono">${escapeHtml(localMcp)}</span></div>
           <div class="row"><span class="label">Write mode</span><span class="pill ${config.writeMode === "workspace" ? "" : "warn"}">${escapeHtml(writeTone)}</span></div>
+          <div class="row"><span class="label">Tool mode</span><span class="pill ${config.toolMode === "standard" ? "" : "warn"}">${escapeHtml(config.toolMode)}</span></div>
           <div class="row"><span class="label">Bash mode</span><span class="pill ${config.bashMode === "safe" ? "" : "warn"}">${escapeHtml(config.bashMode)}</span></div>
+          <div class="row"><span class="label">Widget domain</span><span class="mono">${escapeHtml(config.widgetDomain)}</span></div>
           <div class="row"><span class="label">Auth</span><span class="pill">${escapeHtml(authLabel)}</span></div>
         </div>
       </article>
@@ -350,6 +352,8 @@ async function main(): Promise<void> {
       allowedRoots: config.allowedRoots,
       bashMode: config.bashMode,
       writeMode: config.writeMode,
+      toolMode: config.toolMode,
+      widgetDomain: config.widgetDomain,
       contextDir: config.contextDir,
       authEnabled: Boolean(config.authToken),
       authRequired: config.requireHttpToken
@@ -426,6 +430,7 @@ async function main(): Promise<void> {
     console.error(`[CodexPro] allowedRoots=${config.allowedRoots.join(", ")}`);
     console.error(`[CodexPro] bashMode=${config.bashMode}`);
     console.error(`[CodexPro] writeMode=${config.writeMode}`);
+    console.error(`[CodexPro] widgetDomain=${config.widgetDomain}`);
   });
 }
 

--- a/src/proContext.ts
+++ b/src/proContext.ts
@@ -199,6 +199,7 @@ export async function buildProContext(
       `Workspace ID: ${workspace.id}`,
       `Write mode: ${config.writeMode}`,
       `Bash mode: ${config.bashMode}`,
+      `Tool mode: ${config.toolMode}`,
       "",
       "Purpose: paste this bundle into a high-context ChatGPT model when that model cannot call the CodexPro MCP tools directly.",
       "Instruction for ChatGPT: use this as repository context, produce a narrow Codex execution plan, and avoid inventing files or runtime facts not shown here."

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ function logToolCall(name: string, status: "ok" | "error", started: number): voi
   console.error(`[CodexProTool] ${name} ${status} ${Date.now() - started}ms`);
 }
 
-function registerToolCardResource(server: McpServer): void {
+function registerToolCardResource(server: McpServer, config: CodexProConfig): void {
   const s = server as any;
   if (typeof s.registerResource !== "function") return;
   s.registerResource(
@@ -74,7 +74,7 @@ function registerToolCardResource(server: McpServer): void {
     TOOL_CARD_URI,
     {
       title: "CodexPro Tool Card",
-      description: "Compact visual renderer for high-signal CodexPro diffs and handoffs.",
+      description: "Compact visual renderer for CodexPro workspace orientation, source changes, and handoffs.",
       mimeType: TOOL_CARD_MIME_TYPE
     },
     async () => ({
@@ -86,13 +86,15 @@ function registerToolCardResource(server: McpServer): void {
           _meta: {
             ui: {
               prefersBorder: true,
+              domain: config.widgetDomain,
               csp: {
                 connectDomains: [],
                 resourceDomains: []
               }
             },
-            "openai/widgetDescription": "Renders high-signal CodexPro changes such as file diffs, Pro context exports, and Codex handoff plans as compact developer cards.",
+            "openai/widgetDescription": "Renders CodexPro workspace orientation, file diffs, change reviews, Pro context exports, and handoff plans as compact developer cards. Bash stays data-only.",
             "openai/widgetPrefersBorder": true,
+            "openai/widgetDomain": config.widgetDomain,
             "openai/widgetCSP": {
               connect_domains: [],
               resource_domains: []
@@ -166,6 +168,59 @@ function registerToolCompat(
   throw new Error("Unsupported MCP SDK: McpServer has neither registerTool nor tool.");
 }
 
+const MINIMAL_TOOLS = new Set([
+  "server_config",
+  "open_current_workspace",
+  "open_workspace",
+  "read",
+  "write",
+  "edit",
+  "bash",
+  "show_changes"
+]);
+
+const STANDARD_TOOLS = new Set([
+  ...MINIMAL_TOOLS,
+  "tree",
+  "search",
+  "read_handoff",
+  "export_pro_context",
+  "handoff_to_agent"
+]);
+
+function shouldRegisterTool(config: CodexProConfig, name: string): boolean {
+  if (config.toolMode === "full") return true;
+  if (config.toolMode === "minimal") return MINIMAL_TOOLS.has(name);
+  return STANDARD_TOOLS.has(name);
+}
+
+function registerCodexTool(
+  config: CodexProConfig,
+  server: McpServer,
+  name: string,
+  options: Record<string, unknown>,
+  handler: (args: any) => Promise<any> | any
+): void {
+  if (!shouldRegisterTool(config, name)) return;
+  registerToolCompat(server, name, options, handler);
+}
+
+function serverInstructions(config: CodexProConfig): string {
+  return [
+    "CodexPro connects ChatGPT to one local development workspace.",
+    "",
+    "Preferred workflow:",
+    "1. Start with open_current_workspace. Use open_workspace only when the user gives a different root or asks to switch folders.",
+    "2. Follow any AGENTS.md-style instructions returned by the workspace open call before editing files.",
+    "3. Inspect with tree, search, and read. Do not use bash for git status, git diff, cat, sed, grep, rg, find, ls, or file reading.",
+    "4. Edit with write/edit. After edits, call show_changes once for git status, diff stats, and review diff.",
+    "5. Use bash only for meaningful verification commands such as npm test, npm run build, lint, typecheck, or an existing project script.",
+    "6. Keep tool calls minimal. Prefer one targeted search plus show_changes instead of repeated broad bash/git calls.",
+    "",
+    `Current modes: tool=${config.toolMode}, bash=${config.bashMode}, write=${config.writeMode}.`
+  ].join("\n");
+}
+
 function limitInt(value: unknown, fallback: number, min: number, max: number): number {
   const n = Number(value ?? fallback);
   if (!Number.isFinite(n)) return fallback;
@@ -180,6 +235,32 @@ function parseBool(value: unknown, fallback = false): boolean {
 
 function diffBlock(diff: string): string {
   return `\n\n\`\`\`diff\n${diff}\n\`\`\``;
+}
+
+function diffStats(diff: string): { additions: number; deletions: number; changed: boolean } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) additions += 1;
+    if (line.startsWith("-") && !line.startsWith("---")) deletions += 1;
+  }
+  return { additions, deletions, changed: Boolean(diff.trim()) };
+}
+
+function normalizeGitOutput(output: string): string {
+  return output.trim() === "(no output)" ? "" : output;
+}
+
+function looksLikeGitError(output: string): boolean {
+  const trimmed = output.trim();
+  return trimmed.startsWith("fatal:") || trimmed.startsWith("error:") || trimmed.startsWith("git unavailable or failed:");
+}
+
+function changedStatusLines(status: string): string[] {
+  return status
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("##"));
 }
 
 function jsonlEvent(event: string, data: Record<string, unknown>): string {
@@ -385,10 +466,11 @@ function getSharedWorkspaceManager(config: CodexProConfig): WorkspaceManager {
 export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = getSharedWorkspaceManager(config);
   const guard = new PathGuard(config);
-  const server = new McpServer({ name: "CodexPro", version: "0.28.0" });
-  registerToolCardResource(server);
+  const server = new McpServer({ name: "CodexPro", version: "0.28.4" }, { instructions: serverInstructions(config) });
+  registerToolCardResource(server, config);
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "server_config",
     {
@@ -407,9 +489,11 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         allowedRoots: config.allowedRoots,
         host: config.host,
         port: config.port,
+        widgetDomain: config.widgetDomain,
         authEnabled: Boolean(config.authToken),
         bashMode: config.bashMode,
         writeMode: config.writeMode,
+        toolMode: config.toolMode,
         inheritEnv: config.inheritEnv,
         contextDir: config.contextDir,
         maxReadBytes: config.maxReadBytes,
@@ -422,7 +506,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "codexpro_inventory",
     {
@@ -460,7 +545,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "list_workspaces",
     {
@@ -482,7 +568,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "open_current_workspace",
     {
@@ -492,10 +579,12 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         include_tree: z.boolean().optional().describe("Include a compact file tree. Default: false for speed."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth when include_tree=true. Default: 2."),
-        include_skills: z.boolean().optional().describe("Discover repo-local skills. Default: true.")
+        include_skills: z.boolean().optional().describe("Discover workspace, user, and plugin skills by name/description. Default: true."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: true.")
       },
       annotations: SESSION_READ_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Opening current CodexPro workspace...",
         "openai/toolInvocation/invoked": "Current CodexPro workspace opened"
       }
@@ -506,7 +595,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         includeTree: parseBool(args.include_tree, false),
         maxDepth: limitInt(args.max_depth, 2, 1, 8),
         includeSkills: parseBool(args.include_skills, true),
-        includeGlobalSkills: false,
+        includeGlobalSkills: parseBool(args.include_global_skills, true),
         bootstrapContext: false
       });
       return textResult(summary.text, {
@@ -515,14 +604,19 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         agents_loaded: summary.agentsLoaded,
         agents_path: summary.agentsPath,
         skills: summary.skills,
+        skill_inventory: summary.skillInventory,
+        skill_counts: summary.skillCounts,
+        tree: summary.tree,
         git_status: summary.gitStatus,
         bash_mode: config.bashMode,
-        write_mode: config.writeMode
+        write_mode: config.writeMode,
+        tool_mode: config.toolMode
       });
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "open_workspace",
     {
@@ -531,25 +625,30 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         "Open a local project directory as a CodexPro workspace. Returns a workspace_id plus git status, AGENTS.md, skills, and a compact file tree.",
       inputSchema: {
         root: z.string().optional().describe("Project directory to open. Omit to use CODEXPRO_ROOT/current working directory. Supports ~/ paths."),
+        path: z.string().optional().describe("Alias for root. Useful for clients that naturally send path instead of root."),
         include_tree: z.boolean().optional().describe("Include a compact file tree. Default: true."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth. Default: 3."),
-        include_skills: z.boolean().optional().describe("Discover repo-local skills. Default: false for speed."),
-        include_global_skills: z.boolean().optional().describe("Also scan home-level skill folders when include_skills=true. Default: false."),
+        include_skills: z.boolean().optional().describe("Discover workspace, user, and plugin skills by name/description. Default: true."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: true."),
         bootstrap_context: z.boolean().optional().describe("Deprecated and ignored. Use handoff_to_agent to create .ai-bridge files.")
       },
       annotations: SESSION_READ_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Opening CodexPro workspace...",
         "openai/toolInvocation/invoked": "CodexPro workspace opened"
       }
     },
     async (args) => {
-      const workspace = workspaces.openWorkspace(args.root);
+      if (args.root && args.path && args.root !== args.path) {
+        throw new CodexProError("open_workspace accepts either root or path. If both are provided, they must match.");
+      }
+      const workspace = workspaces.openWorkspace(args.root ?? args.path);
       const summary = await workspaceSummary(config, guard, workspace, {
         includeTree: args.include_tree !== false,
         maxDepth: limitInt(args.max_depth, 3, 1, 8),
-        includeSkills: parseBool(args.include_skills, false),
-        includeGlobalSkills: parseBool(args.include_global_skills, false),
+        includeSkills: parseBool(args.include_skills, true),
+        includeGlobalSkills: parseBool(args.include_global_skills, true),
         bootstrapContext: false
       });
       return textResult(summary.text, {
@@ -558,14 +657,19 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         agents_loaded: summary.agentsLoaded,
         agents_path: summary.agentsPath,
         skills: summary.skills,
+        skill_inventory: summary.skillInventory,
+        skill_counts: summary.skillCounts,
+        tree: summary.tree,
         git_status: summary.gitStatus,
         bash_mode: config.bashMode,
-        write_mode: config.writeMode
+        write_mode: config.writeMode,
+        tool_mode: config.toolMode
       });
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "workspace_snapshot",
     {
@@ -597,7 +701,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "tree",
     {
@@ -628,7 +733,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "search",
     {
@@ -663,7 +769,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "read",
     {
@@ -694,7 +801,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "write",
     {
@@ -737,7 +845,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "edit",
     {
@@ -781,13 +890,14 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "bash",
     {
       title: "Bash",
       description:
-        "Run one safe inspection or test command in the workspace. Do not chain commands with &&, pipes, redirects, or shell file readers; use tree/read/search for listing and file content.",
+        "Run one allowlisted verification command in the workspace, such as tests, build, lint, typecheck, or a project script. Do not use for git status/diff or file inspection; use show_changes, tree, search, and read instead. Do not chain commands with &&, pipes, redirects, or shell file readers.",
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         command: z.string().describe("Command to run."),
@@ -811,7 +921,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "git_status",
     {
@@ -833,7 +944,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "git_diff",
     {
@@ -857,7 +969,69 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
+    server,
+    "show_changes",
+    {
+      title: "Show Changes",
+      description: "Summarize the current workspace changes in one review-oriented result with git status, diff stats, and optional diff. Use this instead of bash git status, bash git diff, git_status, or git_diff when reviewing work.",
+      inputSchema: {
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
+        path: z.string().optional().describe("Optional file path relative to workspace root."),
+        staged: z.boolean().optional().describe("Show staged diff. Default: false."),
+        include_diff: z.boolean().optional().describe("Include the unified diff. Default: true.")
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+      _meta: {
+        ...toolCardMeta(),
+        "openai/toolInvocation/invoking": "Summarizing workspace changes...",
+        "openai/toolInvocation/invoked": "Workspace changes summarized"
+      }
+    },
+    async (args) => {
+      const workspace = workspaces.getWorkspace(args.workspace_id);
+      const status = gitStatus(config, workspace);
+      const includeDiff = parseBool(args.include_diff, true);
+      const rawDiff = includeDiff ? normalizeGitOutput(gitDiff(config, guard, workspace, args.path, parseBool(args.staged, false))) : "";
+      const statusError = looksLikeGitError(status) ? status : "";
+      const diffError = rawDiff && looksLikeGitError(rawDiff) ? rawDiff : "";
+      const diff = diffError ? "" : rawDiff;
+      const stats = diffStats(diff);
+      const changedFiles = statusError ? [] : changedStatusLines(status);
+      const changedText = statusError
+        ? `- Git status unavailable: ${statusError}`
+        : changedFiles.length
+          ? changedFiles.map((line) => `- ${line}`).join("\n")
+          : "- No changed files.";
+      const diffText = includeDiff
+        ? diffError
+          ? `\n\nGit diff unavailable: ${diffError}`
+          : diff
+          ? diffBlock(diff)
+          : "\n\nNo diff output."
+        : "\n\nDiff omitted by request.";
+      const text = `# Show Changes\n\nWorkspace: ${workspace.root}\n\n## Changed\n\n${changedText}\n\n## Diff stats\n\n+${stats.additions} -${stats.deletions}${diffText}`;
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        path: args.path ?? "workspace changes",
+        status,
+        status_error: statusError || undefined,
+        diff_error: diffError || undefined,
+        changed_files: changedFiles,
+        staged: parseBool(args.staged, false),
+        include_diff: includeDiff,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        changed: !statusError && (changedFiles.length > 0 || stats.changed),
+        diff
+      });
+    }
+  );
+
+  registerCodexTool(
+    config,
     server,
     "read_handoff",
     {
@@ -879,7 +1053,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "codex_context",
     {
@@ -921,7 +1096,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "export_pro_context",
     {
@@ -973,7 +1149,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "handoff_to_agent",
     {
@@ -1040,7 +1217,8 @@ ${result.prompt}
     }
   );
 
-  registerToolCompat(
+  registerCodexTool(
+    config,
     server,
     "handoff_to_codex",
     {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import { runBash } from "./bashOps.js";
 import { gitDiff, gitLog, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./workspaceOps.js";
 import { exportProContext } from "./proContext.js";
-import { codexproInventory } from "./capabilitiesOps.js";
+import { codexproInventory, loadSkill } from "./capabilitiesOps.js";
 import { TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
 
@@ -183,6 +183,7 @@ const STANDARD_TOOLS = new Set([
   ...MINIMAL_TOOLS,
   "tree",
   "search",
+  "load_skill",
   "read_handoff",
   "export_pro_context",
   "handoff_to_agent"
@@ -541,6 +542,49 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         skills: inventory.skills,
         mcp_servers: inventory.mcpServers,
         widget_uri: TOOL_CARD_URI
+      });
+    }
+  );
+
+  registerCodexTool(
+    config,
+    server,
+    "load_skill",
+    {
+      title: "Load Skill",
+      description:
+        "Load the bounded SKILL.md body for a discovered workspace, user, or plugin skill by name. Does not accept arbitrary paths; use after open_current_workspace/open_workspace shows skill_inventory.",
+      inputSchema: {
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
+        name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
+        source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source when multiple skills share a name."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: true."),
+        max_bytes: z.number().int().min(1000).max(100000).optional().describe("Maximum bytes to return from SKILL.md. Default: 40000.")
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+      _meta: {
+        "openai/toolInvocation/invoking": "Loading skill instructions...",
+        "openai/toolInvocation/invoked": "Skill instructions loaded"
+      }
+    },
+    async (args) => {
+      const workspace = workspaces.getWorkspace(args.workspace_id);
+      const loaded = await loadSkill(workspace, {
+        name: String(args.name ?? ""),
+        source: args.source,
+        includeGlobal: parseBool(args.include_global_skills, true),
+        maxBytes: limitInt(args.max_bytes, 40_000, 1_000, 100_000)
+      });
+      const truncated = loaded.truncated ? "\n\n[truncated: increase max_bytes if more context is required]" : "";
+      const text = `# Load Skill\n\nName: ${loaded.skill.name}\nSource: ${loaded.skill.source}\nPath: ${loaded.skill.path}\nBytes: ${loaded.bytes}/${loaded.totalBytes}\n\n\`\`\`markdown\n${loaded.text}${truncated}\n\`\`\``;
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        skill: loaded.skill,
+        bytes: loaded.bytes,
+        total_bytes: loaded.totalBytes,
+        truncated: loaded.truncated,
+        text: loaded.text
       });
     }
   );

--- a/src/toolCardWidget.ts
+++ b/src/toolCardWidget.ts
@@ -593,7 +593,7 @@ export const toolCardWidgetHtml = String.raw`
 
   function gitStatusRows(status, max = 8) {
     return String(status || "")
-      .split("\\n")
+      .split("\n")
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith("##"))
       .slice(0, max)
@@ -609,7 +609,7 @@ export const toolCardWidgetHtml = String.raw`
     const skills = Array.isArray(data.skill_inventory) ? data.skill_inventory : (Array.isArray(data.skills) ? data.skills : []);
     const skillCount = Number(data.skill_counts?.total ?? skills.length);
     const changedRows = gitStatusRows(data.git_status, 8);
-    const gitLines = String(data.git_status || "").split("\\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("##"));
+    const gitLines = String(data.git_status || "").split("\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("##"));
     const agentsLabel = data.agents_loaded ? (data.agents_path || "AGENTS.md") : "no AGENTS";
     const pills = [
       pill(agentsLabel, data.agents_loaded ? "good" : "warn"),

--- a/src/toolCardWidget.ts
+++ b/src/toolCardWidget.ts
@@ -1,4 +1,4 @@
-export const TOOL_CARD_URI = "ui://widget/codexpro-tool-card-v5.html";
+export const TOOL_CARD_URI = "ui://widget/codexpro-tool-card-v8.html";
 export const TOOL_CARD_MIME_TYPE = "text/html;profile=mcp-app";
 
 export const toolCardWidgetHtml = String.raw`
@@ -9,9 +9,9 @@ export const toolCardWidgetHtml = String.raw`
       <span class="glyph">C</span>
       <div class="headline">
         <div class="title">CodexPro</div>
-        <div class="subtitle">Working in the workspace...</div>
+        <div class="subtitle">Waiting for tool result...</div>
       </div>
-      <span class="pill info">running</span>
+      <span class="pill info">waiting</span>
     </header>
     <div class="skeleton">
       <span></span>
@@ -24,23 +24,23 @@ export const toolCardWidgetHtml = String.raw`
 <style>
   :root {
     color-scheme: dark light;
-    --bg: #090b0f;
-    --panel: #10141b;
-    --panel-2: #151a23;
+    --panel: #11151c;
+    --panel-2: #161b24;
     --panel-3: #0c1016;
-    --line: rgba(148, 163, 184, 0.18);
-    --line-strong: rgba(148, 163, 184, 0.28);
-    --text: #f4f7fb;
-    --soft: #cbd5e1;
-    --muted: #8a96a8;
-    --quiet: #647084;
-    --blue: #7dd3fc;
-    --teal: #5eead4;
-    --green: #86efac;
-    --red: #fda4af;
-    --amber: #fde68a;
-    --violet: #c4b5fd;
-    --shadow: rgba(0, 0, 0, 0.32);
+    --panel-4: #1d222b;
+    --line: rgba(212, 219, 229, 0.13);
+    --line-strong: rgba(212, 219, 229, 0.24);
+    --text: #f2f4f7;
+    --soft: #c9d0da;
+    --muted: #97a1af;
+    --quiet: #6f7988;
+    --accent: #d7b56d;
+    --accent-soft: rgba(215, 181, 109, 0.12);
+    --blue: #9dc3ff;
+    --green: #8edc99;
+    --red: #f29a9a;
+    --amber: #e8c978;
+    --shadow: rgba(0, 0, 0, 0.26);
   }
 
   * { box-sizing: border-box; }
@@ -49,7 +49,7 @@ export const toolCardWidgetHtml = String.raw`
     margin: 0;
     background: transparent;
     color: var(--text);
-    font: 12px/1.48 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font: 12px/1.48 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     letter-spacing: 0;
   }
 
@@ -61,19 +61,19 @@ export const toolCardWidgetHtml = String.raw`
     position: relative;
     overflow: hidden;
     border: 1px solid var(--line);
-    border-radius: 10px;
+    border-radius: 8px;
     background:
-      radial-gradient(circle at 14px 0, rgba(94, 234, 212, 0.12), transparent 32px),
-      linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0)),
+      radial-gradient(circle at 18px 0, rgba(215, 181, 109, 0.12), transparent 42px),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.042), rgba(255, 255, 255, 0)),
       var(--panel);
-    box-shadow: 0 18px 44px var(--shadow);
+    box-shadow: 0 14px 34px var(--shadow);
   }
 
   .rail {
     position: absolute;
     inset: 0 auto 0 0;
     width: 3px;
-    background: linear-gradient(180deg, var(--teal), #60a5fa 64%, transparent);
+    background: linear-gradient(180deg, var(--accent), rgba(142, 220, 153, 0.75) 64%, transparent);
     opacity: 0.88;
   }
 
@@ -92,11 +92,11 @@ export const toolCardWidgetHtml = String.raw`
     place-items: center;
     width: 26px;
     height: 26px;
-    border: 1px solid rgba(125, 211, 252, 0.26);
+    border: 1px solid rgba(215, 181, 109, 0.28);
     border-radius: 8px;
-    background: linear-gradient(180deg, rgba(125, 211, 252, 0.16), rgba(94, 234, 212, 0.06));
-    color: var(--blue);
-    font-size: 11px;
+    background: linear-gradient(180deg, rgba(215, 181, 109, 0.16), rgba(215, 181, 109, 0.04));
+    color: var(--accent);
+    font-size: 10px;
     font-weight: 900;
   }
 
@@ -108,7 +108,7 @@ export const toolCardWidgetHtml = String.raw`
     overflow: hidden;
     color: var(--text);
     font-size: 12px;
-    font-weight: 900;
+    font-weight: 760;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -118,7 +118,7 @@ export const toolCardWidgetHtml = String.raw`
     margin-top: 2px;
     color: var(--muted);
     font-size: 11px;
-    font-weight: 700;
+    font-weight: 650;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -139,18 +139,18 @@ export const toolCardWidgetHtml = String.raw`
     overflow: hidden;
     padding: 2px 7px;
     border: 1px solid var(--line);
-    border-radius: 999px;
+    border-radius: 6px;
     background: rgba(255, 255, 255, 0.035);
     color: var(--muted);
     font-size: 10px;
-    font-weight: 850;
+    font-weight: 720;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .pill.good { color: var(--green); border-color: rgba(134, 239, 172, 0.28); background: rgba(134, 239, 172, 0.08); }
   .pill.bad { color: var(--red); border-color: rgba(253, 164, 175, 0.28); background: rgba(253, 164, 175, 0.08); }
-  .pill.info { color: var(--blue); border-color: rgba(125, 211, 252, 0.28); background: rgba(125, 211, 252, 0.08); }
+  .pill.info { color: var(--blue); border-color: rgba(157, 195, 255, 0.28); background: rgba(157, 195, 255, 0.08); }
   .pill.warn { color: var(--amber); border-color: rgba(253, 230, 138, 0.28); background: rgba(253, 230, 138, 0.08); }
 
   .body {
@@ -170,7 +170,7 @@ export const toolCardWidgetHtml = String.raw`
     min-width: 0;
     padding: 8px 9px;
     border: 1px solid var(--line);
-    border-radius: 8px;
+    border-radius: 7px;
     background: rgba(255, 255, 255, 0.025);
   }
 
@@ -193,7 +193,7 @@ export const toolCardWidgetHtml = String.raw`
   .code {
     overflow: hidden;
     border: 1px solid var(--line);
-    border-radius: 8px;
+    border-radius: 7px;
     background: var(--panel-3);
   }
 
@@ -208,7 +208,7 @@ export const toolCardWidgetHtml = String.raw`
     background: var(--panel-2);
     color: var(--muted);
     font-size: 11px;
-    font-weight: 850;
+    font-weight: 720;
   }
 
   pre {
@@ -216,16 +216,134 @@ export const toolCardWidgetHtml = String.raw`
     padding: 10px;
     overflow: visible;
     color: var(--soft);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 11px;
+    line-height: 1.52;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
   }
 
-  .diff-line { display: block; min-height: 18px; padding: 0 3px; }
-  .diff-add { color: var(--green); background: rgba(134, 239, 172, 0.075); }
-  .diff-del { color: var(--red); background: rgba(253, 164, 175, 0.075); }
+  .diff-line { display: block; min-height: 18px; padding: 0 4px; border-radius: 3px; }
+  .diff-add { color: var(--green); background: rgba(142, 220, 153, 0.08); }
+  .diff-del { color: var(--red); background: rgba(242, 154, 154, 0.08); }
   .diff-hunk { color: var(--blue); }
   .terminal pre { color: #dbe7f5; }
-  .prompt { color: var(--teal); }
+  .prompt { color: var(--accent); }
+
+  .summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+
+  .summary-item {
+    min-width: 0;
+    padding: 9px 10px;
+    border: 1px solid var(--line);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.025);
+  }
+
+  .summary-label {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--quiet);
+    font-size: 10px;
+    font-weight: 760;
+  }
+
+  .summary-value {
+    color: var(--text);
+    font-size: 15px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 760;
+  }
+
+  .file-list {
+    display: grid;
+    gap: 4px;
+    margin-bottom: 10px;
+  }
+
+  .section-label {
+    margin: 10px 1px 6px;
+    color: var(--quiet);
+    font-size: 10px;
+    font-weight: 850;
+    text-transform: uppercase;
+  }
+
+  .fold {
+    margin-top: 8px;
+    border: 1px solid var(--line);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.018);
+  }
+
+  .fold > summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    min-height: 34px;
+    padding: 8px 10px;
+    cursor: pointer;
+    color: var(--soft);
+    font-weight: 760;
+    list-style: none;
+  }
+
+  .fold > summary::-webkit-details-marker { display: none; }
+
+  .fold-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .fold-count {
+    color: var(--muted);
+    font-size: 10px;
+    font-weight: 800;
+  }
+
+  .fold-body {
+    padding: 0 8px 8px;
+  }
+
+  .file-row {
+    display: grid;
+    grid-template-columns: 42px minmax(0, 1fr);
+    gap: 8px;
+    align-items: center;
+    padding: 7px 8px;
+    border: 1px solid var(--line);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.022);
+  }
+
+  .file-code {
+    color: var(--accent);
+    font: 10px/1.2 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-weight: 800;
+  }
+
+  .file-name {
+    overflow: hidden;
+    color: var(--soft);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .empty {
+    padding: 10px;
+    border: 1px dashed var(--line-strong);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.018);
+    color: var(--muted);
+  }
 
   .search {
     display: grid;
@@ -285,6 +403,7 @@ export const toolCardWidgetHtml = String.raw`
   @media (max-width: 640px) {
     .head { grid-template-columns: 28px minmax(0, 1fr); }
     .meta { grid-column: 1 / -1; justify-content: flex-start; }
+    .summary,
     .metrics,
     .hit { grid-template-columns: 1fr; }
   }
@@ -306,6 +425,21 @@ export const toolCardWidgetHtml = String.raw`
     return text.length > max ? text.slice(0, max) + "\n...[truncated in widget]" : text;
   }
 
+  function countLines(value) {
+    const text = String(value || "");
+    if (!text) return 0;
+    return text.replace(/\n$/, "").split("\n").length;
+  }
+
+  function previewLines(value, maxLines = 18) {
+    const text = String(value || "").replace(/\n$/, "");
+    if (!text) return "";
+    const lines = text.split("\n");
+    const shown = lines.slice(0, maxLines).join("\n");
+    const remaining = lines.length - maxLines;
+    return remaining > 0 ? shown + "\n...[" + remaining + " more lines]" : shown;
+  }
+
   function basename(value) {
     const text = String(value || "");
     return text.split("/").filter(Boolean).pop() || text || ".";
@@ -313,23 +447,28 @@ export const toolCardWidgetHtml = String.raw`
 
   function titleFor(tool) {
     const titles = {
-      write: "Write File",
-      edit: "Edit File",
+      open_current_workspace: "Workspace",
+      open_workspace: "Workspace",
+      write: "File write",
+      edit: "Exact edit",
       git_diff: "Git Diff",
-      export_pro_context: "Pro Context",
-      handoff_to_agent: "Agent Handoff",
-      handoff_to_codex: "Codex Handoff",
+      show_changes: "Change review",
+      export_pro_context: "Pro context",
+      handoff_to_agent: "Agent handoff",
+      handoff_to_codex: "Codex handoff",
       bash: "Terminal",
       search: "Search",
-      read: "Read File"
+      read: "Read file"
     };
     return titles[tool] || "CodexPro";
   }
 
   function iconFor(tool) {
+    if (tool === "open_current_workspace" || tool === "open_workspace") return "W";
     if (tool === "write") return "W";
     if (tool === "edit") return "E";
     if (tool === "git_diff") return "G";
+    if (tool === "show_changes") return "D";
     if (tool === "export_pro_context") return "P";
     if (tool === "handoff_to_agent") return "A";
     if (tool === "handoff_to_codex") return "H";
@@ -340,6 +479,16 @@ export const toolCardWidgetHtml = String.raw`
   }
 
   function subtitleFor(data) {
+    if (data?.codexpro_tool === "open_current_workspace" || data?.codexpro_tool === "open_workspace") {
+      return data?.root || "Workspace opened";
+    }
+    if (data?.codexpro_tool === "show_changes") {
+      if (data?.status_error || data?.diff_error) return "Git state unavailable";
+      const count = Array.isArray(data?.changed_files) ? data.changed_files.length : 0;
+      if (!count && !data?.changed) return "Workspace is clean";
+      return count === 1 ? "1 changed file" : count + " changed files";
+    }
+    if (data?.codexpro_tool === "handoff_to_agent" && data?.agent_name) return data.agent_name;
     if (data?.path) return data.path;
     if (data?.plan_path) return data.plan_path;
     if (data?.root) return data.root;
@@ -367,8 +516,24 @@ export const toolCardWidgetHtml = String.raw`
     return '<div class="metric"><span class="label">' + esc(label) + '</span><div class="value">' + esc(value ?? "-") + '</div></div>';
   }
 
+  function summaryItem(label, value) {
+    return '<div class="summary-item"><span class="summary-label">' + esc(label) + '</span><div class="summary-value">' + esc(value ?? "-") + '</div></div>';
+  }
+
   function codebox(label, text, extraClass) {
     return '<div class="code ' + esc(extraClass || "") + '"><div class="codebar"><span>' + esc(label || "output") + '</span></div><pre>' + text + '</pre></div>';
+  }
+
+  function fold(title, count, body, open) {
+    if (!body) return "";
+    return '<details class="fold"' + (open ? " open" : "") + '><summary><span class="fold-title">' + esc(title) + '</span><span class="fold-count">' + esc(count || "") + '</span></summary><div class="fold-body">' + body + '</div></details>';
+  }
+
+  function shortSource(value) {
+    if (value === "workspace") return "repo";
+    if (value === "plugin") return "plug";
+    if (value === "user") return "user";
+    return "skill";
   }
 
   function renderDiff(diff) {
@@ -394,13 +559,133 @@ export const toolCardWidgetHtml = String.raw`
       '</div></article>';
   }
 
+  function renderChanges(data) {
+    const files = Array.isArray(data.changed_files) ? data.changed_files : [];
+    const hasGitError = Boolean(data.status_error || data.diff_error);
+    const changed = Boolean(data.changed);
+    const pills = [
+      hasGitError ? pill("git unavailable", "warn") : changed ? pill("changed", "info") : pill("clean", "good"),
+      data.additions !== undefined ? pill("+" + data.additions, "good") : "",
+      data.deletions !== undefined ? pill("-" + data.deletions, "bad") : ""
+    ].join("");
+    const fileRows = files.slice(0, 10).map((line) => {
+      const status = String(line).slice(0, 2).trim() || "?";
+      const name = String(line).slice(2).trim() || String(line);
+      return '<div class="file-row"><span class="file-code">' + esc(status) + '</span><span class="file-name">' + esc(name) + '</span></div>';
+    }).join("");
+    const moreFiles = files.length > 10 ? '<div class="empty">+' + esc(files.length - 10) + ' more changed files</div>' : "";
+    const state = hasGitError
+      ? '<div class="empty">' + esc(data.status_error || data.diff_error) + '</div>'
+      : fileRows
+        ? '<div class="file-list">' + fileRows + '</div>' + moreFiles
+        : '<div class="empty">No changed files.</div>';
+    const diff = data.diff ? codebox("diff", renderDiff(data.diff), "") : "";
+    return '<article class="card">' + header(data, pills) + '<div class="body">' +
+      '<div class="summary">' +
+      summaryItem("Files", files.length) +
+      summaryItem("Added", "+" + (data.additions ?? 0)) +
+      summaryItem("Deleted", "-" + (data.deletions ?? 0)) +
+      '</div>' +
+      state +
+      diff +
+      '</div></article>';
+  }
+
+  function gitStatusRows(status, max = 8) {
+    return String(status || "")
+      .split("\\n")
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("##"))
+      .slice(0, max)
+      .map((line) => {
+        const code = line.slice(0, 2).trim() || "?";
+        const name = line.slice(2).trim() || line;
+        return '<div class="file-row"><span class="file-code">' + esc(code) + '</span><span class="file-name">' + esc(name) + '</span></div>';
+      })
+      .join("");
+  }
+
+  function renderWorkspace(data) {
+    const skills = Array.isArray(data.skill_inventory) ? data.skill_inventory : (Array.isArray(data.skills) ? data.skills : []);
+    const skillCount = Number(data.skill_counts?.total ?? skills.length);
+    const changedRows = gitStatusRows(data.git_status, 8);
+    const gitLines = String(data.git_status || "").split("\\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("##"));
+    const agentsLabel = data.agents_loaded ? (data.agents_path || "AGENTS.md") : "no AGENTS";
+    const pills = [
+      pill(agentsLabel, data.agents_loaded ? "good" : "warn"),
+      pill(skillCount + " skills", skillCount ? "info" : ""),
+      data.tool_mode ? pill("tools " + data.tool_mode) : ""
+    ].join("");
+    const contextRows = [
+      '<div class="file-row"><span class="file-code">root</span><span class="file-name">' + esc(data.root || ".") + '</span></div>',
+      data.workspace_id ? '<div class="file-row"><span class="file-code">id</span><span class="file-name">' + esc(data.workspace_id) + '</span></div>' : "",
+      data.agents_loaded ? '<div class="file-row"><span class="file-code">rules</span><span class="file-name">' + esc(data.agents_path || "AGENTS.md") + '</span></div>' : ""
+    ].join("");
+    const skillRows = skills.slice(0, 16).map((skill) => {
+      const value = typeof skill === "string" ? skill : (skill?.name || "skill");
+      const source = typeof skill === "string" ? "skill" : shortSource(skill?.source);
+      return '<div class="file-row"><span class="file-code">' + esc(source) + '</span><span class="file-name">' + esc(value) + '</span></div>';
+    }).join("");
+    const skillText = skills.length
+      ? '<div class="file-list">' + skillRows + '</div>' + (skills.length > 16 ? '<div class="empty">+' + esc(skills.length - 16) + ' more skills</div>' : "")
+      : '<div class="empty">No skills discovered. Use include_global_skills=true if this is unexpected.</div>';
+    const gitText = changedRows
+      ? '<div class="file-list">' + changedRows + '</div>' + (gitLines.length > 8 ? '<div class="empty">+' + esc(gitLines.length - 8) + ' more changed files</div>' : "")
+      : '<div class="empty">Working tree clean.</div>';
+    const tree = data.tree ? codebox("tree", esc(previewLines(data.tree, 18)), "") : "";
+    return '<article class="card">' + header(data, pills) + '<div class="body">' +
+      '<div class="summary">' +
+      summaryItem("Write", data.write_mode || "-") +
+      summaryItem("Bash", data.bash_mode || "-") +
+      summaryItem("Tools", data.tool_mode || "-") +
+      '</div>' +
+      '<div class="section-label">Context</div><div class="file-list">' + contextRows + '</div>' +
+      fold("Git", gitLines.length ? gitLines.length + " changed" : "clean", gitText, false) +
+      fold("Skills", skillCount + " discovered", skillText, false) +
+      fold("Tree", data.tree ? "available" : "", tree, false) +
+      '</div></article>';
+  }
+
+  function renderHandoff(data) {
+    const pills = [
+      data.agent_name ? pill(data.agent_name, "info") : "",
+      data.model ? pill(data.model) : "",
+      data.additions !== undefined ? pill("+" + data.additions, "good") : "",
+      data.deletions !== undefined ? pill("-" + data.deletions, "bad") : ""
+    ].join("");
+    const rows = [
+      data.plan_path ? '<div class="file-row"><span class="file-code">plan</span><span class="file-name">' + esc(data.plan_path) + '</span></div>' : "",
+      data.status_path ? '<div class="file-row"><span class="file-code">status</span><span class="file-name">' + esc(data.status_path) + '</span></div>' : "",
+      data.diff_path ? '<div class="file-row"><span class="file-code">diff</span><span class="file-name">' + esc(data.diff_path) + '</span></div>' : ""
+    ].join("");
+    const diff = data.diff ? codebox("plan file diff", renderDiff(data.diff), "") : "";
+    return '<article class="card">' + header(data, pills) + '<div class="body">' +
+      '<div class="file-list">' + rows + '</div>' +
+      diff +
+      '</div></article>';
+  }
+
   function renderBash(data) {
     const ok = Number(data.exitCode) === 0;
-    const pills = pill("exit " + (data.exitCode ?? "-"), ok ? "good" : "bad") + pill((data.durationMs ?? "-") + " ms");
+    const stdoutLines = countLines(data.stdout);
+    const stderrLines = countLines(data.stderr);
+    const totalLines = stdoutLines + stderrLines;
+    const pills = [
+      pill(ok ? "passed" : "failed", ok ? "good" : "bad"),
+      pill(totalLines + " lines", "info"),
+      pill((data.durationMs ?? "-") + " ms")
+    ].join("");
     const command = '<span class="prompt">$</span> ' + esc(data.command || "");
-    const output = esc(truncate(data.stdout || data.stderr || ""));
+    const output = previewLines(data.stdout || data.stderr || "", 18);
+    const outputBox = output ? codebox("output preview", esc(truncate(output, 5000)), "terminal") : '<div class="empty">Command produced no output.</div>';
     return '<article class="card">' + header(data, pills) + '<div class="body">' +
-      codebox("command", command + "\\n\\n" + output, "terminal") +
+      '<div class="summary">' +
+      summaryItem("Exit", data.exitCode ?? "-") +
+      summaryItem("Lines", totalLines) +
+      summaryItem("Duration", (data.durationMs ?? "-") + " ms") +
+      '</div>' +
+      codebox("command", command, "terminal") +
+      outputBox +
       '</div></article>';
   }
 
@@ -438,8 +723,8 @@ export const toolCardWidgetHtml = String.raw`
       '<div class="rail"></div>',
       '<header class="head">',
       '<span class="glyph">C</span>',
-      '<div class="headline"><div class="title">CodexPro</div><div class="subtitle">Working in the workspace...</div></div>',
-      '<span class="pill info">running</span>',
+      '<div class="headline"><div class="title">CodexPro</div><div class="subtitle">Waiting for tool result...</div></div>',
+      '<span class="pill info">waiting</span>',
       '</header>',
       '<div class="skeleton"><span></span><span></span><span></span></div>',
       '</article>'
@@ -452,7 +737,13 @@ export const toolCardWidgetHtml = String.raw`
       return;
     }
     const tool = data.codexpro_tool;
-    if (tool === "write" || tool === "edit" || tool === "git_diff" || tool === "export_pro_context" || tool === "handoff_to_agent" || tool === "handoff_to_codex" || tool === "read") {
+    if (tool === "open_current_workspace" || tool === "open_workspace") {
+      root.innerHTML = renderWorkspace(data);
+    } else if (tool === "show_changes") {
+      root.innerHTML = renderChanges(data);
+    } else if (tool === "handoff_to_agent" || tool === "handoff_to_codex") {
+      root.innerHTML = renderHandoff(data);
+    } else if (tool === "write" || tool === "edit" || tool === "git_diff" || tool === "export_pro_context" || tool === "read") {
       root.innerHTML = renderFile(data);
     } else if (tool === "bash") {
       root.innerHTML = renderBash(data);

--- a/src/workspaceOps.ts
+++ b/src/workspaceOps.ts
@@ -7,6 +7,8 @@ import type { Workspace } from "./guard.js";
 import { PathGuard } from "./guard.js";
 import { readTextFile, repoTree, ensureAiBridge } from "./fsOps.js";
 import { gitDiff, gitLog, gitStatus } from "./gitOps.js";
+import { discoverSkillInventory } from "./capabilitiesOps.js";
+import type { SkillInventoryItem } from "./capabilitiesOps.js";
 
 export interface WorkspaceSummary {
   text: string;
@@ -15,6 +17,8 @@ export interface WorkspaceSummary {
   agentsLoaded: boolean;
   agentsPath?: string;
   skills: string[];
+  skillInventory: SkillInventoryItem[];
+  skillCounts: Record<string, number>;
   tree?: string;
   gitStatus: string;
 }
@@ -61,16 +65,21 @@ export async function discoverSkills(workspace: Workspace, options: { includeGlo
   return unique(skills).sort((a, b) => a.localeCompare(b));
 }
 
-async function findAgentsFile(workspace: Workspace): Promise<string | undefined> {
-  const candidates = ["AGENTS.override.md", "AGENTS.md", "agents.md", ".agents.md"];
-  for (const candidate of candidates) {
-    const abs = path.join(workspace.root, candidate);
-    if (fs.existsSync(abs)) return candidate;
+function skillCounts(skills: Array<{ source?: string }>): Record<string, number> {
+  const counts: Record<string, number> = { total: skills.length, workspace: 0, user: 0, plugin: 0, other: 0 };
+  for (const skill of skills) {
+    const source = skill.source ?? "other";
+    counts[source] = (counts[source] ?? 0) + 1;
   }
-  return undefined;
+  return counts;
 }
 
-function candidateAgentsPaths(targetPath: string): string[] {
+async function findAgentsFile(workspace: Workspace): Promise<string | undefined> {
+  const [first] = await findAgentsFilesInDir(workspace, ".");
+  return first;
+}
+
+function candidateAgentDirs(targetPath: string): string[] {
   const normalized = targetPath.split(path.sep).join("/").replace(/^\.\//, "");
   const parts = normalized && normalized !== "." ? normalized.split("/").filter(Boolean) : [];
   const dirs = [""];
@@ -78,11 +87,28 @@ function candidateAgentsPaths(targetPath: string): string[] {
   for (let i = 0; i < directoryParts.length; i += 1) {
     dirs.push(directoryParts.slice(0, i + 1).join("/"));
   }
+  return [...new Set(dirs)];
+}
 
+async function findAgentsFilesInDir(workspace: Workspace, dir: string): Promise<string[]> {
   const names = ["AGENTS.override.md", "AGENTS.md", "agents.md", ".agents.md"];
-  return unique(
-    dirs.flatMap((dir) => names.map((name) => (dir ? `${dir}/${name}` : name)))
-  );
+  const absDir = path.join(workspace.root, dir);
+  const entries = await safeReaddir(absDir);
+  const files = entries.filter((entry) => entry.isFile());
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const name of names) {
+    const entry =
+      files.find((item) => item.name === name) ??
+      files.find((item) => item.name.toLowerCase() === name.toLowerCase());
+    if (!entry) continue;
+    const rel = dir && dir !== "." ? `${dir}/${entry.name}` : entry.name;
+    const real = fs.realpathSync(path.join(workspace.root, rel)).toLowerCase();
+    if (seen.has(real)) continue;
+    seen.add(real);
+    out.push(rel);
+  }
+  return out;
 }
 
 async function readAgentsChain(
@@ -95,7 +121,10 @@ async function readAgentsChain(
   const chunks: string[] = [];
   const files: string[] = [];
   const seenRealPaths = new Set<string>();
-  for (const rel of candidateAgentsPaths(targetPath)) {
+  const candidates = (
+    await Promise.all(candidateAgentDirs(targetPath).map((dir) => findAgentsFilesInDir(workspace, dir || ".")))
+  ).flat();
+  for (const rel of candidates) {
     try {
       const resolved = guard.resolve(workspace, rel);
       if (!fs.existsSync(resolved.absPath)) continue;
@@ -125,16 +154,15 @@ export async function workspaceSummary(
   if (options.bootstrapContext) {
     await ensureAiBridge(config, guard, workspace);
   }
-  const skills = options.includeSkills ? await discoverSkills(workspace, { includeGlobal: options.includeGlobalSkills }) : [];
+  const skillInventory = options.includeSkills
+    ? await discoverSkillInventory(workspace, { includeGlobal: options.includeGlobalSkills !== false, maxSkills: 120 })
+    : [];
+  const skills = skillInventory.map((skill) => skill.name);
+  const counts = skillCounts(skillInventory);
   const agentsPath = await findAgentsFile(workspace);
   let agentsText = "AGENTS.md: none loaded";
   if (agentsPath) {
-    try {
-      const agents = await readTextFile(config, guard, workspace, agentsPath, { maxBytes: 40_000 });
-      agentsText = `AGENTS.md loaded from ${agentsPath}\n\n${agents.text}`;
-    } catch {
-      agentsText = `AGENTS.md found at ${agentsPath}, but it could not be read.`;
-    }
+    agentsText = `AGENTS.md: ${agentsPath} (read this file before editing or making project decisions).`;
   }
 
   let treeText: string | undefined;
@@ -151,9 +179,9 @@ export async function workspaceSummary(
   const status = gitStatus(config, workspace);
   const log = gitLog(config, workspace, 5);
   const skillText = options.includeSkills
-    ? `Skills (${skills.length}): ${skills.join(", ") || "none discovered"}`
-    : "Skills: skipped for speed. Pass include_skills=true if repo-local skill discovery is needed.";
-  const text = `# Workspace\n\nWorkspace: ${workspace.id}\nRoot: ${workspace.root}\nBash mode: ${config.bashMode}\nWrite mode: ${config.writeMode}\nAllowed roots:\n${config.allowedRoots.map((root) => `- ${root}`).join("\n")}\n\n${skillText}\n\n${agentsText}\n\n## Git status\n\n${status}\n\n## Recent commits\n\n${log}\n${treeText ? `\n## Files\n\n${treeText}` : ""}`;
+    ? `Skills: ${counts.total} total (${counts.workspace ?? 0} workspace, ${counts.user ?? 0} user, ${counts.plugin ?? 0} plugin, ${counts.other ?? 0} other).`
+    : "Skills: skipped. Pass include_skills=true if skill discovery is needed.";
+  const text = `# Workspace\n\nWorkspace: ${workspace.id}\nRoot: ${workspace.root}\nBash mode: ${config.bashMode}\nWrite mode: ${config.writeMode}\nTool mode: ${config.toolMode}\n\n${agentsText}\n${skillText}\n\n## Git status\n\n${status}\n\n## Recent commits\n\n${log}\n${treeText ? `\n## Files\n\n${treeText}` : ""}`;
 
   return {
     text,
@@ -162,6 +190,8 @@ export async function workspaceSummary(
     agentsLoaded: Boolean(agentsPath),
     agentsPath,
     skills,
+    skillInventory,
+    skillCounts: counts,
     tree: treeText,
     gitStatus: status
   };
@@ -236,6 +266,7 @@ export async function readCodexContext(
     `Target path: ${targetPath}`,
     `Bash mode: ${config.bashMode}`,
     `Write mode: ${config.writeMode}`,
+    `Tool mode: ${config.toolMode}`,
     "",
     "## AGENTS Instructions",
     "",


### PR DESCRIPTION
## Summary
- add compact ChatGPT workspace cards with folded Git, Skills, and Tree sections
- discover workspace, user, and plugin skills during workspace open by default
- add `load_skill` so ChatGPT can load bounded `SKILL.md` instructions for discovered skills without arbitrary path reads
- keep routine bash output data-only and add widget domain configuration for stable template loading
- address Codex review comments for setup `--widget-domain` propagation and git status newline splitting
- update docs, changelog, package version, and smoke coverage for the new behavior

## Why
The previous ChatGPT card flow was too noisy: workspace open could dump too much context, bash calls rendered oversized cards, and skill discovery did not let ChatGPT load skill instructions safely. This keeps the default tool surface focused while still surfacing the context ChatGPT needs.

## Validation
- `npm run build`
- `npm run smoke`
- `npm pack --dry-run`
- `npm audit --audit-level=high`
- `git diff --check`
- live MCP tunnel check: v8 widget present, widget domain set, folded card template present, bash widget disabled, AGENTS.md detected, skill inventory returned
