### PR TITLE
Fix show_changes scoping and skill ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.28.5
+
+- Fixed path-scoped `show_changes` so unrelated workspace status is not reported for a clean requested path.
+- Kept duplicate `load_skill` matches ambiguous until the caller supplies the exact displayed skill path.
+
 ## 0.28.4
 
 - Made workspace cards compact by default, moving git details, discovered skills, and optional file tree output behind collapsible disclosure rows.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Standard mode exposes:
 - `open_workspace` — open a local project directory using `root` or `path` and return workspace id, git status, AGENTS.md status, optional skill discovery, and optional file tree.
 - `tree` — inspect files.
 - `search` — search code with ripgrep or a Node fallback.
-- `load_skill` — load bounded `SKILL.md` instructions for a discovered workspace, user, or plugin skill by name.
+- `load_skill` — load bounded `SKILL.md` instructions for a discovered workspace, user, or plugin skill by name, with optional source/path disambiguation.
 - `read` — read text files with line numbers.
 - `write` — create/overwrite files and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
 - `edit` — exact text replacement and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
@@ -605,7 +605,7 @@ Do not call open_workspace after open_current_workspace unless you are switching
 Use tree/search/read for inspection, one targeted search plus show_changes for review, and bash only for focused build/test/lint verification.
 ```
 
-`open_current_workspace` and `open_workspace` discover workspace, user, and plugin skills by default. Use `include_global_skills=false` when you only want repo-local instructions, or `include_skills=false` when you want the fastest possible open call. `load_skill` only accepts a discovered skill name and optional source, then reads that skill's `SKILL.md` with a bounded byte limit; it does not accept arbitrary file paths. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
+`open_current_workspace` and `open_workspace` discover workspace, user, and plugin skills by default. Use `include_global_skills=false` when you only want repo-local instructions, or `include_skills=false` when you want the fastest possible open call. `load_skill` only accepts a discovered skill name plus optional source and exact displayed path, then reads that skill's `SKILL.md` with a bounded byte limit; it does not accept arbitrary file paths. If multiple discovered skills still match, CodexPro returns an ambiguity error instead of guessing. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
 
 ## Codex-style context
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -80,7 +80,7 @@ ChatGPT Web 可以操作：
 
 默认 `CODEXPRO_TOOL_MODE=standard`，只暴露常用编码循环、`show_changes`、上下文导出和 handoff。演示时可以用 `--tool-mode minimal`，需要完整兼容工具时用 `--tool-mode full`。
 
-默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，并可用 `load_skill` 按名称加载需要的 `SKILL.md`，但不会把几十个 skill 变成单独 action。
+默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，并可用 `load_skill` 按名称、source 和显示出的 path 加载需要的 `SKILL.md`；如果仍有重名匹配，CodexPro 会报歧义错误，不会随便选一个，也不会把几十个 skill 变成单独 action。
 
 ChatGPT 里只有关键动作会显示卡片：open workspace 项目摘要、write/edit diff、`show_changes` 审查和 handoff 导出。workspace 卡片默认紧凑，git、skills 和 tree 放在可展开详情里。bash 只用于测试、构建、lint、typecheck 等验证命令，并保持纯数据，避免刷屏。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexpro",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexpro",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexpro",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "A local MCP/App SDK-style connector that lets ChatGPT inspect, edit, and hand off work to Codex inside a local dev workspace.",
   "type": "module",
   "license": "MIT",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -73,6 +73,16 @@ await fs.writeFile(path.join(tmp, '.codex', 'skills', 'smoke-skill', 'SKILL.md')
   '# Smoke Skill',
   ''
 ].join('\n'), 'utf8');
+await fs.mkdir(path.join(tmp, '.agents', 'skills', 'smoke-skill'), { recursive: true });
+await fs.writeFile(path.join(tmp, '.agents', 'skills', 'smoke-skill', 'SKILL.md'), [
+  '---',
+  'name: smoke-skill',
+  'description: Duplicate smoke test skill discovery.',
+  '---',
+  '',
+  '# Duplicate Smoke Skill',
+  ''
+].join('\n'), 'utf8');
 await fs.writeFile(path.join(tmp, 'package.json'), JSON.stringify({
   scripts: {
     'build:clients': "node -e \"console.log('clients ok')\""
@@ -93,6 +103,10 @@ for (const args of [['init'], ['add', 'demo.txt', 'AGENTS.md', 'package.json']])
   if (result.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
   }
+}
+const commitResult = spawnSync('git', ['-c', 'user.email=smoke@example.com', '-c', 'user.name=Smoke Test', 'commit', '-m', 'initial smoke fixture'], { cwd: tmp, encoding: 'utf8' });
+if (commitResult.status !== 0) {
+  throw new Error(`git commit failed: ${commitResult.stderr || commitResult.stdout}`);
 }
 
 const client = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe', '--tool-mode', 'full'], {
@@ -157,7 +171,15 @@ if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_curren
 if (!current.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
   throw new Error('open_current_workspace did not discover workspace skill inventory');
 }
-const loadedSkill = await client.request('tools/call', { name: 'load_skill', arguments: { name: 'smoke-skill', source: 'workspace' } });
+await expectToolError('load_skill', { name: 'smoke-skill', source: 'workspace' }, /Multiple skills named smoke-skill/);
+const loadedSkill = await client.request('tools/call', {
+  name: 'load_skill',
+  arguments: {
+    name: 'smoke-skill',
+    source: 'workspace',
+    path: '$WORKSPACE/.codex/skills/smoke-skill/SKILL.md'
+  }
+});
 if (loadedSkill.structuredContent.skill?.name !== 'smoke-skill' || !loadedSkill.structuredContent.text?.includes('# Smoke Skill')) {
   throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
 }
@@ -196,6 +218,17 @@ await client.request('tools/call', { name: 'edit', arguments: { workspace_id: ws
 const changes = await client.request('tools/call', { name: 'show_changes', arguments: { workspace_id: ws } });
 if (!changes.structuredContent.changed || !changes.structuredContent.diff.includes('demo.txt')) {
   throw new Error('show_changes did not report the edited demo.txt diff');
+}
+const demoChanges = await client.request('tools/call', { name: 'show_changes', arguments: { workspace_id: ws, path: 'demo.txt' } });
+if (!demoChanges.structuredContent.changed || !demoChanges.structuredContent.changed_files?.some?.((line) => line.includes('demo.txt'))) {
+  throw new Error(`path-scoped show_changes did not report demo.txt: ${JSON.stringify(demoChanges.structuredContent.changed_files)}`);
+}
+if (demoChanges.structuredContent.changed_files?.some?.((line) => line.includes('env-ref.js'))) {
+  throw new Error(`path-scoped show_changes leaked unrelated env-ref.js status: ${JSON.stringify(demoChanges.structuredContent.changed_files)}`);
+}
+const cleanPathChanges = await client.request('tools/call', { name: 'show_changes', arguments: { workspace_id: ws, path: 'package.json' } });
+if (cleanPathChanges.structuredContent.changed || cleanPathChanges.structuredContent.changed_files?.length || cleanPathChanges.structuredContent.diff.includes('demo.txt')) {
+  throw new Error(`path-scoped show_changes leaked unrelated changes: ${JSON.stringify(cleanPathChanges.structuredContent)}`);
 }
 const codexContext = await client.request('tools/call', { name: 'codex_context', arguments: { workspace_id: ws, target_path: 'demo.txt' } });
 if (!codexContext.structuredContent.agents_files.includes('AGENTS.md')) throw new Error('codex_context did not include AGENTS.md');

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -203,6 +203,7 @@ export async function loadSkill(
   options: {
     name: string;
     source?: SkillInventoryItem["source"];
+    path?: string;
     includeGlobal?: boolean;
     maxSkills?: number;
     maxBytes?: number;
@@ -210,23 +211,30 @@ export async function loadSkill(
 ): Promise<LoadedSkill> {
   const name = options.name.trim();
   if (!name) throw new Error("Skill name is required.");
+  const requestedPath = options.path?.trim();
 
   const records = await discoverSkillRecords(workspace, {
     includeGlobal: options.includeGlobal !== false,
     maxSkills: options.maxSkills
   });
-  const matches = records.filter((skill) => skill.name === name && (!options.source || skill.source === options.source));
+  const matches = records.filter(
+    (skill) =>
+      skill.name === name &&
+      (!options.source || skill.source === options.source) &&
+      (!requestedPath || skill.path === requestedPath)
+  );
   if (!matches.length) {
     const near = records
       .filter((skill) => skill.name.toLowerCase().includes(name.toLowerCase()))
       .slice(0, 8)
       .map((skill) => `${skill.name} [${skill.source}]`)
       .join(", ");
-    throw new Error(`Skill not found: ${name}${near ? `. Similar skills: ${near}` : ""}`);
+    const suffix = requestedPath ? ` at ${requestedPath}` : "";
+    throw new Error(`Skill not found: ${name}${suffix}${near ? `. Similar skills: ${near}` : ""}`);
   }
-  if (matches.length > 1 && !options.source) {
+  if (matches.length > 1) {
     const choices = matches.map((skill) => `${skill.name} [${skill.source}] at ${skill.path}`).join("; ");
-    throw new Error(`Multiple skills named ${name} were found. Pass source to choose one: ${choices}`);
+    throw new Error(`Multiple skills named ${name} were found. Pass source and path to choose one: ${choices}`);
   }
 
   const [skill] = matches;

--- a/src/gitOps.ts
+++ b/src/gitOps.ts
@@ -22,8 +22,14 @@ function runGit(workspace: Workspace, args: string[], maxOutputBytes: number): s
   return redactSensitiveText(result.stdout.trim() || "(no output)");
 }
 
-export function gitStatus(config: CodexProConfig, workspace: Workspace): string {
-  return runGit(workspace, ["status", "--short", "--branch"], config.maxOutputBytes);
+export function gitStatus(config: CodexProConfig, workspace: Workspace, guard?: PathGuard, filePath?: string): string {
+  const args = ["status", "--short", "--branch"];
+  if (filePath?.trim()) {
+    if (!guard) return "path-scoped git status requires a path guard";
+    const resolved = guard.resolve(workspace, filePath);
+    args.push("--", resolved.relPath);
+  }
+  return runGit(workspace, args, config.maxOutputBytes);
 }
 
 export function gitDiff(config: CodexProConfig, guard: PathGuard, workspace: Workspace, filePath?: string, staged = false): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -558,6 +558,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
         source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source when multiple skills share a name."),
+        path: z.string().optional().describe("Exact sanitized path from skill_inventory when name/source are still ambiguous."),
         include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: true."),
         max_bytes: z.number().int().min(1000).max(100000).optional().describe("Maximum bytes to return from SKILL.md. Default: 40000.")
       },
@@ -572,6 +573,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const loaded = await loadSkill(workspace, {
         name: String(args.name ?? ""),
         source: args.source,
+        path: typeof args.path === "string" ? args.path : undefined,
         includeGlobal: parseBool(args.include_global_skills, true),
         maxBytes: limitInt(args.max_bytes, 40_000, 1_000, 100_000)
       });
@@ -1035,9 +1037,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     },
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
-      const status = gitStatus(config, workspace);
+      const scopedPath = typeof args.path === "string" ? args.path : undefined;
+      const status = gitStatus(config, workspace, guard, scopedPath);
       const includeDiff = parseBool(args.include_diff, true);
-      const rawDiff = includeDiff ? normalizeGitOutput(gitDiff(config, guard, workspace, args.path, parseBool(args.staged, false))) : "";
+      const rawDiff = includeDiff ? normalizeGitOutput(gitDiff(config, guard, workspace, scopedPath, parseBool(args.staged, false))) : "";
       const statusError = looksLikeGitError(status) ? status : "";
       const diffError = rawDiff && looksLikeGitError(rawDiff) ? rawDiff : "";
       const diff = diffError ? "" : rawDiff;


### PR DESCRIPTION
## Summary
- scope show_changes git status to the requested path so clean path reviews do not show unrelated workspace changes
- keep duplicate load_skill matches ambiguous until source plus exact displayed path selects one skill
- bump package metadata to 0.28.5 for the post-0.28.4 fixes

## Validation
- npm run build
- npm run smoke
- npm pack --dry-run
- npm audit --audit-level=high
- git diff --check