### PR TITLE
Fix bash session guard review issues

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -474,6 +474,15 @@ function validateBashSession(value) {
   return trimmed;
 }
 
+function bashSessionOptions(args, profile = {}) {
+  const bashSession = validateBashSession(optionValue(args, profile, 'bashSession', ['CODEXPRO_BASH_SESSION_ID'], ''));
+  const requireBashSession = optionBool(args, profile, 'requireBashSession', ['CODEXPRO_REQUIRE_BASH_SESSION'], false);
+  if (requireBashSession && !bashSession) {
+    throw new Error('--require-bash-session requires --bash-session <id>.');
+  }
+  return { bashSession, requireBashSession };
+}
+
 function stableToken(existing = '') {
   return existing || randomBytes(24).toString('hex');
 }
@@ -1778,8 +1787,7 @@ function profileFromPreference(root, args, profile, preference) {
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], 'agent');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], '');
-  const bashSession = validateBashSession(optionValue(args, profile, 'bashSession', ['CODEXPRO_BASH_SESSION_ID'], ''));
-  const requireBashSession = optionBool(args, profile, 'requireBashSession', ['CODEXPRO_REQUIRE_BASH_SESSION'], false);
+  const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
@@ -1921,8 +1929,7 @@ async function runSetupWizard(argv) {
     const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
     const widgetDomain = optionValue(defaults, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
     if (bash) args.push('--bash', bash);
-    const bashSession = validateBashSession(optionValue(defaults, profile, 'bashSession', ['CODEXPRO_BASH_SESSION_ID'], ''));
-    const requireBashSession = optionBool(defaults, profile, 'requireBashSession', ['CODEXPRO_REQUIRE_BASH_SESSION'], false);
+    const { bashSession, requireBashSession } = bashSessionOptions(defaults, profile);
     if (bashSession) args.push('--bash-session', bashSession);
     if (requireBashSession) args.push('--require-bash-session');
     if (write) args.push('--write', write);
@@ -1999,6 +2006,8 @@ async function runSetupWizard(argv) {
         ...(profileCloudflareTokenFile ? { cloudflareTokenFile: profileCloudflareTokenFile } : {}),
         ...(profileToken ? { token: profileToken } : {}),
         ...(bash ? { bash } : {}),
+        ...(bashSession ? { bashSession } : {}),
+        ...(requireBashSession ? { requireBashSession: true } : {}),
         ...(write ? { write } : {}),
         ...(toolMode ? { toolMode } : {}),
         ...(widgetDomain ? { widgetDomain } : {}),
@@ -2069,8 +2078,7 @@ function saveSettingsFromArgs(root, args, profile) {
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? '');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], profile.widgetDomain ?? '');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
-  const bashSession = validateBashSession(optionValue(args, profile, 'bashSession', ['CODEXPRO_BASH_SESSION_ID'], profile.bashSession ?? ''));
-  const requireBashSession = optionBool(args, profile, 'requireBashSession', ['CODEXPRO_REQUIRE_BASH_SESSION'], Boolean(profile.requireBashSession));
+  const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const token = tunnel === 'none'
     ? optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], profile.token ?? '')
     : stableToken(optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], profile.token ?? ''));
@@ -2407,13 +2415,11 @@ async function main() {
   const host = optionValue(args, profile, 'host', ['CODEXPRO_HOST'], '127.0.0.1');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
-  const bashSession = validateBashSession(optionValue(args, profile, 'bashSession', ['CODEXPRO_BASH_SESSION_ID'], ''));
-  const requireBashSession = optionBool(args, profile, 'requireBashSession', ['CODEXPRO_REQUIRE_BASH_SESSION'], false);
+  const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], 'https://rebel0789.github.io');
   if (!['off', 'safe', 'full'].includes(bash)) throw new Error('--bash must be off, safe, or full');
-  if (requireBashSession && !bashSession) throw new Error('--require-bash-session requires --bash-session <id>.');
   if (!['off', 'handoff', 'workspace'].includes(write)) throw new Error('--write must be off, handoff, or workspace');
   if (!['minimal', 'standard', 'full'].includes(toolMode)) throw new Error('--tool-mode must be minimal, standard, or full');
 

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -16,6 +16,22 @@ function run(args, env) {
   return `${result.stdout}\n${result.stderr}`;
 }
 
