### PR TITLE
[codex] Improve CodexPro diagnostics and cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Fixed path-scoped `show_changes` so unrelated workspace status is not reported for a clean requested path.
 - Kept duplicate `load_skill` matches ambiguous until the caller supplies the exact displayed skill path.
+- Added `codexpro_self_test`, a local-only diagnostic that checks modes, expected tools, safe bash policy, selected-only Pro context, and an optional `.ai-bridge/codexpro-self-test.md` write/edit probe without touching source files.
+- Upgraded ChatGPT cards to `ui://widget/codexpro-tool-card-v9.html` and attached compact card metadata to every CodexPro tool, with large git/tree/context/bash payloads folded or bounded instead of printed as a giant chat block.
+- Added `include_important_files` and `include_changed_files` controls to `export_pro_context` plus CLI smoke coverage for exact selected-only bundles.
+- Added a dedicated compact `server_config` renderer and accepted model-friendly aliases `workspace_snapshot.max_files` plus `git_diff.include_diff=false` to reduce avoidable retry/error loops in ChatGPT.
+- Reconfirmed the compliance boundary in runtime diagnostics and docs: CodexPro is a local workspace MCP bridge, not a model provider, model proxy, quota bypass, resale layer, or remote executor.
 
 ## 0.28.4
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,23 @@ Account tier and model tool support are separate things. Plus/Pro can expose App
 
 ## Status
 
-CodexPro is a public open-source MCP bridge with conservative defaults: workspace-only writes, safe bash by default, blocked secret paths, token-protected public URLs, and compact visual cards for high-signal code changes.
+CodexPro is a public open-source MCP bridge with conservative defaults: workspace-only writes, safe bash by default, blocked secret paths, token-protected public URLs, and compact visual cards for every tool result.
 
 CodexPro does not bypass, avoid, increase, pool, resell, or modify ChatGPT, Codex, OpenAI, or third-party model limits. It does not provide models or account access. It only exposes local repo tools to the ChatGPT session the user already controls through official MCP and Developer Mode.
 
 ChatGPT can do MCP-backed agentic coding in your local repo, while Codex remains available for terminal execution, review, or handoff workflows. Model, tool, and quota behavior are controlled by the product and account you connect CodexPro to.
+
+### Compliance boundary
+
+CodexPro is designed for the official ChatGPT Developer Mode / MCP app path:
+
+- It exposes local workspace files, git state, safe verification commands, and `.ai-bridge` handoff files selected by the user.
+- It does not ask for raw ChatGPT transcripts or broad conversation history. Context exports use explicit workspace files and bounded previews.
+- It does not scrape or act as pass-through middleware for third-party services unless the user connects an authorized local integration that follows that service's terms.
+- It does not automate ChatGPT, Codex, or terminal approval flows to bypass product security, rate limits, quota limits, account access, or review prompts.
+- Remote MCP tools do not execute Codex/OpenCode/Pi/local agents. Agent execution is a separate user-started CLI/watch process on the user's machine.
+
+Relevant OpenAI references: [ChatGPT Developer Mode](https://developers.openai.com/api/docs/guides/developer-mode), [MCP servers for ChatGPT Apps](https://developers.openai.com/api/docs/mcp), and [Apps SDK submission guidelines](https://developers.openai.com/apps-sdk/app-submission-guidelines).
 
 ## Tools exposed to ChatGPT
 
@@ -110,6 +122,7 @@ The smaller default tool list is deliberate. ChatGPT behaves better when routine
 Standard mode exposes:
 
 - `server_config` — show safety modes, limits, blocked globs, and allowed roots.
+- `codexpro_self_test` — run one local-only diagnostic for modes, expected tools, safe bash policy, `.ai-bridge` write/edit, and selected-only Pro context.
 - `open_current_workspace` — open the configured default workspace without accepting a path. Fastest/safest first call.
 - `open_workspace` — open a local project directory using `root` or `path` and return workspace id, git status, AGENTS.md status, optional skill discovery, and optional file tree.
 - `tree` — inspect files.
@@ -128,6 +141,7 @@ Minimal mode exposes only:
 
 ```text
 server_config
+codexpro_self_test
 open_current_workspace / open_workspace
 read / write / edit
 bash
@@ -185,44 +199,31 @@ The watcher writes the same review files as `execute-handoff`:
 
 ## Visual ChatGPT cards
 
-v0.8+ registers a reusable Apps SDK widget resource:
+v0.28.5+ registers a reusable Apps SDK widget resource:
 
 ```text
-ui://widget/codexpro-tool-card-v8.html
+ui://widget/codexpro-tool-card-v9.html
 ```
 
-Only high-signal workflow tools attach that resource through `_meta.ui.resourceUri` and the ChatGPT compatibility key `_meta["openai/outputTemplate"]`. In ChatGPT Developer Mode this renders compact cards for:
+Every CodexPro tool descriptor attaches that resource through `_meta.ui.resourceUri` and the ChatGPT compatibility key `_meta["openai/outputTemplate"]`. In ChatGPT Developer Mode this renders compact cards for:
 
 ```text
+server_config and codexpro_self_test
 open_current_workspace / open_workspace project summaries
+codexpro_inventory, list_workspaces, workspace_snapshot
+tree, search, load_skill, read
 write/edit diffs
-show_changes review summaries
+bash verification commands
+git_status, git_diff, show_changes review summaries
+read_handoff, codex_context
 handoff/pro-context exports
 ```
 
-Workspace cards stay compact by default. Git details, discovered skills, and optional file tree output are folded into disclosure rows so the chat does not fill with project inventory unless you open it.
+Cards stay compact by default. Git details, discovered skills, file trees, terminal output, context bundles, and raw diffs are folded or bounded so the chat does not fill with project inventory unless you open it.
 
-Routine plumbing tools intentionally stay data-only and compact:
+ChatGPT may still show some raw tool transcript around a card depending on the host UI and model behavior. CodexPro minimizes that by returning structured data, bounded previews, and a v9 card for every tool, but the ChatGPT client controls final transcript rendering.
 
-```text
-server_config
-codexpro_inventory
-tree
-search
-load_skill
-read
-bash
-git_status / git_diff
-read_handoff
-workspace_snapshot
-codex_context
-```
-
-`bash` and `git_diff` are intentionally data-only. Use `bash` for focused verification commands, and use `show_changes` when you want the visual review card. Empty or large raw diffs should not create a visual card or trigger a widget fetch just to say there is no output.
-
-This avoids the noisy "every tool call becomes a card" behavior. It follows the Apps SDK decoupled pattern: data-processing tools return normal tool results, while render-worthy tools attach the widget template.
-
-The visual cards are not unlocked by "normal coding mode" alone; the MCP server has to register an HTML resource with `text/html;profile=mcp-app` and point selected tool descriptors at it.
+The visual cards are not unlocked by "normal coding mode" alone; the MCP server has to register an HTML resource with `text/html;profile=mcp-app` and point tool descriptors at it.
 
 The widget sets both domain and CSP metadata surfaces:
 
@@ -691,6 +692,20 @@ This writes:
 
 The bundle includes the file tree, git status, current diff, recent commits, selected important config files, changed files, and existing `.ai-bridge` handoff context. `--copy` also copies the bundle to the macOS clipboard when `pbcopy` is available.
 
+For an exact selected-file bundle, disable the automatic config/docs and changed-file inclusions:
+
+```bash
+codexpro pro-bundle \
+  --root /absolute/path/to/your/repo \
+  --path README.md \
+  --path package.json \
+  --no-important-files \
+  --no-changed-files \
+  --no-diff \
+  --no-ai-bridge \
+  --copy
+```
+
 Useful options:
 
 ```bash
@@ -1050,14 +1065,16 @@ CODEXPRO_BLOCKED_GLOBS='**/secrets/**,**/*.sqlite,**/*.db' codexpro start --root
 ```text
 Use CodexPro.
 
-Call server_config first.
+Call server_config first, then codexpro_self_test.
+If self-test fails, stop and report the failed checks.
 Then call open_current_workspace with include_tree=false.
-If you need global skill or MCP server names, ask me to restart CodexPro with --tool-mode full.
 
-Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and show_changes when useful.
+Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and show_changes when useful. Use bash only for focused verification commands such as build, test, lint, or typecheck.
 
 Keep changes scoped to the request. Do not use handoff_to_agent unless I explicitly ask for planning-only handoff.
 ```
+
+After upgrading CodexPro or changing the Server URL, refresh the app actions in ChatGPT before judging the card UI. Existing cards do not retroactively re-render after a widget URI change.
 
 ## Prompt for a local agent
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -78,11 +78,11 @@ ChatGPT Web 可以操作：
   ChatGPT 回看执行结果和 diff
 ```
 
-默认 `CODEXPRO_TOOL_MODE=standard`，只暴露常用编码循环、`show_changes`、上下文导出和 handoff。演示时可以用 `--tool-mode minimal`，需要完整兼容工具时用 `--tool-mode full`。
+默认 `CODEXPRO_TOOL_MODE=standard`，只暴露常用编码循环、`codexpro_self_test`、`show_changes`、上下文导出和 handoff。演示时可以用 `--tool-mode minimal`，需要完整兼容工具时用 `--tool-mode full`。
 
 默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，并可用 `load_skill` 按名称、source 和显示出的 path 加载需要的 `SKILL.md`；如果仍有重名匹配，CodexPro 会报歧义错误，不会随便选一个，也不会把几十个 skill 变成单独 action。
 
-ChatGPT 里只有关键动作会显示卡片：open workspace 项目摘要、write/edit diff、`show_changes` 审查和 handoff 导出。workspace 卡片默认紧凑，git、skills 和 tree 放在可展开详情里。bash 只用于测试、构建、lint、typecheck 等验证命令，并保持纯数据，避免刷屏。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
+ChatGPT 里每个 CodexPro 工具都可以显示紧凑 v9 卡片：server config、自测、workspace 摘要、读写 diff、bash 验证、git/tree/search/context 和 handoff/export 都有结构化视图。git、skills、tree、terminal 输出、context 和 raw diff 默认折叠或截断，避免在聊天里刷出大段原始数据。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 
 ## 快速开始
 
@@ -317,6 +317,8 @@ git status
 推荐流程：
 
 ```text
+先调用 server_config 和 codexpro_self_test
+如果 self-test 失败，先停下来报告失败项
 先调用 open_current_workspace，include_tree=false
 再调用 codex_context，target_path 指向要改的文件，include_diff=false
 然后只读取当前任务需要的文件

--- a/docs/index.html
+++ b/docs/index.html
@@ -426,6 +426,7 @@ codexpro settings delete --yes</code></pre>
           </div>
           <div class="tool-list">
             <span>server_config</span>
+            <span>codexpro_self_test</span>
             <span>open_current_workspace</span>
             <span>open_workspace</span>
             <span>tree</span>
@@ -454,8 +455,8 @@ codexpro settings delete --yes</code></pre>
           </article>
           <article>
             <small>Visual widgets</small>
-            <h3>Cards only for useful changes</h3>
-            <p>Workspace opens, write/edit diffs, show_changes review cards, and handoff exports get compact cards. Skills, git, and tree details stay folded until opened; <code>load_skill</code> loads bounded instructions on demand, and bash stays data-only.</p>
+            <h3>Compact cards for every tool</h3>
+            <p>Every CodexPro tool can render a compact v9 card. Skills, git, tree, context, terminal output, and raw diffs stay folded or bounded until opened; <code>load_skill</code> loads bounded instructions on demand.</p>
           </article>
           <article>
             <small>Stable URL rule</small>

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -194,20 +194,15 @@ try {
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);
   const queryToolNames = toolNames(queryTools);
-  for (const expected of ['server_config', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'load_skill', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+  for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'load_skill', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
     if (!queryToolNames.includes(expected)) {
       throw new Error(`URL-token MCP tools/list missing ${expected}; got ${queryToolNames.join(', ')}`);
     }
   }
-  const toolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
-  for (const visualTool of ['open_current_workspace', 'open_workspace', 'write', 'edit', 'show_changes', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
+  const toolCardUri = 'ui://widget/codexpro-tool-card-v9.html';
+  for (const visualTool of queryToolNames) {
     if (!hasWidgetMeta(queryTools, visualTool, toolCardUri)) {
       throw new Error(`${visualTool} should render the CodexPro widget`);
-    }
-  }
-  for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'load_skill', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
-    if (hasWidgetMeta(queryTools, quietTool, toolCardUri)) {
-      throw new Error(`${quietTool} should stay data-only without widget metadata`);
     }
   }
 
@@ -228,7 +223,7 @@ try {
     const widget = await client.readResource({ uri: toolCardUri });
     const widgetText = widget.contents?.[0]?.text ?? '';
     const widgetMeta = widget.contents?.[0]?._meta ?? {};
-    if (!widgetText.includes('Waiting for tool result') || !widgetText.includes('renderWorkspace') || !widgetText.includes('details class="fold"') || !widgetText.includes('ui/notifications/tool-result')) {
+    if (!widgetText.includes('Waiting for tool result') || !widgetText.includes('renderWorkspace') || !widgetText.includes('renderSelfTest') || !widgetText.includes('details class="fold"') || !widgetText.includes('ui/notifications/tool-result')) {
       throw new Error('HTTP tool-card widget resource did not include expected Apps bridge code');
     }
     if (!widgetMeta.ui?.csp || !widgetMeta['openai/widgetCSP']) {

--- a/scripts/pro-bundle.mjs
+++ b/scripts/pro-bundle.mjs
@@ -19,6 +19,8 @@ Options:
   --max-files <n>           Maximum file contents to include. Default: 24.
   --max-file-bytes <n>      Maximum bytes per included file. Default: 60000.
   --max-total-bytes <n>     Maximum bytes in .ai-bridge/pro-context.md.
+  --no-important-files      Do not auto-include root config/docs such as AGENTS.md, README.md, package.json.
+  --no-changed-files        Do not auto-include currently changed files from git status.
   --no-diff                 Do not include git diff.
   --no-ai-bridge            Do not include existing .ai-bridge files.
   --copy                    Copy generated context to the macOS clipboard with pbcopy.
@@ -34,6 +36,8 @@ function parseArgs(argv) {
     const key = raw.slice(2);
     if (key === 'help') out.help = true;
     else if (key === 'copy') out.copy = true;
+    else if (key === 'no-important-files') out.noImportantFiles = true;
+    else if (key === 'no-changed-files') out.noChangedFiles = true;
     else if (key === 'no-diff') out.noDiff = true;
     else if (key === 'no-ai-bridge') out.noAiBridge = true;
     else {
@@ -84,6 +88,8 @@ async function main() {
     title: args.title,
     selectedPaths: args.paths,
     extraGlobs: args.globs,
+    includeImportantFiles: !args.noImportantFiles,
+    includeChangedFiles: !args.noChangedFiles,
     includeDiff: !args.noDiff,
     includeAiBridge: !args.noAiBridge,
     maxFiles: numberArg(args.maxFiles),

--- a/scripts/pro-smoke.mjs
+++ b/scripts/pro-smoke.mjs
@@ -24,6 +24,24 @@ const proContext = await fs.readFile(path.join(root, '.ai-bridge', 'pro-context.
 if (!proContext.includes('CodexPro Context Bundle') || !proContext.includes('demo.txt')) {
   throw new Error('pro context bundle did not include expected content');
 }
+run([
+  'scripts/pro-bundle.mjs',
+  '--root', root,
+  '--path', 'demo.txt',
+  '--no-important-files',
+  '--no-changed-files',
+  '--no-diff',
+  '--no-ai-bridge',
+  '--max-files', '4',
+  '--max-total-bytes', '80000'
+]);
+const exactProContext = await fs.readFile(path.join(root, '.ai-bridge', 'pro-context.md'), 'utf8');
+if (!exactProContext.includes('Auto-include important root files: no') || !exactProContext.includes('Auto-include changed files: no')) {
+  throw new Error('selected-only pro context did not record disabled auto-inclusion settings');
+}
+if (!exactProContext.includes('### demo.txt') || exactProContext.includes('### README.md')) {
+  throw new Error('selected-only pro context did not include exactly the requested file');
+}
 
 const planFile = path.join(root, 'plan.md');
 await fs.writeFile(planFile, 'Inspect demo.txt and keep changes narrow.\n', 'utf8');

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -375,6 +375,28 @@ async function assertToolMode(mode, expected, hidden) {
 await assertToolMode('', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
 await assertToolMode('minimal', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
 
+const nonGitRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-non-git-'));
+await fs.writeFile(path.join(nonGitRoot, 'README.md'), '# Non-git fixture\n', 'utf8');
+const nonGitClient = new McpStdioClient('node', ['dist/stdio.js', '--root', nonGitRoot, '--allow-root', nonGitRoot, '--tool-mode', 'full'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: nonGitRoot, CODEXPRO_ALLOWED_ROOTS: nonGitRoot }
+});
+await nonGitClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-non-git-smoke', version: '0.1.0' }
+});
+nonGitClient.notify('notifications/initialized');
+const nonGitDiff = await nonGitClient.request('tools/call', { name: 'git_diff', arguments: { include_diff: false } });
+const nonGitPayload = JSON.stringify(nonGitDiff);
+if (!nonGitDiff.structuredContent.diff_error || !nonGitDiff.structuredContent.diff || nonGitDiff.structuredContent.changed) {
+  throw new Error(`git_diff include_diff=false hid non-git diagnostics: ${nonGitPayload}`);
+}
+if (!/not a git repository|git unavailable|fatal:/i.test(nonGitPayload)) {
+  throw new Error(`git_diff include_diff=false did not preserve the git diagnostic text: ${nonGitPayload}`);
+}
+nonGitClient.close();
+
 const lowerAgentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-lower-agents-'));
 await fs.writeFile(path.join(lowerAgentsRoot, 'agents.md'), '# Lowercase agents\n\n- Lowercase instruction file loaded.\n', 'utf8');
 await fs.mkdir(path.join(lowerAgentsRoot, 'src'));

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -122,10 +122,10 @@ await client.request('initialize', {
 client.notify('notifications/initialized');
 const tools = await client.request('tools/list', {});
 const toolNames = tools.tools.map((tool) => tool.name);
-for (const expected of ['server_config', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'git_status', 'git_diff', 'show_changes', 'read_handoff', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
   if (!toolNames.includes(expected)) throw new Error(`missing tool: ${expected}`);
 }
-const toolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
+const toolCardUri = 'ui://widget/codexpro-tool-card-v9.html';
 const toolsByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
 function hasWidgetMeta(name) {
   const meta = toolsByName.get(name)?._meta ?? {};
@@ -141,11 +141,8 @@ async function expectToolError(name, args, pattern) {
     throw new Error(`${name} error did not match ${pattern}: ${text}`);
   }
 }
-for (const visualTool of ['open_current_workspace', 'open_workspace', 'write', 'edit', 'show_changes', 'export_pro_context', 'handoff_to_agent', 'handoff_to_codex']) {
+for (const visualTool of toolNames) {
   if (!hasWidgetMeta(visualTool)) throw new Error(`${visualTool} should render the CodexPro widget`);
-}
-for (const quietTool of ['server_config', 'codexpro_inventory', 'list_workspaces', 'workspace_snapshot', 'tree', 'search', 'load_skill', 'read', 'bash', 'git_status', 'git_diff', 'read_handoff', 'codex_context']) {
-  if (hasWidgetMeta(quietTool)) throw new Error(`${quietTool} should stay data-only without widget metadata`);
 }
 const resources = await client.request('resources/list', {});
 const toolCard = resources.resources.find((resource) => resource.uri === toolCardUri);
@@ -154,7 +151,7 @@ if (toolCard.mimeType !== 'text/html;profile=mcp-app') throw new Error(`unexpect
 const widget = await client.request('resources/read', { uri: toolCardUri });
 const widgetText = widget.contents?.[0]?.text ?? '';
 const widgetMeta = widget.contents?.[0]?._meta ?? {};
-if (!widgetText.includes('Waiting for tool result') || !widgetText.includes('renderWorkspace') || !widgetText.includes('details class="fold"') || !widgetText.includes('ui/notifications/tool-result')) {
+if (!widgetText.includes('Waiting for tool result') || !widgetText.includes('renderWorkspace') || !widgetText.includes('renderSelfTest') || !widgetText.includes('details class="fold"') || !widgetText.includes('ui/notifications/tool-result')) {
   throw new Error('tool-card widget resource did not include expected Apps bridge code');
 }
 if (!widgetMeta.ui?.csp || !widgetMeta['openai/widgetCSP']) {
@@ -170,6 +167,31 @@ if (current.structuredContent.codexpro_tool !== 'open_current_workspace') throw 
 if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_current_workspace did not expose tool_mode: ${current.structuredContent.tool_mode}`);
 if (!current.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
   throw new Error('open_current_workspace did not discover workspace skill inventory');
+}
+const selfTest = await client.request('tools/call', {
+  name: 'codexpro_self_test',
+  arguments: {
+    workspace_id: current.structuredContent.workspace_id,
+    max_skills: 12
+  }
+});
+if (selfTest.structuredContent.status === 'fail' || !selfTest.structuredContent.expected_tools?.includes?.('codexpro_self_test')) {
+  throw new Error(`codexpro_self_test failed: ${JSON.stringify(selfTest.structuredContent)}`);
+}
+if (!selfTest.structuredContent.files_touched?.includes?.('.ai-bridge/codexpro-self-test.md')) {
+  throw new Error('codexpro_self_test did not run the .ai-bridge write/edit probe');
+}
+const snapshotAlias = await client.request('tools/call', {
+  name: 'workspace_snapshot',
+  arguments: {
+    workspace_id: current.structuredContent.workspace_id,
+    max_depth: 1,
+    max_files: 20,
+    include_skills: false
+  }
+});
+if (!snapshotAlias.structuredContent.tree) {
+  throw new Error('workspace_snapshot did not accept max_files alias or return a tree');
 }
 await expectToolError('load_skill', { name: 'smoke-skill', source: 'workspace' }, /Multiple skills named smoke-skill/);
 const loadedSkill = await client.request('tools/call', {
@@ -219,6 +241,13 @@ const changes = await client.request('tools/call', { name: 'show_changes', argum
 if (!changes.structuredContent.changed || !changes.structuredContent.diff.includes('demo.txt')) {
   throw new Error('show_changes did not report the edited demo.txt diff');
 }
+const statsOnlyDiff = await client.request('tools/call', { name: 'git_diff', arguments: { workspace_id: ws, include_diff: false } });
+if (statsOnlyDiff.structuredContent.include_diff !== false || statsOnlyDiff.structuredContent.diff !== '') {
+  throw new Error(`git_diff include_diff=false returned raw diff: ${JSON.stringify(statsOnlyDiff.structuredContent)}`);
+}
+if (!statsOnlyDiff.content?.[0]?.text?.includes('Raw diff omitted by include_diff=false')) {
+  throw new Error('git_diff include_diff=false did not report omitted diff in text output');
+}
 const demoChanges = await client.request('tools/call', { name: 'show_changes', arguments: { workspace_id: ws, path: 'demo.txt' } });
 if (!demoChanges.structuredContent.changed || !demoChanges.structuredContent.changed_files?.some?.((line) => line.includes('demo.txt'))) {
   throw new Error(`path-scoped show_changes did not report demo.txt: ${JSON.stringify(demoChanges.structuredContent.changed_files)}`);
@@ -246,6 +275,32 @@ if (!clientBuild.content?.[0]?.text?.includes('clients ok')) {
 const exported = await client.request('tools/call', { name: 'export_pro_context', arguments: { workspace_id: ws, selected_paths: ['demo.txt'], max_files: 4, max_total_bytes: 80000 } });
 if (exported.structuredContent.path !== '.ai-bridge/pro-context.md') throw new Error('export_pro_context wrote an unexpected path');
 await fs.stat(path.join(tmp, '.ai-bridge', 'pro-context.md'));
+const exactExport = await client.request('tools/call', {
+  name: 'export_pro_context',
+  arguments: {
+    workspace_id: ws,
+    selected_paths: ['demo.txt'],
+    include_important_files: false,
+    include_changed_files: false,
+    include_diff: false,
+    include_ai_bridge: false,
+    max_files: 4,
+    max_total_bytes: 80000
+  }
+});
+if (!exactExport.structuredContent.files_included?.includes('demo.txt')) {
+  throw new Error(`selected-only export did not include demo.txt: ${JSON.stringify(exactExport.structuredContent.files_included)}`);
+}
+if (exactExport.structuredContent.files_included?.some?.((file) => file !== 'demo.txt')) {
+  throw new Error(`selected-only export included unexpected files: ${JSON.stringify(exactExport.structuredContent.files_included)}`);
+}
+const exactProContext = await fs.readFile(path.join(tmp, '.ai-bridge', 'pro-context.md'), 'utf8');
+if (!exactProContext.includes('Auto-include important root files: no') || !exactProContext.includes('Auto-include changed files: no')) {
+  throw new Error('selected-only export did not record disabled auto-inclusion settings');
+}
+if (exactProContext.includes('### AGENTS.md') || exactProContext.includes('### package.json') || exactProContext.includes('### env-ref.js')) {
+  throw new Error('selected-only export leaked auto-included important or changed files');
+}
 const agentHandoff = await client.request('tools/call', {
   name: 'handoff_to_agent',
   arguments: {
@@ -317,8 +372,8 @@ async function assertToolMode(mode, expected, hidden) {
   modeClient.close();
 }
 
-await assertToolMode('', ['server_config', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
-await assertToolMode('minimal', ['server_config', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
+await assertToolMode('', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
+await assertToolMode('minimal', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
 
 const lowerAgentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-lower-agents-'));
 await fs.writeFile(path.join(lowerAgentsRoot, 'agents.md'), '# Lowercase agents\n\n- Lowercase instruction file loaded.\n', 'utf8');

--- a/src/proContext.ts
+++ b/src/proContext.ts
@@ -14,6 +14,8 @@ export interface ProContextOptions {
   title?: string;
   selectedPaths?: string[];
   extraGlobs?: string[];
+  includeImportantFiles?: boolean;
+  includeChangedFiles?: boolean;
   includeDiff?: boolean;
   includeAiBridge?: boolean;
   maxDepth?: number;
@@ -173,10 +175,13 @@ export async function buildProContext(
 
   const status = gitStatus(config, workspace);
   const changedFiles = parseChangedFiles(status);
-  const importantFiles = await existingImportantFiles(guard, workspace);
+  const includeImportantFiles = options.includeImportantFiles !== false;
+  const includeChangedFiles = options.includeChangedFiles !== false;
+  const importantFiles = includeImportantFiles ? await existingImportantFiles(guard, workspace) : [];
+  const changedFileCandidates = includeChangedFiles ? changedFiles : [];
   const selectedPaths = unique(options.selectedPaths ?? []);
   const extraGlobFiles = await filesForGlobs(guard, workspace, options.extraGlobs ?? [], maxFiles);
-  const candidates = unique([...importantFiles, ...changedFiles, ...selectedPaths, ...extraGlobFiles])
+  const candidates = unique([...importantFiles, ...changedFileCandidates, ...selectedPaths, ...extraGlobFiles])
     .filter((rel) => rel !== `${config.contextDir}/pro-context.md`)
     .sort((a, b) => {
       const aImportant = isLikelyImportantConfig(a) ? 0 : 1;
@@ -232,6 +237,8 @@ export async function buildProContext(
     "Selected Files",
     [
       `Changed files detected: ${changedFiles.length ? changedFiles.join(", ") : "none"}`,
+      `Auto-include important root files: ${includeImportantFiles ? "yes" : "no"}`,
+      `Auto-include changed files: ${includeChangedFiles ? "yes" : "no"}`,
       `Explicit selected paths: ${selectedPaths.length ? selectedPaths.join(", ") : "none"}`,
       `Extra globs: ${(options.extraGlobs ?? []).length ? (options.extraGlobs ?? []).join(", ") : "none"}`,
       `Files included below: ${candidates.length ? candidates.join(", ") : "none"}`

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { searchWorkspace } from "./searchOps.js";
 import { runBash } from "./bashOps.js";
 import { gitDiff, gitLog, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./workspaceOps.js";
-import { exportProContext } from "./proContext.js";
+import { buildProContext, exportProContext } from "./proContext.js";
 import { codexproInventory, loadSkill } from "./capabilitiesOps.js";
 import { TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
@@ -92,7 +92,7 @@ function registerToolCardResource(server: McpServer, config: CodexProConfig): vo
                 resourceDomains: []
               }
             },
-            "openai/widgetDescription": "Renders CodexPro workspace orientation, file diffs, change reviews, Pro context exports, and handoff plans as compact developer cards. Bash stays data-only.",
+            "openai/widgetDescription": "Renders CodexPro workspace orientation, diagnostics, file diffs, change reviews, terminal checks, Pro context exports, and handoff plans as compact developer cards with bounded previews.",
             "openai/widgetPrefersBorder": true,
             "openai/widgetDomain": config.widgetDomain,
             "openai/widgetCSP": {
@@ -168,8 +168,9 @@ function registerToolCompat(
   throw new Error("Unsupported MCP SDK: McpServer has neither registerTool nor tool.");
 }
 
-const MINIMAL_TOOLS = new Set([
+const MINIMAL_TOOL_NAMES = [
   "server_config",
+  "codexpro_self_test",
   "open_current_workspace",
   "open_workspace",
   "read",
@@ -177,17 +178,51 @@ const MINIMAL_TOOLS = new Set([
   "edit",
   "bash",
   "show_changes"
-]);
+] as const;
 
-const STANDARD_TOOLS = new Set([
-  ...MINIMAL_TOOLS,
+const STANDARD_TOOL_NAMES = [
+  ...MINIMAL_TOOL_NAMES,
   "tree",
   "search",
   "load_skill",
   "read_handoff",
   "export_pro_context",
   "handoff_to_agent"
-]);
+] as const;
+
+const FULL_TOOL_NAMES = [
+  "server_config",
+  "codexpro_self_test",
+  "codexpro_inventory",
+  "load_skill",
+  "list_workspaces",
+  "open_current_workspace",
+  "open_workspace",
+  "workspace_snapshot",
+  "tree",
+  "search",
+  "read",
+  "write",
+  "edit",
+  "bash",
+  "git_status",
+  "git_diff",
+  "show_changes",
+  "read_handoff",
+  "codex_context",
+  "export_pro_context",
+  "handoff_to_agent",
+  "handoff_to_codex"
+] as const;
+
+function toolNamesForMode(config: CodexProConfig): string[] {
+  if (config.toolMode === "full") return [...FULL_TOOL_NAMES];
+  if (config.toolMode === "minimal") return [...MINIMAL_TOOL_NAMES];
+  return [...STANDARD_TOOL_NAMES];
+}
+
+const MINIMAL_TOOLS = new Set<string>(MINIMAL_TOOL_NAMES);
+const STANDARD_TOOLS = new Set<string>(STANDARD_TOOL_NAMES);
 
 function shouldRegisterTool(config: CodexProConfig, name: string): boolean {
   if (config.toolMode === "full") return true;
@@ -255,6 +290,11 @@ function normalizeGitOutput(output: string): string {
 function looksLikeGitError(output: string): boolean {
   const trimmed = output.trim();
   return trimmed.startsWith("fatal:") || trimmed.startsWith("error:") || trimmed.startsWith("git unavailable or failed:");
+}
+
+function previewText(value: string, maxLines = 40, maxChars = 12_000): string {
+  const lines = value.replace(/\r\n/g, "\n").split("\n").slice(0, maxLines).join("\n");
+  return lines.length > maxChars ? `${lines.slice(0, maxChars)}\n...[preview truncated]` : lines;
 }
 
 function changedStatusLines(status: string): string[] {
@@ -467,7 +507,7 @@ function getSharedWorkspaceManager(config: CodexProConfig): WorkspaceManager {
 export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = getSharedWorkspaceManager(config);
   const guard = new PathGuard(config);
-  const server = new McpServer({ name: "CodexPro", version: "0.28.4" }, { instructions: serverInstructions(config) });
+  const server = new McpServer({ name: "CodexPro", version: "0.28.5" }, { instructions: serverInstructions(config) });
   registerToolCardResource(server, config);
 
   registerCodexTool(
@@ -480,6 +520,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {},
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Reading CodexPro server config...",
         "openai/toolInvocation/invoked": "CodexPro server config ready"
       }
@@ -510,6 +551,212 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
   registerCodexTool(
     config,
     server,
+    "codexpro_self_test",
+    {
+      title: "CodexPro Self Test",
+      description:
+        "Run one controlled, local-only CodexPro diagnostic. It checks modes, expected tools, workspace access, skills, git, safe bash policy, selected-only Pro context, and optional .ai-bridge write/edit without touching source files.",
+      inputSchema: {
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
+        write_probe: z.boolean().optional().describe("Create/edit only .ai-bridge/codexpro-self-test.md. Default: true."),
+        bash_probe: z.boolean().optional().describe("Check bash policy with safe local commands only. Default: true."),
+        pro_context_probe: z.boolean().optional().describe("Build a selected-only Pro context bundle in memory without writing pro-context.md. Default: true."),
+        include_global_skills: z.boolean().optional().describe("Include user/plugin skill discovery in the inventory check. Default: true."),
+        max_skills: z.number().int().min(1).max(120).optional().describe("Maximum skills to inspect during the inventory check. Default: 40.")
+      },
+      annotations: HANDOFF_WRITE_ANNOTATIONS,
+      _meta: {
+        ...toolCardMeta(),
+        "openai/toolInvocation/invoking": "Running CodexPro self-test...",
+        "openai/toolInvocation/invoked": "CodexPro self-test complete"
+      }
+    },
+    async (args) => {
+      const workspace = workspaces.getWorkspace(args.workspace_id);
+      const started = Date.now();
+      const checks: Array<{ name: string; status: "pass" | "warn" | "fail"; detail: string }> = [];
+      const filesTouched: string[] = [];
+      const probePath = `${config.contextDir}/codexpro-self-test.md`;
+
+      const check = (name: string, status: "pass" | "warn" | "fail", detail: string) => {
+        checks.push({ name, status, detail: cleanOneLine(detail, detail, 260) });
+      };
+
+      check("workspace", "pass", workspace.root);
+      check("tool mode", config.toolMode === "full" ? "pass" : "warn", `${config.toolMode}; expected tools: ${toolNamesForMode(config).length}`);
+      check("write mode", config.writeMode === "off" ? "warn" : "pass", config.writeMode);
+      check("bash mode", config.bashMode === "full" ? "warn" : "pass", config.bashMode);
+      check(
+        "http auth",
+        config.requireHttpToken && !config.authToken ? "fail" : "pass",
+        config.requireHttpToken ? "token required for public/non-loopback access" : "loopback token not required"
+      );
+      check("registered tool set", "pass", `${toolNamesForMode(config).length} tools for ${config.toolMode} mode`);
+
+      try {
+        const inventory = await codexproInventory(config, workspace, {
+          includeGlobalSkills: parseBool(args.include_global_skills, true),
+          includeMcpServers: true,
+          maxSkills: limitInt(args.max_skills, 40, 1, 120)
+        });
+        check("inventory", "pass", `${inventory.skills.length} skills inspected, ${inventory.mcpServers.length} MCP server names visible`);
+      } catch (error) {
+        check("inventory", "fail", errorText(error));
+      }
+
+      try {
+        const status = gitStatus(config, workspace);
+        const gitFailed = looksLikeGitError(status);
+        const changed = gitFailed ? 0 : changedStatusLines(status).length;
+        check("git status", gitFailed ? "warn" : "pass", gitFailed ? status : `${changed} changed entries`);
+      } catch (error) {
+        check("git status", "fail", errorText(error));
+      }
+
+      if (parseBool(args.write_probe, true)) {
+        if (config.writeMode === "off") {
+          check("write/edit probe", "warn", "skipped because CODEXPRO_WRITE_MODE=off");
+        } else {
+          try {
+            assertWriteToolAllowed(config, probePath);
+            const content = [
+              "# CodexPro Self Test",
+              "",
+              `Updated: ${new Date().toISOString()}`,
+              `Workspace: ${workspace.root}`,
+              "marker: before",
+              ""
+            ].join("\n");
+            await writeTextFile(config, guard, workspace, probePath, content, { createDirs: true, overwrite: true });
+            await editTextFile(config, guard, workspace, probePath, "marker: before", "marker: after", { expectedReplacements: 1 });
+            const readBack = await readTextFile(config, guard, workspace, probePath, { maxBytes: 20_000 });
+            if (!readBack.text.includes("marker: after")) throw new CodexProError("self-test edit marker was not found after edit.");
+            const scopedStatus = gitStatus(config, workspace, guard, probePath);
+            const scopedFiles = changedStatusLines(scopedStatus);
+            filesTouched.push(probePath);
+            check(
+              "write/edit probe",
+              scopedFiles.length && scopedFiles.every((line) => line.includes(probePath)) ? "pass" : "warn",
+              scopedFiles.length ? `path-scoped status: ${scopedFiles.join(", ")}` : "path-scoped status clean after write/edit"
+            );
+          } catch (error) {
+            check("write/edit probe", "fail", errorText(error));
+          }
+        }
+      } else {
+        check("write/edit probe", "warn", "skipped by request");
+      }
+
+      if (parseBool(args.pro_context_probe, true)) {
+        try {
+          if (!filesTouched.includes(probePath)) {
+            check("selected-only pro context", "warn", "skipped because write probe did not create the selected file");
+          } else {
+            const context = await buildProContext(config, guard, workspace, {
+              title: "CodexPro Self Test Context",
+              selectedPaths: [probePath],
+              includeImportantFiles: false,
+              includeChangedFiles: false,
+              includeDiff: false,
+              includeAiBridge: false,
+              maxFiles: 4,
+              maxTotalBytes: 80_000
+            });
+            const exactOnly = context.filesIncluded.length === 1 && context.filesIncluded[0] === probePath;
+            check(
+              "selected-only pro context",
+              exactOnly ? "pass" : "fail",
+              exactOnly ? `included only ${probePath}` : `included ${context.filesIncluded.join(", ") || "no files"}`
+            );
+          }
+        } catch (error) {
+          check("selected-only pro context", "fail", errorText(error));
+        }
+      } else {
+        check("selected-only pro context", "warn", "skipped by request");
+      }
+
+      if (parseBool(args.bash_probe, true)) {
+        try {
+          if (config.bashMode === "off") {
+            check("bash policy", "warn", "bash disabled");
+          } else {
+            const pwd = await runBash(config, guard, workspace, "pwd", { timeoutMs: 10_000 });
+            if (config.bashMode === "safe") {
+              try {
+                await runBash(config, guard, workspace, "ls $HOME", { timeoutMs: 10_000 });
+                check("bash policy", "fail", "safe bash allowed environment expansion unexpectedly");
+              } catch {
+                check("bash policy", pwd.exitCode === 0 ? "pass" : "warn", "safe bash allowed pwd and blocked environment expansion");
+              }
+            } else {
+              check("bash policy", pwd.exitCode === 0 ? "warn" : "fail", "full bash is enabled; use only for trusted local repos");
+            }
+          }
+        } catch (error) {
+          check("bash policy", "fail", errorText(error));
+        }
+      } else {
+        check("bash policy", "warn", "skipped by request");
+      }
+
+      check(
+        "terms boundary",
+        "pass",
+        "local workspace bridge only; does not provide models, proxy model access, bypass quotas, or execute remote/local agents from MCP"
+      );
+
+      const failed = checks.filter((item) => item.status === "fail").length;
+      const warned = checks.filter((item) => item.status === "warn").length;
+      const passed = checks.filter((item) => item.status === "pass").length;
+      const status = failed ? "fail" : warned ? "warn" : "pass";
+      const text = [
+        "# CodexPro Self Test",
+        "",
+        `Status: ${status}`,
+        `Workspace: ${workspace.root}`,
+        `Mode: tools=${config.toolMode}, write=${config.writeMode}, bash=${config.bashMode}`,
+        `Expected tools: ${toolNamesForMode(config).length}`,
+        `Duration: ${Date.now() - started} ms`,
+        "",
+        "## Checks",
+        "",
+        ...checks.map((item) => `- ${item.status.toUpperCase()} ${item.name}: ${item.detail}`),
+        "",
+        "## Terms Boundary",
+        "",
+        "CodexPro exposes local repo tools to the ChatGPT session the user controls. It does not provide models, proxy model access, resell access, modify quotas, bypass limits, or run local implementation agents through remote MCP tools."
+      ].join("\n");
+
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        status,
+        passed,
+        warned,
+        failed,
+        duration_ms: Date.now() - started,
+        expected_tools: toolNamesForMode(config),
+        expected_tool_count: toolNamesForMode(config).length,
+        bash_mode: config.bashMode,
+        write_mode: config.writeMode,
+        tool_mode: config.toolMode,
+        files_touched: filesTouched,
+        checks,
+        terms_boundary: {
+          local_workspace_bridge: true,
+          provides_models: false,
+          proxies_model_access: false,
+          bypasses_quotas: false,
+          remote_agent_execution: false
+        }
+      });
+    }
+  );
+
+  registerCodexTool(
+    config,
+    server,
     "codexpro_inventory",
     {
       title: "CodexPro Inventory",
@@ -523,6 +770,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Reading CodexPro inventory...",
         "openai/toolInvocation/invoked": "CodexPro inventory ready"
       }
@@ -539,8 +787,11 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         root: workspace.root,
         bash_mode: config.bashMode,
         write_mode: config.writeMode,
+        tool_mode: config.toolMode,
         skills: inventory.skills,
+        skill_count: inventory.skills.length,
         mcp_servers: inventory.mcpServers,
+        mcp_server_count: inventory.mcpServers.length,
         widget_uri: TOOL_CARD_URI
       });
     }
@@ -564,6 +815,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Loading skill instructions...",
         "openai/toolInvocation/invoked": "Skill instructions loaded"
       }
@@ -601,6 +853,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {},
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Listing CodexPro workspaces...",
         "openai/toolInvocation/invoked": "CodexPro workspaces listed"
       }
@@ -610,7 +863,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const text = current.length
         ? current.map((workspace) => `- ${workspace.id} — ${workspace.root} (opened ${workspace.openedAt})`).join("\n")
         : "No workspaces opened yet. Call open_workspace first.";
-      return textResult(text, { workspaces: current });
+      return textResult(text, { workspaces: current, count: current.length });
     }
   );
 
@@ -674,6 +927,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         path: z.string().optional().describe("Alias for root. Useful for clients that naturally send path instead of root."),
         include_tree: z.boolean().optional().describe("Include a compact file tree. Default: true."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth. Default: 3."),
+        max_files: z.number().int().min(1).max(3000).optional().describe("Alias for maximum tree entries. Default: 500."),
         include_skills: z.boolean().optional().describe("Discover workspace, user, and plugin skills by name/description. Default: true."),
         include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: true."),
         bootstrap_context: z.boolean().optional().describe("Deprecated and ignored. Use handoff_to_agent to create .ai-bridge files.")
@@ -693,6 +947,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const summary = await workspaceSummary(config, guard, workspace, {
         includeTree: args.include_tree !== false,
         maxDepth: limitInt(args.max_depth, 3, 1, 8),
+        maxEntries: limitInt(args.max_files, 500, 1, 3000),
         includeSkills: parseBool(args.include_skills, true),
         includeGlobalSkills: parseBool(args.include_global_skills, true),
         bootstrapContext: false
@@ -724,11 +979,13 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth. Default: 3."),
+        max_files: z.number().int().min(1).max(3000).optional().describe("Alias for maximum tree entries. Default: 500."),
         include_skills: z.boolean().optional().describe("Discover repo-local skills. Default: false for speed."),
         include_global_skills: z.boolean().optional().describe("Also scan home-level skill folders when include_skills=true. Default: false.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Collecting workspace snapshot...",
         "openai/toolInvocation/invoked": "Workspace snapshot ready"
       }
@@ -738,12 +995,27 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const summary = await workspaceSummary(config, guard, workspace, {
         includeTree: true,
         maxDepth: limitInt(args.max_depth, 3, 1, 8),
+        maxEntries: limitInt(args.max_files, 500, 1, 3000),
         includeSkills: parseBool(args.include_skills, false),
         includeGlobalSkills: parseBool(args.include_global_skills, false)
       });
       const ai = await readAiBridgeContext(config, guard, workspace);
       const text = `${summary.text}\n\n## AI handoff context\n\n${ai.text}`;
-      return textResult(text, { workspace_id: workspace.id, root: workspace.root, ai_context_files: ai.files });
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        agents_loaded: summary.agentsLoaded,
+        agents_path: summary.agentsPath,
+        skills: summary.skills,
+        skill_inventory: summary.skillInventory,
+        skill_counts: summary.skillCounts,
+        tree: summary.tree,
+        git_status: summary.gitStatus,
+        ai_context_files: ai.files,
+        bash_mode: config.bashMode,
+        write_mode: config.writeMode,
+        tool_mode: config.toolMode
+      });
     }
   );
 
@@ -763,6 +1035,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Listing workspace files...",
         "openai/toolInvocation/invoked": "Workspace files listed"
       }
@@ -797,6 +1070,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Searching workspace...",
         "openai/toolInvocation/invoked": "Workspace search complete"
       }
@@ -831,6 +1105,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Reading file...",
         "openai/toolInvocation/invoked": "File read"
       }
@@ -952,6 +1227,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: BASH_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Running bash command...",
         "openai/toolInvocation/invoked": "Bash command finished"
       }
@@ -979,6 +1255,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Reading git status...",
         "openai/toolInvocation/invoked": "Git status ready"
       }
@@ -986,7 +1263,16 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
       const status = gitStatus(config, workspace);
-      return textResult(status, { workspace_id: workspace.id, root: workspace.root, status });
+      const statusError = looksLikeGitError(status) ? status : "";
+      const changedFiles = statusError ? [] : changedStatusLines(status);
+      return textResult(status, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        status,
+        status_error: statusError || undefined,
+        changed_files: changedFiles,
+        changed: !statusError && changedFiles.length > 0
+      });
     }
   );
 
@@ -1000,18 +1286,44 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         path: z.string().optional().describe("Optional file path relative to workspace root."),
-        staged: z.boolean().optional().describe("Show staged diff. Default: false.")
+        staged: z.boolean().optional().describe("Show staged diff. Default: false."),
+        include_diff: z.boolean().optional().describe("Include the raw unified diff in the response. Default: true. Set false for stats-only checks.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Reading git diff...",
         "openai/toolInvocation/invoked": "Git diff ready"
       }
     },
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
-      const diff = gitDiff(config, guard, workspace, args.path, parseBool(args.staged, false));
-      return textResult(diff, { workspace_id: workspace.id, root: workspace.root, diff });
+      const rawDiff = normalizeGitOutput(gitDiff(config, guard, workspace, args.path, parseBool(args.staged, false)));
+      const stats = diffStats(rawDiff);
+      const includeDiff = parseBool(args.include_diff, true);
+      const text = includeDiff
+        ? rawDiff
+        : [
+            "# Git Diff",
+            "",
+            `Workspace: ${workspace.root}`,
+            `Path: ${args.path ?? "workspace diff"}`,
+            `Staged: ${parseBool(args.staged, false)}`,
+            `Diff stats: +${stats.additions} -${stats.deletions}`,
+            "",
+            "Raw diff omitted by include_diff=false."
+          ].join("\n");
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        path: args.path ?? "workspace diff",
+        staged: parseBool(args.staged, false),
+        include_diff: includeDiff,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        changed: stats.changed,
+        diff: includeDiff ? rawDiff : ""
+      });
     }
   );
 
@@ -1089,6 +1401,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Reading agent handoff context...",
         "openai/toolInvocation/invoked": "Agent handoff context ready"
       }
@@ -1096,7 +1409,13 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
       const context = await readAiBridgeContext(config, guard, workspace);
-      return textResult(context.text, { workspace_id: workspace.id, root: workspace.root, files: context.files });
+      return textResult(context.text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        files: context.files,
+        file_count: context.files.length,
+        preview: previewText(context.text)
+      });
     }
   );
 
@@ -1118,6 +1437,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
+        ...toolCardMeta(),
         "openai/toolInvocation/invoking": "Loading Codex context...",
         "openai/toolInvocation/invoked": "Codex context ready"
       }
@@ -1138,7 +1458,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         agents_files: context.agentsFiles,
         ai_context_files: context.aiContextFiles,
         included_git_status: context.gitStatus !== undefined,
-        included_git_diff: context.gitDiff !== undefined
+        included_git_diff: context.gitDiff !== undefined,
+        preview: previewText(context.text)
       });
     }
   );
@@ -1156,6 +1477,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         title: z.string().optional().describe("Markdown title for the context bundle."),
         selected_paths: z.array(z.string()).optional().describe("Specific workspace-relative files to include."),
         extra_globs: z.array(z.string()).optional().describe("Additional workspace-relative glob patterns to include, for example src/**/*.ts."),
+        include_important_files: z.boolean().optional().describe("Auto-include important root config/docs such as AGENTS.md, README.md, and package.json. Default: true."),
+        include_changed_files: z.boolean().optional().describe("Auto-include currently changed files from git status. Default: true."),
         include_diff: z.boolean().optional().describe("Include the current git diff. Default: true."),
         include_ai_bridge: z.boolean().optional().describe("Include existing .ai-bridge planning files. Default: true."),
         max_depth: z.number().int().min(1).max(6).optional().describe("Repository tree depth. Default: 3."),
@@ -1176,6 +1499,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         title: args.title,
         selectedPaths: args.selected_paths,
         extraGlobs: args.extra_globs,
+        includeImportantFiles: args.include_important_files,
+        includeChangedFiles: args.include_changed_files,
         includeDiff: args.include_diff,
         includeAiBridge: args.include_ai_bridge,
         maxDepth: args.max_depth,

--- a/src/server.ts
+++ b/src/server.ts
@@ -289,7 +289,15 @@ function normalizeGitOutput(output: string): string {
 
 function looksLikeGitError(output: string): boolean {
   const trimmed = output.trim();
-  return trimmed.startsWith("fatal:") || trimmed.startsWith("error:") || trimmed.startsWith("git unavailable or failed:");
+  const lower = trimmed.toLowerCase();
+  return (
+    trimmed.startsWith("fatal:") ||
+    trimmed.startsWith("error:") ||
+    trimmed.startsWith("git unavailable or failed:") ||
+    trimmed.startsWith("git exited with status") ||
+    trimmed.startsWith("usage: git ") ||
+    lower.includes("not a git repository")
+  );
 }
 
 function previewText(value: string, maxLines = 40, maxChars = 12_000): string {
@@ -1299,9 +1307,12 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
       const rawDiff = normalizeGitOutput(gitDiff(config, guard, workspace, args.path, parseBool(args.staged, false)));
-      const stats = diffStats(rawDiff);
+      const diffError = rawDiff && looksLikeGitError(rawDiff) ? rawDiff : "";
+      const stats = diffError ? { additions: 0, deletions: 0, changed: false } : diffStats(rawDiff);
       const includeDiff = parseBool(args.include_diff, true);
-      const text = includeDiff
+      const text = diffError
+        ? diffError
+        : includeDiff
         ? rawDiff
         : [
             "# Git Diff",
@@ -1319,10 +1330,11 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         path: args.path ?? "workspace diff",
         staged: parseBool(args.staged, false),
         include_diff: includeDiff,
+        diff_error: diffError || undefined,
         additions: stats.additions,
         deletions: stats.deletions,
-        changed: stats.changed,
-        diff: includeDiff ? rawDiff : ""
+        changed: !diffError && stats.changed,
+        diff: diffError || includeDiff ? rawDiff : ""
       });
     }
   );

--- a/src/toolCardWidget.ts
+++ b/src/toolCardWidget.ts
@@ -1,4 +1,4 @@
-export const TOOL_CARD_URI = "ui://widget/codexpro-tool-card-v8.html";
+export const TOOL_CARD_URI = "ui://widget/codexpro-tool-card-v9.html";
 export const TOOL_CARD_MIME_TYPE = "text/html;profile=mcp-app";
 
 export const toolCardWidgetHtml = String.raw`
@@ -447,12 +447,22 @@ export const toolCardWidgetHtml = String.raw`
 
   function titleFor(tool) {
     const titles = {
+      server_config: "Server config",
+      codexpro_self_test: "Self-test",
+      codexpro_inventory: "Inventory",
+      load_skill: "Skill",
+      list_workspaces: "Workspaces",
       open_current_workspace: "Workspace",
       open_workspace: "Workspace",
+      workspace_snapshot: "Workspace snapshot",
+      tree: "File tree",
       write: "File write",
       edit: "Exact edit",
+      git_status: "Git Status",
       git_diff: "Git Diff",
       show_changes: "Change review",
+      read_handoff: "Handoff context",
+      codex_context: "Codex context",
       export_pro_context: "Pro context",
       handoff_to_agent: "Agent handoff",
       handoff_to_codex: "Codex handoff",
@@ -464,11 +474,20 @@ export const toolCardWidgetHtml = String.raw`
   }
 
   function iconFor(tool) {
+    if (tool === "server_config") return "S";
+    if (tool === "codexpro_self_test") return "T";
+    if (tool === "codexpro_inventory") return "I";
+    if (tool === "load_skill") return "L";
+    if (tool === "list_workspaces") return "W";
     if (tool === "open_current_workspace" || tool === "open_workspace") return "W";
+    if (tool === "workspace_snapshot") return "W";
+    if (tool === "tree") return "T";
     if (tool === "write") return "W";
     if (tool === "edit") return "E";
-    if (tool === "git_diff") return "G";
+    if (tool === "git_status" || tool === "git_diff") return "G";
     if (tool === "show_changes") return "D";
+    if (tool === "read_handoff") return "H";
+    if (tool === "codex_context") return "C";
     if (tool === "export_pro_context") return "P";
     if (tool === "handoff_to_agent") return "A";
     if (tool === "handoff_to_codex") return "H";
@@ -488,6 +507,18 @@ export const toolCardWidgetHtml = String.raw`
       if (!count && !data?.changed) return "Workspace is clean";
       return count === 1 ? "1 changed file" : count + " changed files";
     }
+    if (data?.codexpro_tool === "codexpro_self_test") return data?.status ? "Status " + data.status : "Local diagnostic";
+    if (data?.codexpro_tool === "codexpro_inventory") return (data?.skill_count ?? 0) + " skills, " + (data?.mcp_server_count ?? 0) + " MCP servers";
+    if (data?.codexpro_tool === "list_workspaces") return (data?.count ?? 0) + " open workspaces";
+    if (data?.codexpro_tool === "server_config") return "tools " + (data?.toolMode || data?.tool_mode || "-") + ", bash " + (data?.bashMode || data?.bash_mode || "-");
+    if (data?.codexpro_tool === "workspace_snapshot") return data?.root || "Workspace snapshot";
+    if (data?.codexpro_tool === "git_status") {
+      const count = Array.isArray(data?.changed_files) ? data.changed_files.length : 0;
+      return count ? count + " changed entries" : "Working tree clean";
+    }
+    if (data?.codexpro_tool === "codex_context") return (data?.agents_files?.length ?? 0) + " AGENTS, " + (data?.ai_context_files?.length ?? 0) + " bridge files";
+    if (data?.codexpro_tool === "read_handoff") return (data?.file_count ?? 0) + " bridge files";
+    if (data?.codexpro_tool === "load_skill" && data?.skill?.name) return data.skill.name;
     if (data?.codexpro_tool === "handoff_to_agent" && data?.agent_name) return data.agent_name;
     if (data?.path) return data.path;
     if (data?.plan_path) return data.plan_path;
@@ -702,6 +733,130 @@ export const toolCardWidgetHtml = String.raw`
       '<div class="body"><div class="search">' + hits + '</div></div></article>';
   }
 
+  function renderSelfTest(data) {
+    const checks = Array.isArray(data.checks) ? data.checks : [];
+    const status = String(data.status || "unknown");
+    const pills = [
+      pill(status, status === "pass" ? "good" : status === "fail" ? "bad" : "warn"),
+      pill((data.expected_tool_count ?? "-") + " tools", "info"),
+      pill((data.duration_ms ?? "-") + " ms")
+    ].join("");
+    const rows = checks.slice(0, 16).map((check) => {
+      const state = String(check?.status || "?").toUpperCase();
+      const cls = check?.status === "pass" ? "good" : check?.status === "fail" ? "bad" : "warn";
+      return '<div class="file-row"><span class="file-code ' + esc(cls) + '">' + esc(state) + '</span><span class="file-name">' + esc((check?.name || "check") + ": " + (check?.detail || "")) + '</span></div>';
+    }).join("");
+    const terms = data.terms_boundary
+      ? '<div class="file-list">' +
+          '<div class="file-row"><span class="file-code">tos</span><span class="file-name">local repo bridge only; no model access, quota, resale, or bypass behavior</span></div>' +
+        '</div>'
+      : "";
+    return '<article class="card">' + header(data, pills) + '<div class="body">' +
+      '<div class="summary">' +
+      summaryItem("Passed", data.passed ?? 0) +
+      summaryItem("Warned", data.warned ?? 0) +
+      summaryItem("Failed", data.failed ?? 0) +
+      '</div>' +
+      '<div class="file-list">' + (rows || '<div class="empty">No checks returned.</div>') + '</div>' +
+      fold("Terms boundary", "", terms, false) +
+      fold("Expected tools", Array.isArray(data.expected_tools) ? data.expected_tools.length + " tools" : "", codebox("tools", esc((data.expected_tools || []).join("\\n")), ""), false) +
+      '</div></article>';
+  }
+
+  function renderInventory(data) {
+    const skills = Array.isArray(data.skills) ? data.skills : [];
+    const servers = Array.isArray(data.mcp_servers) ? data.mcp_servers : [];
+    const skillRows = skills.slice(0, 18).map((skill) =>
+      '<div class="file-row"><span class="file-code">' + esc(shortSource(skill?.source)) + '</span><span class="file-name">' + esc((skill?.name || "skill") + (skill?.description ? " — " + skill.description : "")) + '</span></div>'
+    ).join("");
+    const serverRows = servers.slice(0, 18).map((server) =>
+      '<div class="file-row"><span class="file-code">mcp</span><span class="file-name">' + esc((server?.name || "server") + (server?.source ? " — " + server.source : "")) + '</span></div>'
+    ).join("");
+    return '<article class="card">' + header(data, pill((data.skill_count ?? skills.length) + " skills", "info") + pill((data.mcp_server_count ?? servers.length) + " MCP")) +
+      '<div class="body">' +
+      '<div class="summary">' +
+      summaryItem("Write", data.write_mode || "-") +
+      summaryItem("Bash", data.bash_mode || "-") +
+      summaryItem("Tools", data.tool_mode || "-") +
+      '</div>' +
+      fold("Skills", (data.skill_count ?? skills.length) + " found", '<div class="file-list">' + (skillRows || '<div class="empty">No skills discovered.</div>') + '</div>', false) +
+      fold("MCP servers", (data.mcp_server_count ?? servers.length) + " found", '<div class="file-list">' + (serverRows || '<div class="empty">No MCP server names discovered.</div>') + '</div>', false) +
+      '</div></article>';
+  }
+
+  function renderWorkspaces(data) {
+    const spaces = Array.isArray(data.workspaces) ? data.workspaces : [];
+    const rows = spaces.map((workspace) =>
+      '<div class="file-row"><span class="file-code">ws</span><span class="file-name">' + esc((workspace?.id || "workspace") + " — " + (workspace?.root || "")) + '</span></div>'
+    ).join("");
+    return '<article class="card">' + header(data, pill((data.count ?? spaces.length) + " open", "info")) +
+      '<div class="body"><div class="file-list">' + (rows || '<div class="empty">No workspaces opened yet.</div>') + '</div></div></article>';
+  }
+
+  function renderServerConfig(data) {
+    const blocked = Array.isArray(data.blockedGlobs) ? data.blockedGlobs : [];
+    const allowed = Array.isArray(data.allowedRoots) ? data.allowedRoots : [];
+    const rootRows = [
+      '<div class="file-row"><span class="file-code">root</span><span class="file-name">' + esc(data.defaultRoot || "-") + '</span></div>',
+      '<div class="file-row"><span class="file-code">url</span><span class="file-name">' + esc((data.host || "127.0.0.1") + ":" + (data.port || "-")) + '</span></div>',
+      '<div class="file-row"><span class="file-code">ui</span><span class="file-name">' + esc(data.widgetDomain || "-") + '</span></div>'
+    ].join("");
+    const allowedRows = allowed.map((root) =>
+      '<div class="file-row"><span class="file-code">allow</span><span class="file-name">' + esc(root) + '</span></div>'
+    ).join("");
+    const blockedRows = blocked.slice(0, 24).map((pattern) =>
+      '<div class="file-row"><span class="file-code">block</span><span class="file-name">' + esc(pattern) + '</span></div>'
+    ).join("");
+    const limits = [
+      summaryItem("Read", data.maxReadBytes ?? "-"),
+      summaryItem("Write", data.maxWriteBytes ?? "-"),
+      summaryItem("Output", data.maxOutputBytes ?? "-")
+    ].join("");
+    return '<article class="card">' + header(data, [
+      pill("tools " + (data.toolMode || "-"), "info"),
+      pill("bash " + (data.bashMode || "-")),
+      pill(data.authEnabled ? "auth on" : "auth off", data.authEnabled ? "good" : "warn")
+    ].join("")) + '<div class="body">' +
+      '<div class="summary">' +
+      summaryItem("Write", data.writeMode || "-") +
+      summaryItem("Bash", data.bashMode || "-") +
+      summaryItem("Tools", data.toolMode || "-") +
+      '</div>' +
+      '<div class="section-label">Runtime</div><div class="file-list">' + rootRows + '</div>' +
+      fold("Allowed roots", allowed.length + " roots", '<div class="file-list">' + (allowedRows || '<div class="empty">No roots configured.</div>') + '</div>', false) +
+      fold("Limits", "", '<div class="summary">' + limits + '</div>', false) +
+      fold("Blocked paths", blocked.length + " patterns", '<div class="file-list">' + (blockedRows || '<div class="empty">No blocked globs configured.</div>') + '</div>', false) +
+      fold("Raw config", "", codebox("config", esc(truncate(JSON.stringify(data || {}, null, 2), 8000)), ""), false) +
+      '</div></article>';
+  }
+
+  function renderStatus(data) {
+    const files = Array.isArray(data.changed_files) ? data.changed_files : [];
+    const rows = files.slice(0, 14).map((line) => {
+      const status = String(line).slice(0, 2).trim() || "?";
+      const name = String(line).slice(2).trim() || String(line);
+      return '<div class="file-row"><span class="file-code">' + esc(status) + '</span><span class="file-name">' + esc(name) + '</span></div>';
+    }).join("");
+    const state = data.status_error ? '<div class="empty">' + esc(data.status_error) + '</div>' : rows || '<div class="empty">Working tree clean.</div>';
+    return '<article class="card">' + header(data, pill(files.length ? files.length + " changed" : "clean", files.length ? "info" : "good")) +
+      '<div class="body"><div class="file-list">' + state + '</div>' +
+      fold("Raw status", countLines(data.status) + " lines", codebox("git status", esc(previewLines(data.status, 40)), ""), false) +
+      '</div></article>';
+  }
+
+  function renderTextSummary(data, label) {
+    const files = Array.isArray(data.files) ? data.files : Array.isArray(data.ai_context_files) ? data.ai_context_files : [];
+    const preview = data.preview || data.text || data.status || "";
+    const rows = files.slice(0, 14).map((file) =>
+      '<div class="file-row"><span class="file-code">file</span><span class="file-name">' + esc(file) + '</span></div>'
+    ).join("");
+    return '<article class="card">' + header(data, pill(files.length + " files", "info")) +
+      '<div class="body">' +
+      (rows ? '<div class="file-list">' + rows + '</div>' : '<div class="empty">No files listed.</div>') +
+      fold(label || "Preview", countLines(preview) + " lines", codebox(label || "preview", esc(previewLines(preview, 40)), ""), false) +
+      '</div></article>';
+  }
+
   function renderGeneric(data) {
     const keys = Object.keys(data || {}).filter((key) => !key.startsWith("codexpro_"));
     const metrics = keys.slice(0, 3).map((key) => metric(key, typeof data[key] === "object" ? JSON.stringify(data[key]) : data[key])).join("");
@@ -737,8 +892,18 @@ export const toolCardWidgetHtml = String.raw`
       return;
     }
     const tool = data.codexpro_tool;
-    if (tool === "open_current_workspace" || tool === "open_workspace") {
+    if (tool === "server_config") {
+      root.innerHTML = renderServerConfig(data);
+    } else if (tool === "codexpro_self_test") {
+      root.innerHTML = renderSelfTest(data);
+    } else if (tool === "codexpro_inventory") {
+      root.innerHTML = renderInventory(data);
+    } else if (tool === "list_workspaces") {
+      root.innerHTML = renderWorkspaces(data);
+    } else if (tool === "open_current_workspace" || tool === "open_workspace" || tool === "workspace_snapshot") {
       root.innerHTML = renderWorkspace(data);
+    } else if (tool === "git_status") {
+      root.innerHTML = renderStatus(data);
     } else if (tool === "show_changes") {
       root.innerHTML = renderChanges(data);
     } else if (tool === "handoff_to_agent" || tool === "handoff_to_codex") {
@@ -749,6 +914,10 @@ export const toolCardWidgetHtml = String.raw`
       root.innerHTML = renderBash(data);
     } else if (tool === "search") {
       root.innerHTML = renderSearch(data);
+    } else if (tool === "read_handoff") {
+      root.innerHTML = renderTextSummary(data, "handoff");
+    } else if (tool === "codex_context") {
+      root.innerHTML = renderTextSummary(data, "context");
     } else {
       root.innerHTML = renderGeneric(data);
     }

--- a/src/workspaceOps.ts
+++ b/src/workspaceOps.ts
@@ -149,7 +149,7 @@ export async function workspaceSummary(
   config: CodexProConfig,
   guard: PathGuard,
   workspace: Workspace,
-  options: { includeTree?: boolean; maxDepth?: number; bootstrapContext?: boolean; includeSkills?: boolean; includeGlobalSkills?: boolean } = {}
+  options: { includeTree?: boolean; maxDepth?: number; maxEntries?: number; bootstrapContext?: boolean; includeSkills?: boolean; includeGlobalSkills?: boolean } = {}
 ): Promise<WorkspaceSummary> {
   if (options.bootstrapContext) {
     await ensureAiBridge(config, guard, workspace);
@@ -171,7 +171,7 @@ export async function workspaceSummary(
       path: ".",
       maxDepth: Math.max(1, Math.min(options.maxDepth ?? 3, 8)),
       includeHidden: false,
-      maxEntries: 500
+      maxEntries: Math.max(1, Math.min(options.maxEntries ?? 500, 3000))
     });
     treeText = tree.text;
   }


### PR DESCRIPTION

## What changed

- Adds `codexpro_self_test` so ChatGPT can verify the live CodexPro server, tool mode, write mode, safe bash policy, selected-only Pro context, and `.ai-bridge` write/edit behavior in one local-only call.
- Upgrades the ChatGPT widget to `ui://widget/codexpro-tool-card-v9.html` and attaches compact card metadata to every CodexPro tool.
- Adds dedicated compact cards for server config, self-test, inventory, workspace snapshots, git status, handoff/context reads, and bounded terminal/diff previews.
- Adds exact selected-only context export controls with `include_important_files` and `include_changed_files`.
- Accepts model-friendly aliases found in live testing: `workspace_snapshot.max_files` and `git_diff.include_diff=false`.
- Updates README, Chinese README, docs site, and changelog for v9 cards, self-test flow, exact Pro context exports, and the local-only/TOS-safe boundary.

## Why

The live ChatGPT run proved the connector works, but it also showed two user-experience gaps: some tools still dumped too much raw data, and natural model arguments caused avoidable retry loops. This PR makes the first-run diagnostic path explicit and keeps tool output compact by default.

## Validation

- `npm run build`
- `npm run smoke`
- `npm audit --omit=dev`
- `npm pack --dry-run`
- Live local MCP check against `/Users/rebel/Desktop/ads`: 22 tools exposed, `codexpro_self_test` passed, `workspace_snapshot(max_files)` worked, and `git_diff(include_diff=false)` returned stats without raw diff bytes.

## Notes

- Public npm is still `0.28.4`; this branch prepares local `0.28.5` for release.
- Remote MCP tools still do not execute Codex/OpenCode/Pi/local agents. Agent execution remains a user-started local CLI/watch workflow.