+function runFail(args, env, pattern) {
+  const result = spawnSync(process.execPath, ['scripts/codexpro.mjs', ...args], {
+    cwd: path.resolve('.'),
+    env,
+    encoding: 'utf8'
+  });
+  if (result.status === 0) {
+    throw new Error(`codexpro ${args.join(' ')} unexpectedly succeeded\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  const output = `${result.stdout}\n${result.stderr}`;
+  if (pattern && !pattern.test(output)) {
+    throw new Error(`codexpro ${args.join(' ')} failed for the wrong reason\n${output}`);
+  }
+  return output;
+}
+
 async function readProfile(root, home) {
   const realRoot = await fs.realpath(root);
   const id = createHash('sha256').update(realRoot).digest('hex').slice(0, 24);
@@ -68,6 +84,39 @@ if (shown.includes('codexpro-settings-token')) {
 const profile = await readProfile(root, home);
 if (profile.toolMode !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
   throw new Error(`settings profile did not persist tool/widget options: ${JSON.stringify(profile)}`);
+}
+
+runFail([
+  'settings',
+  'set',
+  '--root',
+  root,
+  '--tunnel',
+  'ngrok',
+  '--hostname',
+  'codexpro-test.ngrok-free.app',
+  '--require-bash-session'
+], env, /requires --bash-session/i);
+
+const guarded = run([
+  'settings',
+  'set',
+  '--root',
+  root,
+  '--tunnel',
+  'ngrok',
+  '--hostname',
+  'codexpro-test.ngrok-free.app',
+  '--bash-session',
+  'guarded-main',
+  '--require-bash-session'
+], env);
+if (!guarded.includes('Bash session') || !guarded.includes('guarded-main required')) {
+  throw new Error(`settings save did not display guarded bash session\n${guarded}`);
+}
+const guardedProfile = await readProfile(root, home);
+if (guardedProfile.bashSession !== 'guarded-main' || guardedProfile.requireBashSession !== true) {
+  throw new Error(`settings profile did not persist bash session guard: ${JSON.stringify(guardedProfile)}`);
 }
 
 const listed = run(['settings', 'list'], env);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -412,6 +412,13 @@ const guardedBash = await sessionGuardClient.request('tools/call', { name: 'bash
 if (guardedBash.structuredContent.bash_session_id !== 'codex-main' || !guardedBash.content?.[0]?.text?.includes('Exit: 0')) {
   throw new Error(`bash session guard did not allow matching session id: ${JSON.stringify(guardedBash.structuredContent)}`);
 }
+const guardedSelfTest = await sessionGuardClient.request('tools/call', {
+  name: 'codexpro_self_test',
+  arguments: { write_probe: false, pro_context_probe: false }
+});
+if (guardedSelfTest.structuredContent.status === 'fail') {
+  throw new Error(`codexpro_self_test failed under bash session guard: ${JSON.stringify(guardedSelfTest.structuredContent.checks)}`);
+}
 sessionGuardClient.close();
 
 const nonGitRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-non-git-'));

--- a/src/server.ts
+++ b/src/server.ts
@@ -696,10 +696,11 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
           if (config.bashMode === "off") {
             check("bash policy", "warn", "bash disabled");
           } else {
-            const pwd = await runBash(config, guard, workspace, "pwd", { timeoutMs: 10_000 });
+            const bashProbeOptions = { timeoutMs: 10_000, sessionId: config.bashSessionId };
+            const pwd = await runBash(config, guard, workspace, "pwd", bashProbeOptions);
             if (config.bashMode === "safe") {
               try {
-                await runBash(config, guard, workspace, "ls $HOME", { timeoutMs: 10_000 });
+                await runBash(config, guard, workspace, "ls $HOME", bashProbeOptions);
                 check("bash policy", "fail", "safe bash allowed environment expansion unexpectedly");
               } catch {
                 check("bash policy", pwd.exitCode === 0 ? "pass" : "warn", "safe bash allowed pwd and blocked environment expansion");


### PR DESCRIPTION
## Summary
- reject `--require-bash-session` unless a `--bash-session <id>` is also configured
- persist bash session guard settings from setup/settings profiles
- let `codexpro_self_test` internal bash probes use the configured session id

## Review comments addressed
- PR #15 P2: reject required guards without a session id
- PR #15 P2: persist bash session values from setup
- PR #15 P2: let self-test bash probes satisfy the session guard

## Verification
- `npm run smoke`
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`