### PR TITLE
[codex] Improve local admin profile controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist/
 .env.*
 *.tgz
 .ai-bridge/
+.hallmark/
+.playwright-cli/
+output/
 CODEXPRO_MCP_REPORT.md
 *.local.md
 *.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Reconfirmed the compliance boundary in runtime diagnostics and docs: CodexPro is a local workspace MCP bridge, not a model provider, model proxy, quota bypass, resale layer, or remote executor.
 - Added `codexpro start --no-bash` and documented that CodexPro does not bind MCP bash to a Codex app conversation id.
 - Added an optional bash session guard with `--bash-session <id> --require-bash-session`; guarded `bash` calls must include the matching `session_id` before any shell command runs.
+- Made bash chat transcripts compact by default, with `--bash-transcript full` for the old raw stdout/stderr chat output.
+- Added opt-in local Codex session discovery with `--codex-sessions metadata|read`, including session ids, titles, cwd paths, source files, resume commands, and bounded transcript reads only in explicit `read` mode.
+- Added a token-protected local profile editor at `/admin/profile` and the setup page so users can save tunnel, hostname, port, mode, bash, Codex session, write/tool mode, widget origin, and tunnel config defaults for the next `codexpro start` without exposing raw tokens in the browser.
 
 ## 0.28.4
 
@@ -103,8 +106,8 @@
 ## 0.22.0
 
 - Added the v5 Apps SDK widget resource at `ui://widget/codexpro-tool-card-v5.html` with cleaner pending states and more polished diff/search/code cards.
-- Added a token-protected local setup/status page at `/` and `/setup` for workspace, mode, allowed-root, and ChatGPT setup visibility.
-- Added the terminal `o` control to open the local setup/status page while CodexPro is running.
+- Added a token-protected local admin dashboard at `/` and `/setup` for workspace, mode, allowed-root, setup, profile, and ChatGPT connection visibility.
+- Added the terminal `o` control to open the local admin dashboard while CodexPro is running.
 - Updated HTTP smoke coverage to verify the onboarding page and v5 widget resource.
 
 ## 0.21.0

--- a/FAQ.md
+++ b/FAQ.md
@@ -126,6 +126,14 @@ codexpro start --bash-session main --require-bash-session
 
 Then `bash` calls must include `session_id: "main"`. This helps avoid accidental shell execution in the wrong CodexPro terminal, but it is not remote control of an existing Codex app chat.
 
+CodexPro can list local Codex session ids and titles when you explicitly opt in:
+
+```bash
+codexpro start --tool-mode full --codex-sessions metadata
+```
+
+This reads local Codex JSONL history under `~/.codex/sessions` and `~/.codex/archived_sessions` and returns metadata plus `codex resume <session-id>` commands. Use `--codex-sessions read` only if you also want bounded transcript reads. It does not attach to a live Codex app conversation.
+
 If you do not want ChatGPT to trigger shell commands while you work in Codex, start CodexPro with bash disabled:
 
 ```bash

--- a/FAQ_ZH.md
+++ b/FAQ_ZH.md
@@ -132,6 +132,14 @@ codexpro start --bash-session main --require-bash-session
 
 之后 `bash` 调用必须包含 `session_id: "main"`。这能避免误触发到错误的 CodexPro 终端，但不是远程控制某个已有的 Codex App 聊天。
 
+如果你显式开启，CodexPro 可以列出本地 Codex session id 和标题：
+
+```bash
+codexpro start --tool-mode full --codex-sessions metadata
+```
+
+它会读取 `~/.codex/sessions` 和 `~/.codex/archived_sessions` 下的本地 Codex JSONL 历史，返回 metadata 和 `codex resume <session-id>` 命令。只有需要有限长度 transcript 读取时才使用 `--codex-sessions read`。它不会附加到正在运行的 Codex App 聊天。
+
 如果你正在 Codex 里工作，不希望 ChatGPT 触发 shell 命令，可以关闭 bash：
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,49 +33,78 @@
   <a href="SECURITY.md">Security</a>
 </p>
 
-CodexPro turns ChatGPT Developer Mode into a local coding agent for the folder on your machine. Install it globally, run setup in a repo, paste the copied Server URL into ChatGPT Create App, and ChatGPT can inspect files, edit code, run safe verification commands, and load the same explicit context you normally give Codex through `AGENTS.md`, `.ai-bridge`, git status, git diff, and source files.
+## Installation
 
-CodexPro is not a rate-limit bypass. It uses ChatGPT's official Developer Mode and MCP app path to connect your own ChatGPT session to your own local repo. ChatGPT and Codex remain separate product surfaces, each subject to its own plan limits, safety rules, and availability.
+CodexPro requires Node.js 20+ and a ChatGPT Plus or Pro account with Apps / Developer Mode access.
 
-If one workflow is unavailable and another product surface you already have access to is still available, CodexPro lets you keep working against the same local repo without modifying or evading either product's limits.
+Install the CLI:
 
 ```bash
 npm install -g codexpro
+```
+
+Then run setup inside the repo you want ChatGPT to work on:
+
+```bash
+cd /path/to/your/repo
 codexpro setup
 ```
 
-## Why
+CodexPro copies the ChatGPT Server URL for you. In ChatGPT, open `Settings -> Apps -> Advanced settings -> Create app`, paste that URL, and choose `Authentication: No Authentication / None`.
 
-```text
-ChatGPT web can see Codex-style context:
-  AGENTS.md
-  .ai-bridge plans and status
-  git status and diff
-  selected source files
+After setup, daily use from the same repo is just:
 
-ChatGPT web can act on your repo:
-  read files
-  write files
-  exact-edit files
-  search code
-  run safe verification commands
-
-Codex stays useful:
-  execute plans locally
-  handle deeper terminal-heavy work
-  review or continue a handoff
+```bash
+codexpro start
 ```
 
-What it gives you:
+CodexPro turns ChatGPT Developer Mode into a local coding agent for that folder. It gives ChatGPT bounded MCP tools for file reads, code search, exact edits, git inspection, safe verification commands, and explicit Codex-style context from `AGENTS.md`, `.ai-bridge`, git state, and selected source files.
 
-```text
-Normal coding mode  ChatGPT reads, writes, edits, searches, and verifies directly.
-Handoff mode        ChatGPT writes .ai-bridge/current-plan.md for a local implementation agent.
-Pro planning mode   Export a durable context bundle for sessions that cannot call MCP tools.
-Stable URLs         Use an ngrok free dev domain or Cloudflare named tunnel so the ChatGPT app URL stays fixed.
-```
+CodexPro is not a rate-limit bypass. It uses ChatGPT's official Developer Mode and MCP app path to connect your own ChatGPT session to your own local repo. ChatGPT and Codex remain separate product surfaces, each subject to its own plan limits, safety rules, and availability.
+
+## Quick Choices
+
+| Need | Use |
+| --- | --- |
+| Fast first setup | `npm install -g codexpro`, then `codexpro setup` |
+| Daily start | `codexpro start` from the same repo |
+| Stable ChatGPT URL | ngrok free dev domain or Cloudflare named tunnel |
+| Smallest tool surface | default `CODEXPRO_TOOL_MODE=standard` |
+| Full diagnostics | `codexpro start --tool-mode full` |
+| No ChatGPT-triggered shell | `codexpro start --no-bash` |
+| Compact chat transcript | default bash cards; use `--bash-transcript full` only when needed |
+| Local Codex history lookup | opt in with `--codex-sessions metadata` or `read` |
+
+## Why CodexPro?
+
+| ChatGPT gets | CodexPro provides |
+| --- | --- |
+| Repo context | `AGENTS.md`, `.ai-bridge`, git status, git diff, selected source files |
+| Coding actions | `read`, `write`, `edit`, `search`, `show_changes` |
+| Verification | safe `bash` for focused test, lint, build, and git commands |
+| Handoff | `.ai-bridge/current-plan.md` for Codex, OpenCode, Pi, or a custom local agent |
+| Fallback planning | `.ai-bridge/pro-context.md` for model surfaces that cannot call MCP tools |
+
+If one workflow is unavailable and another product surface you already have access to is still available, CodexPro lets you keep working against the same local repo without modifying or evading either product's limits.
 
 If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some ChatGPT model surfaces may not be able to call connectors or MCP tools directly. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
+
+## Preview
+
+![CodexPro preview](docs/og.svg)
+
+The website and ChatGPT cards are designed to keep repo inventory, git details, terminal output, and raw diffs folded until you ask for them. The normal path is a compact card plus a clear diff or verification result, not a chat full of raw tool data.
+
+## Feature Map
+
+| Area | Details |
+| --- | --- |
+| Workspace open | `open_current_workspace`, `open_workspace`, `tree`, `search`, `read` |
+| Editing | workspace-scoped `write` and exact-replacement `edit`, both returning diffs |
+| Review | `show_changes`, `git_status`, `git_diff`, compact visual cards |
+| Safety | workspace-only writes, safe bash by default, blocked secret/build/cache paths, token-protected public URLs |
+| Context | `codex_context`, `read_handoff`, selected-only `export_pro_context` |
+| Local execution | `execute-handoff` and `watch-handoff` run from your terminal, not as remote MCP tools |
 
 CodexPro is not an OS sandbox. It is a local developer bridge with safety defaults. Read [SECURITY.md](SECURITY.md) before exposing it through a tunnel.
 
@@ -238,25 +267,7 @@ _meta["openai/widgetCSP"]
 
 After upgrading or changing widget metadata, open the CodexPro app settings in ChatGPT Developer Mode and click `Refresh` / `Refresh actions` so ChatGPT reloads the tool descriptors and resource URI.
 
-## Install
-
-Recommended install:
-
-```bash
-npm install -g codexpro
-```
-
-First run from the repo you want ChatGPT to work on:
-
-```bash
-codexpro setup
-```
-
-Daily start after setup:
-
-```bash
-codexpro start
-```
+## Other Install Paths
 
 No-install fallback:
 
@@ -295,7 +306,7 @@ That is the intended low-friction first-run path. It:
 - starts in normal coding mode with workspace edits enabled
 - shows a compact terminal control panel
 - lets you press Enter to open ChatGPT in your browser
-- lets you press `o` to open a local setup/status page
+- lets you press `o` to open the local admin dashboard
 ```
 
 After setup, daily use from the same repo is:
@@ -400,13 +411,23 @@ codexpro doctor
 
 Use `--no-copy-url` if you do not want CodexPro to copy the connector URL. Add `--open-chatgpt` if you want the browser to open automatically instead of pressing Enter.
 
-Local setup/status page:
+Local admin dashboard:
 
 ```text
 press o in the CodexPro terminal control panel
 ```
 
-The page shows the active workspace, local MCP endpoint, safety modes, allowed roots, and the exact ChatGPT setup steps. It is served by the local CodexPro process and stays token-protected when auth is enabled.
+The page is a token-protected admin surface for setup and settings. It shows the current workspace, local MCP endpoint, safety modes, install/start commands, ChatGPT connection steps, saved profile settings, and allowed roots.
+
+It includes GitHub, npm, and docs links, plus copy buttons for global install, guided setup, daily start, source-checkout setup, and advanced restart commands. The saved profile editor controls next-run defaults:
+
+- tunnel provider and public hostname
+- local port and agent/handoff/pro mode
+- bash mode, compact/full transcript, and optional required bash session
+- Codex session metadata/read mode
+- write mode, tool mode, widget origin, and tunnel config paths
+
+Profile edits apply after the next `codexpro start`. The browser admin page exposes setup/settings/status plus the MCP endpoint; it does not accept raw Cloudflare tunnel tokens, switch ChatGPT accounts, or run CodexPro as a background service. For Cloudflare dashboard-managed tunnels, save the tunnel token in a local file and set `Cloudflare token file`.
 
 Saved workspace profile behavior:
 
@@ -428,7 +449,7 @@ If setup finds a saved ngrok or Cloudflare stable profile, CodexPro prints the s
 codexpro start
 ```
 
-That is enough from the same workspace folder. Use `codexpro setup` again only when you want to change the port, mode, tunnel provider, hostname, or CodexPro auth token.
+That is enough from the same workspace folder. Press `o` in the running CodexPro terminal to update most saved profile defaults from the local page, or use `codexpro setup` when you want the guided terminal flow or a fresh CodexPro auth token.
 
 Useful profile flags:
 
@@ -457,7 +478,7 @@ Terminal controls:
 ```text
 Enter  open ChatGPT connector settings in your browser
 c      copy Server URL again
-o      open local setup/status page
+o      open local admin dashboard
 h      show controls
 q      stop CodexPro
 ```
@@ -469,7 +490,9 @@ Startup modes:
 ```bash
 codexpro start                 # normal coding mode: read/write/edit/search/bash
 codexpro start --no-bash       # normal coding mode without ChatGPT-triggered shell commands
+codexpro start --bash-transcript full  # print raw stdout/stderr in chat instead of compact cards
 codexpro start --bash-session main --require-bash-session
+codexpro start --tool-mode full --codex-sessions metadata
 codexpro setup                 # guided onboarding for new users
 codexpro start --mode handoff  # planning-only .ai-bridge handoff
 codexpro start --mode handoff --no-bash
@@ -1058,6 +1081,23 @@ codexpro start --bash-session main --require-bash-session
 ```
 
 With that guard enabled, the `bash` MCP tool rejects commands unless the call includes `session_id: "main"`. The session label is a local UX guard, not a secret and not a Codex app conversation id.
+
+By default, bash results use a compact transcript so ChatGPT does not fill the conversation with a large stdout/stderr block. Full stdout/stderr is still returned in structured tool data and the CodexPro card keeps the output preview folded. If you want the old raw transcript behavior:
+
+```bash
+codexpro start --bash-transcript full
+```
+
+CodexPro can also expose an opt-in, read-only local Codex session browser when full tools are enabled:
+
+```bash
+codexpro start --tool-mode full --codex-sessions metadata
+codexpro start --tool-mode full --codex-sessions read
+```
+
+`metadata` adds a `codex_sessions` tool that lists local session ids, titles, cwd paths, source files, and `codex resume <session-id>` commands from `~/.codex/sessions` and `~/.codex/archived_sessions`. `read` also adds `read_codex_session` for bounded transcript reads. This is similar to local session managers that scan Codex JSONL history; it still does not attach to a live Codex app chat, execute inside that session, or bypass any product limits.
+
+Use `--codex-dir <dir>` if your Codex history lives somewhere other than `~/.codex`.
 
 If you want ChatGPT to plan while Codex or another local agent edits and runs commands, combine handoff mode with disabled bash:
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -31,16 +31,36 @@
   <a href="SECURITY.md">安全说明</a>
 </p>
 
-CodexPro 把 ChatGPT Developer Mode 变成本地仓库的 MCP 代码代理。你在目标仓库里运行 `codexpro setup`，把复制好的 Server URL 粘贴到 ChatGPT 的 Create app 页面，ChatGPT 就能读取文件、搜索代码、查看 git 状态、写入或精确编辑文件，并运行安全范围内的验证命令。
+## 安装
+
+CodexPro 需要 Node.js 20+，以及能使用 Apps / Developer Mode 的 ChatGPT Plus 或 Pro 账号。
+
+先安装 CLI：
+
+```bash
+npm install -g codexpro
+```
+
+进入你想让 ChatGPT 工作的仓库，然后运行 setup：
+
+```bash
+cd /path/to/your/repo
+codexpro setup
+```
+
+CodexPro 会自动复制 ChatGPT Server URL。到 ChatGPT 打开 `Settings -> Apps -> Advanced settings -> Create app`，粘贴这个 URL，并选择 `Authentication: No Authentication / None`。
+
+以后同一个仓库日常启动只需要：
+
+```bash
+codexpro start
+```
+
+CodexPro 把 ChatGPT Developer Mode 变成本地仓库的 MCP 代码代理。ChatGPT 可以读取文件、搜索代码、查看 git 状态、写入或精确编辑文件，并运行安全范围内的验证命令。
 
 CodexPro 不是速率限制绕过工具。它不会绕过、提升、合并、转售或修改 ChatGPT、Codex、OpenAI 或第三方模型的限制。它只是通过官方 Developer Mode / MCP App 路径，把你自己的 ChatGPT 会话连接到你自己的本地仓库。
 
 如果 Codex 当前工作流暂时不可用，而你的 ChatGPT 页面仍然可用，CodexPro 可以让你继续在同一个本地仓库上工作。反过来也一样：ChatGPT 负责高上下文规划，Codex、OpenCode、Pi 或其他本地执行器负责终端里的实际执行。
-
-```bash
-npm install -g codexpro
-codexpro setup
-```
 
 ## 适合谁
 
@@ -84,28 +104,7 @@ ChatGPT Web 可以操作：
 
 ChatGPT 里每个 CodexPro 工具都可以显示紧凑 v9 卡片：server config、自测、workspace 摘要、读写 diff、bash 验证、git/tree/search/context 和 handoff/export 都有结构化视图。git、skills、tree、terminal 输出、context 和 raw diff 默认折叠或截断，避免在聊天里刷出大段原始数据。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 
-## 快速开始
-
-先全局安装一次：
-
-```bash
-npm install -g codexpro
-```
-
-进入你想让 ChatGPT 工作的仓库：
-
-```bash
-cd /path/to/your/repo
-codexpro setup
-```
-
-`setup` 会引导你选择端口、模式和公网 URL 方式，并保存当前仓库的配置。它会启动本地 MCP HTTP 服务、生成私有 CodexPro token、启动隧道，并把完整 Server URL 复制到剪贴板。
-
-以后同一个仓库的日常启动只需要：
-
-```bash
-codexpro start
-```
+## 其他启动方式
 
 不想全局安装时，也可以用：
 
@@ -371,6 +370,23 @@ codexpro start --bash-session main --require-bash-session
 
 这不是 Codex App 聊天会话 id，而是 CodexPro 本地 bash 工具的显式匹配标签。
 
+bash 结果默认使用紧凑 transcript，避免 ChatGPT 对话里突然铺开大段 stdout/stderr。完整 stdout/stderr 仍在结构化工具数据里，CodexPro 卡片里的输出预览默认折叠。需要旧行为时可以显式打开：
+
+```bash
+codexpro start --bash-transcript full
+```
+
+CodexPro 也可以在 full tools 下显式开启只读的本地 Codex 会话列表：
+
+```bash
+codexpro start --tool-mode full --codex-sessions metadata
+codexpro start --tool-mode full --codex-sessions read
+```
+
+`metadata` 会增加 `codex_sessions` 工具，从 `~/.codex/sessions` 和 `~/.codex/archived_sessions` 读取本地 JSONL 历史，列出 session id、标题、cwd、来源文件和 `codex resume <session-id>` 命令。`read` 还会增加 `read_codex_session`，用于有限长度的 transcript 读取。它类似本地 session manager 扫描 Codex 历史文件，但仍然不会附加到正在运行的 Codex App 聊天，也不会在那个会话里执行命令或绕过产品限制。
+
+如果 Codex 历史不在默认位置，可以用 `--codex-dir <dir>`。
+
 如果只想让 ChatGPT 规划、由你本地决定是否执行：
 
 ```bash
@@ -397,10 +413,16 @@ codexpro watch-handoff --agent opencode --model provider/model --yes
 ```text
 Enter  打开 ChatGPT connector 设置
 c      再次复制 Server URL
-o      打开本地 setup/status 页面
+o      打开本地 admin dashboard
 h      显示帮助
 q      停止 CodexPro
 ```
+
+本地 admin dashboard 是带 token 保护的 setup/settings 页面。它会显示当前 workspace、local MCP endpoint、安全模式、安装/启动命令、ChatGPT 连接步骤、saved profile 设置和 allowed roots。
+
+页面也提供 GitHub、npm、docs 链接，以及 global install、guided setup、daily start、source checkout setup 和高级重启命令的复制按钮。它能修改下一次启动使用的 saved profile：tunnel provider、public hostname、port、mode、bash mode、transcript、Codex session 模式、write mode、tool mode、widget origin 和 tunnel config 路径。修改后需要重新运行 `codexpro start` 才会生效。
+
+浏览器 admin 页面只负责 setup/settings/status 和 MCP endpoint；不能切换 ChatGPT 账号，不能直接保存原始 Cloudflare tunnel token，也不能把 CodexPro 作为后台服务开关。Cloudflare dashboard-managed tunnel 请把 token 放在本地文件里，再填写 Cloudflare token file。
 
 ## FAQ
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,12 +79,14 @@ codexpro start \
 - Public tunnel mode and non-loopback binds fail closed if `CODEXPRO_HTTP_TOKEN` is missing.
 - Do not commit printed connector URLs that include `codexpro_token`.
 - Do not commit Cloudflare tunnel tokens.
+- Do not paste raw Cloudflare tunnel tokens into browser pages or screenshots. Use `--cloudflare-token-file` or the local page's Cloudflare token file field instead.
 - Use `--mode handoff` for planning workflows where ChatGPT should not edit source files.
 - Preview local handoff execution with `codexpro execute-handoff --dry-run` before running an unfamiliar adapter or custom command.
 - Keep `execute-handoff` local. Do not wrap it in a remote MCP tool unless you add a stronger approval and sandbox story.
 - Use default agent mode only with trusted ChatGPT sessions and repo-specific roots.
 - Use `--no-bash` when ChatGPT should never trigger shell commands in the workspace.
 - Use `--bash-session <id> --require-bash-session` when bash should be enabled only for calls that explicitly target this local CodexPro terminal label.
+- Keep Codex session history access off unless needed. `--codex-sessions metadata` only lists local Codex JSONL metadata; `--codex-sessions read` allows bounded transcript reads.
 - Use `--bash full` only for trusted local repos.
 - Do not treat MCP session ids or bash session labels as Codex conversation ids. CodexPro does not execute inside a Codex app session.
 - Prefer a repo-specific `--root` instead of `--allow-home`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,15 +20,13 @@
     <a class="skip-link" href="#quickstart">Skip to setup</a>
     <header class="site-header">
       <a class="brand" href="#top" aria-label="CodexPro home">
-        <span class="brand-mark">CP</span>
+        <img class="brand-mark" src="./favicon.svg" width="34" height="34" alt="" aria-hidden="true" />
         <span>CodexPro</span>
       </a>
       <nav aria-label="Primary navigation">
         <a href="#quickstart">Start</a>
-        <a href="#execute">Execute</a>
-        <a href="#ngrok">ngrok</a>
-        <a href="#cloudflare">Cloudflare</a>
-        <a href="#reference">Docs</a>
+        <a href="#modes">Modes</a>
+        <a href="#reference">Tools</a>
         <a href="#faq">FAQ</a>
         <a href="#stop">Stop</a>
         <a href="./zh.html">中文</a>
@@ -39,68 +37,73 @@
     <main id="top">
       <section class="hero">
         <div class="hero-copy">
-          <p class="launch-pill"><img src="./star.svg" alt="" aria-hidden="true" />Open-source MCP bridge for ChatGPT Plus / Pro</p>
-          <p class="eyebrow">ChatGPT plus local repo tools</p>
-          <h1>Use ChatGPT as a local coding agent.</h1>
+          <p class="launch-pill"><img src="./star.svg" alt="" aria-hidden="true" />Simple install</p>
+          <p class="eyebrow">Install in your repo</p>
+          <h1>Connect ChatGPT to your local code.</h1>
           <p class="hero-lede">
-            CodexPro connects ChatGPT Developer Mode to the repo on your machine. One setup command gives ChatGPT file reads, code search, exact edits, git status, git diff, safe checks, and Codex-style context. It does not bypass limits or provide models.
+            Install the CLI, run setup in your project, then paste the copied Server URL into ChatGPT Developer Mode. CodexPro handles the local server, token, tunnel, and workspace tools.
           </p>
-          <div class="hero-proof" aria-label="Core capabilities">
-            <span>AGENTS.md context</span>
-            <span>.ai-bridge handoff</span>
-            <span>stable ngrok or Cloudflare URL</span>
-          </div>
-          <div class="hero-actions">
-            <a class="button primary" href="#quickstart">Start with setup</a>
-            <a class="button secondary star-button" href="https://github.com/rebel0789/codexpro"><img src="./star.svg" alt="" aria-hidden="true" />Star on GitHub</a>
-            <a class="button secondary" href="https://www.npmjs.com/package/codexpro">View npm package</a>
-          </div>
           <div class="install-line" role="group" aria-label="Install command">
             <code>npm install -g codexpro
 codexpro setup</code>
             <button class="copy-button" data-copy="npm install -g codexpro&#10;codexpro setup">Copy</button>
           </div>
+          <div class="hero-proof" aria-label="Core capabilities">
+            <span>AGENTS.md context</span>
+            <span>.ai-bridge handoff</span>
+            <span>compact cards</span>
+            <span>opt-in Codex session metadata</span>
+          </div>
+          <div class="hero-actions">
+            <a class="button primary" href="#quickstart">Install CodexPro</a>
+            <a class="button secondary star-button" href="https://github.com/rebel0789/codexpro"><img src="./star.svg" alt="" aria-hidden="true" />Star on GitHub</a>
+            <a class="button secondary" href="https://www.npmjs.com/package/codexpro">View npm package</a>
+          </div>
         </div>
 
         <div class="hero-visual" aria-label="CodexPro workspace preview">
           <div class="workspace-demo">
-            <div class="demo-toolbar">
-              <div class="window-dots" aria-hidden="true"><span></span><span></span><span></span></div>
-              <strong>ChatGPT + CodexPro</strong>
-              <small>connected</small>
+            <div class="demo-status">
+              <span class="status-dot" aria-hidden="true"></span>
+              <div class="status-label">
+                <strong>Workspace bridge</strong>
+                <small>/path/to/repo · token protected</small>
+              </div>
+              <span class="status-badge">setup</span>
             </div>
             <div class="demo-grid">
               <div class="chat-pane">
-                <small>ChatGPT</small>
-                <p>“Open the current workspace, read the Codex context, fix the failing test, and show me the diff.”</p>
-                <div class="message-chip">Developer Mode app: CodexPro</div>
+                <small>Install</small>
+                <p><code>npm install -g codexpro</code><br /><code>codexpro setup</code></p>
+                <div class="message-chip">Server URL copied automatically</div>
               </div>
               <div class="tool-pane">
-                <small>CodexPro tools</small>
+                <small>Then ChatGPT can</small>
                 <div class="tool-card-mini active">
-                  <span>codex_context</span>
-                  <strong>AGENTS.md + .ai-bridge + git state</strong>
+                  <span>read/search</span>
+                  <strong>inspect files and find code</strong>
                 </div>
                 <div class="tool-card-mini">
-                  <span>edit</span>
+                  <span>edit/review</span>
                   <strong>exact replacement inside workspace</strong>
                 </div>
                 <div class="tool-card-mini">
-                  <span>bash</span>
-                  <strong>safe npm test / lint / build</strong>
+                  <span>verify</span>
+                  <strong>compact npm test / lint / build result</strong>
                 </div>
               </div>
             </div>
             <div class="repo-pane">
-              <div class="repo-row"><span>README.md</span><strong>+ Chinese docs link</strong></div>
-              <div class="repo-row"><span>src/http.ts</span><strong>token auth checked</strong></div>
+              <div class="repo-row"><span>README.md</span><strong>selected context only</strong></div>
+              <div class="repo-row"><span>src/server.ts</span><strong>workspace-scoped edit</strong></div>
               <div class="repo-row"><span>.ai-bridge/current-plan.md</span><strong>handoff ready</strong></div>
+              <div class="repo-row"><span>~/.codex/sessions</span><strong>metadata mode only</strong></div>
             </div>
           </div>
           <div class="floating-note">
-            <span>Daily command</span>
+            <span>After setup</span>
             <strong>codexpro start</strong>
-            <small>Use ngrok or Cloudflare named tunnel for one stable ChatGPT URL.</small>
+            <small>Run this from the same repo when you want ChatGPT connected again.</small>
           </div>
         </div>
       </section>
@@ -108,18 +111,18 @@ codexpro setup</code>
       <section class="strip" aria-label="Core workflow">
         <div>
           <span>01</span>
-          <strong>Start</strong>
-          <p>Install once, then run setup inside the folder you want ChatGPT to work on.</p>
+          <strong>Install</strong>
+          <p>Run <code>npm install -g codexpro</code> once.</p>
         </div>
         <div>
           <span>02</span>
-          <strong>Paste</strong>
-          <p>The full Server URL is copied automatically, token included.</p>
+          <strong>Setup</strong>
+          <p>Run <code>codexpro setup</code> inside your project.</p>
         </div>
         <div>
           <span>03</span>
-          <strong>Build</strong>
-          <p>ChatGPT gets agentic tools for the folder on your machine.</p>
+          <strong>Paste</strong>
+          <p>Paste the copied Server URL into ChatGPT Create app.</p>
         </div>
       </section>
 
@@ -320,7 +323,7 @@ cloudflared tunnel route dns codexpro codexpro.example.com</code></pre>
         </div>
       </section>
 
-      <section class="section">
+      <section id="modes" class="section">
         <div class="section-heading">
           <p class="eyebrow">Modes</p>
           <h2>Use the right level of control for the task.</h2>
@@ -413,9 +416,14 @@ codexpro settings delete --yes</code></pre>
             <dl>
               <div><dt>Enter</dt><dd>Open ChatGPT connector settings</dd></div>
               <div><dt>c</dt><dd>Copy Server URL again</dd></div>
-              <div><dt>o</dt><dd>Open local setup/status page</dd></div>
+              <div><dt>o</dt><dd>Open local admin dashboard</dd></div>
               <div><dt>q</dt><dd>Stop CodexPro</dd></div>
             </dl>
+          </article>
+          <article>
+            <small>Local admin</small>
+            <h3>Setup, profile, and status</h3>
+            <p>Press <code>o</code> to open the token-protected admin dashboard. It shows install/start commands, ChatGPT connection steps, saved profile settings, modes, allowed roots, and advanced restart shortcuts.</p>
           </article>
         </div>
 
@@ -459,6 +467,11 @@ codexpro settings delete --yes</code></pre>
             <p>Use <code>codexpro start --no-bash</code>, or keep bash enabled with <code>--bash-session main --require-bash-session</code>. Session labels target this local CodexPro server, not a Codex app chat.</p>
           </article>
           <article>
+            <small>Codex sessions</small>
+            <h3>Opt-in local history browser</h3>
+            <p><code>--codex-sessions metadata</code> lists local Codex session ids, titles, cwd paths, and resume commands. <code>read</code> mode adds bounded transcript reads; neither mode attaches to a live Codex chat.</p>
+          </article>
+          <article>
             <small>Visual widgets</small>
             <h3>Compact cards for every tool</h3>
             <p>Every CodexPro tool can render a compact v9 card. Skills, git, tree, context, terminal output, and raw diffs stay folded or bounded until opened; <code>load_skill</code> loads bounded instructions on demand.</p>
@@ -467,6 +480,11 @@ codexpro settings delete --yes</code></pre>
             <small>Stable URL rule</small>
             <h3>One URL needs one reserved hostname</h3>
             <p>Cloudflare quick tunnels change on restart. Use an ngrok free dev domain or Cloudflare named tunnel when you want one ChatGPT app URL.</p>
+          </article>
+          <article>
+            <small>Local web admin</small>
+            <h3>Edit next-run profile defaults</h3>
+            <p>The token-protected local page can save tunnel, hostname, port, mode, bash, Codex sessions, write/tool mode, widget origin, and tunnel config paths for the next <code>codexpro start</code>. Raw tunnel tokens, account switching, and background services stay out of the browser.</p>
           </article>
           <article>
             <small>Local executor</small>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,3 +1,6 @@
+/* Hallmark preflight: P4 H4 E4 S4 R4 V4. Genre: modern minimal developer tool. */
+/* Hallmark critique: remove fake chrome, reduce decorative glow, preserve truthful local-workspace flows. */
+
 :root {
   color-scheme: dark;
   --bg: #0f1115;
@@ -23,6 +26,7 @@
 }
 
 html {
+  overflow-x: clip;
   scroll-behavior: smooth;
 }
 
@@ -32,11 +36,10 @@ html {
 
 body {
   margin: 0;
-  overflow-x: hidden;
+  overflow-x: clip;
   background:
-    radial-gradient(circle at 18% 18%, rgba(232, 111, 67, 0.22), transparent 28rem),
-    radial-gradient(circle at 78% 26%, rgba(112, 214, 255, 0.16), transparent 32rem),
-    linear-gradient(180deg, rgba(246, 196, 83, 0.06), transparent 38rem),
+    linear-gradient(180deg, rgba(112, 214, 255, 0.08), transparent 34rem),
+    linear-gradient(180deg, rgba(246, 196, 83, 0.055), transparent 54rem),
     var(--bg);
   color: var(--text);
   font-family: var(--sans);
@@ -53,19 +56,6 @@ body::before {
     linear-gradient(90deg, rgba(148, 163, 184, 0.045) 1px, transparent 1px);
   background-size: 48px 48px;
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent 75%);
-}
-
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.14;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.35) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 60%, rgba(255, 255, 255, 0.22) 0 1px, transparent 1px);
-  background-size: 34px 34px, 58px 58px;
-  mix-blend-mode: overlay;
 }
 
 .skip-link {
@@ -118,6 +108,7 @@ main {
   align-items: center;
   gap: 24px;
   padding: 18px 0;
+  background: linear-gradient(180deg, rgba(15, 17, 21, 0.92), rgba(15, 17, 21, 0.62));
   backdrop-filter: blur(18px);
 }
 
@@ -130,22 +121,19 @@ main {
 }
 
 .brand-mark {
-  display: grid;
   width: 34px;
   height: 34px;
-  place-items: center;
-  border: 1px solid rgba(246, 196, 83, 0.38);
-  border-radius: 9px;
-  background: linear-gradient(135deg, rgba(246, 196, 83, 0.22), rgba(112, 214, 255, 0.14));
-  color: #fde68a;
-  font-family: var(--mono);
-  font-size: 12px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px rgba(246, 196, 83, 0.42);
 }
 
 nav {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 nav a {
@@ -221,7 +209,7 @@ button:focus-visible {
   grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr);
   align-items: center;
   gap: 56px;
-  min-height: calc(100dvh - 76px);
+  min-height: min(760px, calc(100dvh - 112px));
   padding: 52px 0 64px;
 }
 
@@ -337,7 +325,7 @@ p {
   gap: 10px;
   max-width: 100%;
   border: 1px solid var(--line);
-  border-radius: 14px;
+  border-radius: 8px;
   background: rgba(11, 18, 32, 0.78);
   padding: 8px;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
@@ -347,7 +335,8 @@ p {
   padding: 0 12px;
   color: #dbeafe;
   font-size: 14px;
-  white-space: nowrap;
+  line-height: 1.45;
+  white-space: pre;
 }
 
 .copy-button {
@@ -364,8 +353,6 @@ p {
   min-height: 520px;
 }
 
-.terminal-window,
-.agent-panel,
 .workspace-demo,
 .floating-note,
 .strip,
@@ -386,10 +373,9 @@ p {
 .workspace-demo {
   position: relative;
   overflow: hidden;
-  border-radius: 28px;
+  border-radius: 8px;
   background:
-    linear-gradient(140deg, rgba(112, 214, 255, 0.1), transparent 34%),
-    linear-gradient(320deg, rgba(246, 196, 83, 0.11), transparent 36%),
+    linear-gradient(180deg, rgba(112, 214, 255, 0.08), transparent 42%),
     rgba(18, 22, 31, 0.92);
 }
 
@@ -402,7 +388,7 @@ p {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), inset 0 -60px 90px rgba(2, 6, 23, 0.28);
 }
 
-.demo-toolbar {
+.demo-status {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -411,11 +397,24 @@ p {
   padding: 15px 18px;
 }
 
-.demo-toolbar strong {
+.demo-status strong {
+  display: block;
   font-size: 14px;
 }
 
-.demo-toolbar small {
+.demo-status small {
+  display: block;
+  margin-top: 2px;
+  color: var(--faint);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.status-label {
+  min-width: 0;
+}
+
+.status-badge {
   margin-left: auto;
   border: 1px solid rgba(52, 211, 153, 0.26);
   border-radius: 999px;
@@ -423,26 +422,6 @@ p {
   font-family: var(--mono);
   font-size: 11px;
   padding: 5px 8px;
-}
-
-.window-dots {
-  display: flex;
-  gap: 6px;
-}
-
-.window-dots span {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--rose);
-}
-
-.window-dots span:nth-child(2) {
-  background: var(--amber);
-}
-
-.window-dots span:nth-child(3) {
-  background: var(--green);
 }
 
 .demo-grid {
@@ -456,7 +435,7 @@ p {
 .tool-pane,
 .repo-pane {
   border: 1px solid rgba(148, 163, 184, 0.16);
-  border-radius: 18px;
+  border-radius: 8px;
   background: rgba(12, 15, 22, 0.72);
   padding: 18px;
 }
@@ -494,7 +473,7 @@ p {
 
 .tool-card-mini {
   border: 1px solid rgba(148, 163, 184, 0.12);
-  border-radius: 14px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.035);
   padding: 13px;
 }
@@ -556,9 +535,9 @@ p {
   right: -4px;
   bottom: 4px;
   width: min(330px, 86%);
-  border-radius: 18px;
+  border-radius: 8px;
   background:
-    linear-gradient(140deg, rgba(246, 196, 83, 0.12), transparent 60%),
+    linear-gradient(180deg, rgba(246, 196, 83, 0.12), transparent 72%),
     rgba(13, 16, 24, 0.94);
   padding: 18px;
 }
@@ -583,101 +562,6 @@ p {
   line-height: 1.5;
 }
 
-.terminal-window {
-  position: relative;
-  overflow: hidden;
-  border-radius: 18px;
-}
-
-.terminal-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  border-bottom: 1px solid var(--line);
-  background: #121e31;
-  padding: 13px 16px;
-}
-
-.terminal-bar span {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: #334155;
-}
-
-.terminal-bar span:first-child {
-  background: var(--rose);
-}
-
-.terminal-bar span:nth-child(2) {
-  background: var(--amber);
-}
-
-.terminal-bar span:nth-child(3) {
-  background: var(--green);
-}
-
-.terminal-bar strong {
-  margin-left: 8px;
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: 13px;
-}
-
-.terminal-body {
-  padding: 22px;
-}
-
-.terminal-body p {
-  margin-bottom: 12px;
-  color: #d7dee9;
-  font-family: var(--mono);
-  font-size: 14px;
-}
-
-.ok {
-  color: var(--green);
-  font-weight: 800;
-}
-
-.terminal-card {
-  display: grid;
-  gap: 8px;
-  margin-top: 28px;
-  border: 1px solid #2d3d55;
-  border-radius: 14px;
-  background: #0b1220;
-  padding: 18px;
-}
-
-.terminal-card span,
-.terminal-card small {
-  color: var(--faint);
-}
-
-.agent-panel {
-  position: absolute;
-  right: 8px;
-  bottom: 14px;
-  width: min(330px, 88%);
-  border-radius: 16px;
-  padding: 18px;
-}
-
-.panel-head {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 14px;
-}
-
-.panel-head small {
-  margin-left: auto;
-  color: var(--green);
-  font-family: var(--mono);
-  font-size: 12px;
-}
-
 .status-dot {
   width: 9px;
   height: 9px;
@@ -686,7 +570,6 @@ p {
   box-shadow: 0 0 0 8px rgba(52, 211, 153, 0.08);
 }
 
-.agent-panel ul,
 .safety ul {
   display: grid;
   gap: 10px;
@@ -695,12 +578,10 @@ p {
   list-style: none;
 }
 
-.agent-panel li,
 .safety li {
   color: #d6deea;
 }
 
-.agent-panel li::before,
 .safety li::before {
   content: "";
   display: inline-block;
@@ -716,7 +597,7 @@ p {
   grid-template-columns: repeat(3, 1fr);
   gap: 1px;
   overflow: hidden;
-  border-radius: 18px;
+  border-radius: 8px;
   margin-bottom: 104px;
   background: var(--line);
 }
@@ -763,9 +644,9 @@ p {
 
 .value-matrix > div {
   border: 1px solid var(--line);
-  border-radius: 18px;
+  border-radius: 8px;
   background:
-    linear-gradient(135deg, rgba(103, 232, 249, 0.08), transparent 60%),
+    linear-gradient(180deg, rgba(103, 232, 249, 0.08), transparent 60%),
     rgba(13, 22, 38, 0.9);
   padding: 24px;
   box-shadow: var(--shadow);
@@ -807,7 +688,7 @@ p {
   display: grid;
   gap: 1px;
   overflow: hidden;
-  border-radius: 18px;
+  border-radius: 8px;
   background: var(--line);
 }
 
@@ -850,7 +731,7 @@ p {
 .command-stack pre,
 .compare-grid pre {
   border: 1px solid #263348;
-  border-radius: 12px;
+  border-radius: 8px;
   background: #08111f;
   color: #dbeafe;
   padding: 14px;
@@ -866,7 +747,7 @@ p {
   display: flex;
   min-height: 310px;
   flex-direction: column;
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 24px;
 }
 
@@ -891,7 +772,7 @@ p {
 }
 
 .command-stack > div {
-  border-radius: 16px;
+  border-radius: 8px;
   padding: 18px;
 }
 
@@ -909,7 +790,7 @@ p {
 }
 
 .mode-row > div {
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 24px;
 }
 
@@ -925,7 +806,7 @@ p {
 
 .reference-grid article {
   min-height: 270px;
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 22px;
 }
 
@@ -947,9 +828,9 @@ p {
 .faq-grid article {
   min-height: 240px;
   border: 1px solid var(--line);
-  border-radius: 18px;
+  border-radius: 8px;
   background:
-    linear-gradient(145deg, rgba(250, 204, 21, 0.08), transparent 46%),
+    linear-gradient(180deg, rgba(250, 204, 21, 0.08), transparent 58%),
     rgba(13, 22, 38, 0.88);
   padding: 24px;
   box-shadow: var(--shadow);
@@ -988,7 +869,7 @@ p {
 
 .reference-grid pre {
   border: 1px solid #263348;
-  border-radius: 12px;
+  border-radius: 8px;
   background: #08111f;
   color: #dbeafe;
   margin-bottom: 14px;
@@ -1025,7 +906,7 @@ dd {
   grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.25fr);
   gap: 28px;
   margin: 16px 0;
-  border-radius: 20px;
+  border-radius: 8px;
   padding: 26px;
 }
 
@@ -1054,7 +935,7 @@ dd {
   flex-wrap: wrap;
   gap: 10px;
   margin-top: 16px;
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 16px;
 }
 
@@ -1079,7 +960,7 @@ dd {
   display: grid;
   grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
   gap: 40px;
-  border-radius: 24px;
+  border-radius: 8px;
   padding: 34px;
 }
 
@@ -1106,8 +987,8 @@ dd {
 
   nav {
     width: 100%;
-    overflow-x: auto;
     padding-bottom: 4px;
+    justify-content: flex-start;
   }
 
   .hero,
@@ -1169,11 +1050,34 @@ dd {
   }
 
   h1 {
-    font-size: 3rem;
+    font-size: 2.7rem;
   }
 
   h2 {
     font-size: 2.35rem;
+  }
+
+  nav {
+    gap: 6px;
+  }
+
+  nav a {
+    padding: 7px 9px;
+    font-size: 13px;
+  }
+
+  .hero {
+    padding-top: 28px;
+  }
+
+  .hero-lede {
+    font-size: 17px;
+    line-height: 1.58;
+  }
+
+  .launch-pill {
+    margin-bottom: 14px;
+    font-size: 12px;
   }
 
   .install-line {
@@ -1193,12 +1097,6 @@ dd {
 
   .hero-visual {
     padding-bottom: 150px;
-  }
-
-  .agent-panel {
-    left: 18px;
-    right: auto;
-    width: calc(100% - 36px);
   }
 
   .repo-row {

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -20,7 +20,7 @@
     <a class="skip-link" href="#quickstart">跳到设置</a>
     <header class="site-header">
       <a class="brand" href="#top" aria-label="CodexPro 中文首页">
-        <span class="brand-mark">CP</span>
+        <img class="brand-mark" src="./favicon.svg" width="34" height="34" alt="" aria-hidden="true" />
         <span>CodexPro</span>
       </a>
       <nav aria-label="主导航">
@@ -37,68 +37,73 @@
     <main id="top">
       <section class="hero">
         <div class="hero-copy">
-          <p class="launch-pill"><img src="./star.svg" alt="" aria-hidden="true" />面向 ChatGPT Plus / Pro 的开源 MCP 桥</p>
-          <p class="eyebrow">ChatGPT plus 本地仓库工具</p>
-          <h1>把 ChatGPT 变成本地代码代理。</h1>
+          <p class="launch-pill"><img src="./star.svg" alt="" aria-hidden="true" />简单安装</p>
+          <p class="eyebrow">在仓库里安装</p>
+          <h1>把 ChatGPT 连接到本地代码。</h1>
           <p class="hero-lede">
-            CodexPro 把 ChatGPT Developer Mode 连接到你机器上的仓库。一个 setup 命令之后，ChatGPT 可以读取文件、搜索代码、精确编辑、查看 git 状态和 diff、运行安全检查，并读取 Codex 风格上下文。它不绕过限制，也不提供模型。
+            安装 CLI，在项目里运行 setup，然后把复制好的 Server URL 粘贴到 ChatGPT Developer Mode。CodexPro 会处理本地 server、token、tunnel 和 workspace 工具。
           </p>
-          <div class="hero-proof" aria-label="核心能力">
-            <span>AGENTS.md 上下文</span>
-            <span>.ai-bridge handoff</span>
-            <span>ngrok / Cloudflare 稳定 URL</span>
-          </div>
-          <div class="hero-actions">
-            <a class="button primary" href="#quickstart">开始设置</a>
-            <a class="button secondary star-button" href="https://github.com/rebel0789/codexpro"><img src="./star.svg" alt="" aria-hidden="true" />GitHub 点星</a>
-            <a class="button secondary" href="https://www.npmjs.com/package/codexpro">查看 npm</a>
-          </div>
           <div class="install-line" role="group" aria-label="安装命令">
             <code>npm install -g codexpro
 codexpro setup</code>
             <button class="copy-button" data-copy="npm install -g codexpro&#10;codexpro setup">复制</button>
           </div>
+          <div class="hero-proof" aria-label="核心能力">
+            <span>AGENTS.md 上下文</span>
+            <span>.ai-bridge handoff</span>
+            <span>紧凑卡片</span>
+            <span>Codex session metadata 可选开启</span>
+          </div>
+          <div class="hero-actions">
+            <a class="button primary" href="#quickstart">安装 CodexPro</a>
+            <a class="button secondary star-button" href="https://github.com/rebel0789/codexpro"><img src="./star.svg" alt="" aria-hidden="true" />GitHub 点星</a>
+            <a class="button secondary" href="https://www.npmjs.com/package/codexpro">查看 npm</a>
+          </div>
         </div>
 
         <div class="hero-visual" aria-label="CodexPro 工作区预览">
           <div class="workspace-demo">
-            <div class="demo-toolbar">
-              <div class="window-dots" aria-hidden="true"><span></span><span></span><span></span></div>
-              <strong>ChatGPT + CodexPro</strong>
-              <small>connected</small>
+            <div class="demo-status">
+              <span class="status-dot" aria-hidden="true"></span>
+              <div class="status-label">
+                <strong>Workspace bridge</strong>
+                <small>/path/to/repo · token protected</small>
+              </div>
+              <span class="status-badge">setup</span>
             </div>
             <div class="demo-grid">
               <div class="chat-pane">
-                <small>ChatGPT</small>
-                <p>“打开当前仓库，读取 Codex 上下文，修复失败测试，然后给我看 diff。”</p>
-                <div class="message-chip">Developer Mode app: CodexPro</div>
+                <small>安装</small>
+                <p><code>npm install -g codexpro</code><br /><code>codexpro setup</code></p>
+                <div class="message-chip">Server URL 自动复制</div>
               </div>
               <div class="tool-pane">
-                <small>CodexPro tools</small>
+                <small>然后 ChatGPT 可以</small>
                 <div class="tool-card-mini active">
-                  <span>codex_context</span>
-                  <strong>AGENTS.md + .ai-bridge + git 状态</strong>
+                  <span>read/search</span>
+                  <strong>读取文件并搜索代码</strong>
                 </div>
                 <div class="tool-card-mini">
-                  <span>edit</span>
+                  <span>edit/review</span>
                   <strong>工作区内精确替换</strong>
                 </div>
                 <div class="tool-card-mini">
-                  <span>bash</span>
-                  <strong>安全运行 npm test / lint / build</strong>
+                  <span>verify</span>
+                  <strong>紧凑显示 npm test / lint / build 结果</strong>
                 </div>
               </div>
             </div>
             <div class="repo-pane">
-              <div class="repo-row"><span>README.md</span><strong>加入中文文档入口</strong></div>
-              <div class="repo-row"><span>src/http.ts</span><strong>token auth checked</strong></div>
+              <div class="repo-row"><span>README.md</span><strong>只导出选中的上下文</strong></div>
+              <div class="repo-row"><span>src/server.ts</span><strong>仅在 workspace 内编辑</strong></div>
               <div class="repo-row"><span>.ai-bridge/current-plan.md</span><strong>handoff ready</strong></div>
+              <div class="repo-row"><span>~/.codex/sessions</span><strong>metadata 模式才读取</strong></div>
             </div>
           </div>
           <div class="floating-note">
-            <span>日常命令</span>
+            <span>setup 之后</span>
             <strong>codexpro start</strong>
-            <small>用 ngrok 或 Cloudflare named tunnel 保持同一个 ChatGPT URL。</small>
+            <small>以后在同一个仓库里运行这个命令，就能重新连接 ChatGPT。</small>
           </div>
         </div>
       </section>
@@ -106,18 +111,18 @@ codexpro setup</code>
       <section class="strip" aria-label="核心流程">
         <div>
           <span>01</span>
-          <strong>Start</strong>
-          <p>全局安装一次，在目标仓库里运行 setup。</p>
+          <strong>Install</strong>
+          <p>先运行 <code>npm install -g codexpro</code>。</p>
         </div>
         <div>
           <span>02</span>
-          <strong>Paste</strong>
-          <p>复制好的 Server URL 已包含私有 token。</p>
+          <strong>Setup</strong>
+          <p>在你的项目里运行 <code>codexpro setup</code>。</p>
         </div>
         <div>
           <span>03</span>
-          <strong>Build</strong>
-          <p>ChatGPT 获得本地仓库工具和显式上下文。</p>
+          <strong>Paste</strong>
+          <p>把复制好的 Server URL 粘贴到 ChatGPT Create app。</p>
         </div>
       </section>
 
@@ -132,7 +137,7 @@ codexpro setup</code>
             Codex 和 ChatGPT 是不同产品界面。某个工作流暂时不可用时，如果另一个你本来就有权限的界面仍然可用，CodexPro 可以让它继续在同一个本地仓库上工作，但不会修改任何产品限制。
           </p>
           <p>
-            如果你的 ChatGPT 账号在 Web 产品里提供 GPT-5.5 或更强模型，并且该模型界面可以调用 Developer Mode Apps，CodexPro 可以让它通过 MCP 使用本地仓库工具。CodexPro 不提供、不代理、不转售、也不解锁模型。
+            如果你的 ChatGPT 账号在 Web 产品里提供更强模型，并且该模型界面可以调用 Developer Mode Apps，CodexPro 可以让它通过 MCP 使用本地仓库工具。CodexPro 不提供、不代理、不转售、也不解锁模型。
           </p>
         </div>
         <div class="value-matrix">
@@ -314,6 +319,16 @@ codexpro start</code></pre>
             <p>正在 Codex 里工作时可以用 <code>codexpro start --no-bash</code>，也可以用 <code>--bash-session main --require-bash-session</code>。这个标签属于本地 CodexPro，不是 Codex App 聊天。</p>
           </article>
           <article>
+            <small>本地页面</small>
+            <h3>状态和重启命令</h3>
+            <p>终端按 <code>o</code> 打开 token-protected 本地页面。页面显示 mode、session 状态、allowed roots，并提供 no-bash、required bash session、Codex session metadata/read 和 full transcript 的复制按钮。</p>
+          </article>
+          <article>
+            <small>Codex 会话</small>
+            <h3>显式开启本地历史列表</h3>
+            <p><code>--codex-sessions metadata</code> 会列出本地 Codex session id、标题、cwd 和 resume 命令。<code>read</code> 模式才允许有限 transcript 读取；两者都不会附加到正在运行的 Codex 聊天。</p>
+          </article>
+          <article>
             <small>可视卡片</small>
             <h3>只给关键动作卡片</h3>
             <p>open workspace 摘要、write/edit diff、show_changes 审查和 handoff 导出会显示紧凑卡片。skills、git 和 tree 详情默认折叠；<code>load_skill</code> 按需加载有限长度的说明，bash 保持纯数据。</p>
@@ -322,6 +337,11 @@ codexpro start</code></pre>
             <small>上下文持久化</small>
             <h3>用文件保持连续性</h3>
             <p>把项目规则写进 <code>AGENTS.md</code>，把计划和决策写进 <code>.ai-bridge</code>，让 ChatGPT 换会话后也能恢复上下文。</p>
+          </article>
+          <article>
+            <small>本地网页后台</small>
+            <h3>修改下一次启动的 profile</h3>
+            <p>token-protected 本地页面可以保存 tunnel、hostname、port、mode、bash、Codex sessions、write/tool mode、widget origin 和 tunnel config 路径，下一次 <code>codexpro start</code> 生效。原始 tunnel token、账号切换和后台服务管理仍不放进浏览器。</p>
           </article>
         </div>
       </section>
@@ -377,6 +397,7 @@ codexpro start</code></pre>
           <li>safe bash 用于常见检查和测试，不是任意 shell 控制。</li>
           <li><code>--no-bash</code> 会关闭所有 ChatGPT 触发的 shell 命令。</li>
           <li><code>--bash-session</code> 加 <code>--require-bash-session</code> 会要求 bash 调用显式命中本地会话标签。</li>
+          <li><code>--codex-sessions</code> 默认关闭；开启后只读取本地 Codex JSONL 历史，不进入正在运行的 Codex 聊天。</li>
           <li>只想让 ChatGPT 做计划时，用 handoff 模式。</li>
         </ul>
       </section>

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -2524,13 +2524,13 @@ async function main() {
     CODEXPRO_BASH_SESSION_ID: bashSession,
     CODEXPRO_REQUIRE_BASH_SESSION: requireBashSession ? '1' : '0',
     CODEXPRO_CODEX_SESSIONS: codexSessions,
-    CODEXPRO_CODEX_DIR: codexDir,
     CODEXPRO_WRITE_MODE: write,
     CODEXPRO_TOOL_MODE: toolMode,
     CODEXPRO_WIDGET_DOMAIN: widgetDomain,
     CODEXPRO_MODE: mode,
     CODEXPRO_TUNNEL_MODE: tunnel === 'none' ? '0' : '1'
   };
+  if (codexDir) serverEnv.CODEXPRO_CODEX_DIR = codexDir;
   if (args.logRequests || process.env.CODEXPRO_LOG_REQUESTS === '1') serverEnv.CODEXPRO_LOG_REQUESTS = '1';
   if (args.allowHome) serverEnv.CODEXPRO_ALLOW_HOME = '1';
   if (token) serverEnv.CODEXPRO_HTTP_TOKEN = token;

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -49,8 +49,16 @@ Options:
   --port <port>             Local port. Default: 8787.
   --bash <off|safe|full>    Bash mode. Default: safe.
   --no-bash                 Shortcut for --bash off.
+  --bash-transcript <compact|full>
+                             Chat transcript for bash results. Default: compact.
+                             full prints raw stdout/stderr in chat.
+  --full-bash-transcript    Shortcut for --bash-transcript full.
   --bash-session <id>       Local bash session label exposed to ChatGPT.
   --require-bash-session    Require bash calls to include matching session_id.
+  --codex-sessions <off|metadata|read>
+                             Opt in to read local ~/.codex session history.
+                             metadata lists ids/titles/cwd; read allows bounded transcript reads.
+  --codex-dir <dir>          Codex config/session directory. Default: ~/.codex.
   --write <off|handoff|workspace>
                              Write mode. Default: workspace in agent mode, handoff otherwise.
                              handoff = ChatGPT can write .ai-bridge only; Codex edits source.
@@ -253,6 +261,9 @@ function parseArgs(argv) {
     else if (key === 'allow-home') out.allowHome = true;
     else if (key === 'no-auth') out.noAuth = true;
     else if (key === 'no-bash') out.bash = 'off';
+    else if (key === 'compact-bash-transcript') out.bashTranscript = 'compact';
+    else if (key === 'full-bash-transcript') out.bashTranscript = 'full';
+    else if (key === 'codex-sessions-read') out.codexSessions = 'read';
     else if (key === 'require-bash-session') out.requireBashSession = true;
     else if (key === 'copy-url') out.copyUrl = true;
     else if (key === 'no-copy-url') out.noCopyUrl = true;
@@ -360,6 +371,14 @@ function profilePathForRoot(root) {
   return path.join(profileDir(), `${profileIdForRoot(root)}.json`);
 }
 
+function runtimeDir() {
+  return path.join(codexProHome(), 'runtime');
+}
+
+function runtimeStatusPathForRoot(root) {
+  return path.join(runtimeDir(), `${profileIdForRoot(root)}.json`);
+}
+
 function readJsonFile(filePath) {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -409,6 +428,33 @@ function saveWorkspaceProfile(root, profile) {
     root,
     updatedAt: new Date().toISOString(),
     ...profile
+  };
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {}
+  return filePath;
+}
+
+function saveRuntimeConnection(root, details, options = {}) {
+  const filePath = runtimeStatusPathForRoot(root);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const payload = {
+    version: 1,
+    root,
+    updatedAt: new Date().toISOString(),
+    endpoint: details.endpoint,
+    localBase: options.localBase ?? '',
+    localStatusUrl: details.localStatusUrl ? details.localStatusUrl.replace(/codexpro_token=[^&]+/, 'codexpro_token=<redacted>') : '',
+    tunnel: options.tunnel ?? '',
+    mode: options.mode ?? '',
+    bash: options.bash ?? '',
+    bashTranscript: options.bashTranscript ?? '',
+    codexSessions: options.codexSessions ?? '',
+    bashSession: options.bashSession ?? '',
+    requireBashSession: Boolean(options.requireBashSession),
+    write: options.write ?? '',
+    toolMode: options.toolMode ?? ''
   };
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
   try {
@@ -481,6 +527,18 @@ function bashSessionOptions(args, profile = {}) {
     throw new Error('--require-bash-session requires --bash-session <id>.');
   }
   return { bashSession, requireBashSession };
+}
+
+function bashTranscriptOption(args, profile = {}) {
+  const value = optionValue(args, profile, 'bashTranscript', ['CODEXPRO_BASH_TRANSCRIPT'], 'compact');
+  if (value === 'compact' || value === 'full') return value;
+  throw new Error('--bash-transcript must be compact or full.');
+}
+
+function codexSessionsOption(args, profile = {}) {
+  const value = optionValue(args, profile, 'codexSessions', ['CODEXPRO_CODEX_SESSIONS'], 'off');
+  if (value === 'off' || value === 'metadata' || value === 'read') return value;
+  throw new Error('--codex-sessions must be off, metadata, or read.');
 }
 
 function stableToken(existing = '') {
@@ -1497,6 +1555,8 @@ function printConnectorBlock(endpoint, token, options = {}) {
   console.log(paint('bold', 'CodexPro ready'));
   if (options.root) console.log(`  Workspace  ${options.root}`);
   console.log(`  Mode       ${modeTitle}  tools=${options.toolMode ?? 'standard'}  write=${options.write ?? 'workspace'}  bash=${options.bash ?? 'safe'}`);
+  console.log(`  Transcript bash=${options.bashTranscript ?? 'compact'}`);
+  if (options.codexSessions && options.codexSessions !== 'off') console.log(`  Codex      sessions=${options.codexSessions}`);
   if (options.bashSession) console.log(`  Bash       session=${options.bashSession}${options.requireBashSession ? ' required' : ''}`);
   console.log(`  Connector  ${publicHttps ? 'public HTTPS' : 'local HTTP'}`);
   if (copied.ok) {
@@ -1787,6 +1847,9 @@ function profileFromPreference(root, args, profile, preference) {
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], 'agent');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], '');
+  const bashTranscript = bashTranscriptOption(args, profile);
+  const codexSessions = codexSessionsOption(args, profile);
+  const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
@@ -1804,6 +1867,9 @@ function profileFromPreference(root, args, profile, preference) {
     ...(preference.cloudflareTokenFile ? { cloudflareTokenFile: preference.cloudflareTokenFile } : {}),
     ...(token ? { token } : {}),
     ...(bash ? { bash } : {}),
+    ...(bashTranscript !== 'compact' ? { bashTranscript } : {}),
+    ...(codexSessions !== 'off' ? { codexSessions } : {}),
+    ...(codexDir ? { codexDir } : {}),
     ...(bashSession ? { bashSession } : {}),
     ...(requireBashSession ? { requireBashSession: true } : {}),
     ...(write ? { write } : {}),
@@ -1925,10 +1991,16 @@ async function runSetupWizard(argv) {
     const tunnelChoice = normalizeSetupChoice(tunnelAnswer, ['quick', 'stable', 'ngrok', 'local'], defaultTunnel);
     const args = ['start', '--root', root, '--port', port, '--mode', mode];
     const bash = optionValue(defaults, profile, 'bash', ['CODEXPRO_BASH_MODE'], '');
+    const bashTranscript = bashTranscriptOption(defaults, profile);
+    const codexSessions = codexSessionsOption(defaults, profile);
+    const codexDir = optionValue(defaults, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
     const write = optionValue(defaults, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
     const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
     const widgetDomain = optionValue(defaults, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
     if (bash) args.push('--bash', bash);
+    if (bashTranscript !== 'compact') args.push('--bash-transcript', bashTranscript);
+    if (codexSessions !== 'off') args.push('--codex-sessions', codexSessions);
+    if (codexDir) args.push('--codex-dir', codexDir);
     const { bashSession, requireBashSession } = bashSessionOptions(defaults, profile);
     if (bashSession) args.push('--bash-session', bashSession);
     if (requireBashSession) args.push('--require-bash-session');
@@ -2006,6 +2078,9 @@ async function runSetupWizard(argv) {
         ...(profileCloudflareTokenFile ? { cloudflareTokenFile: profileCloudflareTokenFile } : {}),
         ...(profileToken ? { token: profileToken } : {}),
         ...(bash ? { bash } : {}),
+        ...(bashTranscript !== 'compact' ? { bashTranscript } : {}),
+        ...(codexSessions !== 'off' ? { codexSessions } : {}),
+        ...(codexDir ? { codexDir } : {}),
         ...(bashSession ? { bashSession } : {}),
         ...(requireBashSession ? { requireBashSession: true } : {}),
         ...(write ? { write } : {}),
@@ -2049,6 +2124,9 @@ function printProfile(root, profile) {
     ...(safe.hostname ? [labelValue('Hostname', safe.hostname)] : []),
     ...(safe.port ? [labelValue('Port', safe.port)] : []),
     ...(safe.mode ? [labelValue('Mode', safe.mode)] : []),
+    labelValue('Bash transcript', safe.bashTranscript ?? 'compact'),
+    labelValue('Codex sessions', safe.codexSessions ?? 'off'),
+    ...(safe.codexDir ? [labelValue('Codex dir', safe.codexDir)] : []),
     ...(safe.bashSession ? [labelValue('Bash session', `${safe.bashSession}${safe.requireBashSession ? ' required' : ''}`)] : []),
     ...(safe.token ? [labelValue('Token', safe.token)] : [])
   ]);
@@ -2078,6 +2156,9 @@ function saveSettingsFromArgs(root, args, profile) {
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? '');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], profile.widgetDomain ?? '');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
+  const bashTranscript = bashTranscriptOption(args, profile);
+  const codexSessions = codexSessionsOption(args, profile);
+  const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], profile.codexDir ?? '');
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const token = tunnel === 'none'
     ? optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], profile.token ?? '')
@@ -2093,6 +2174,9 @@ function saveSettingsFromArgs(root, args, profile) {
     ...(args.cloudflareTokenFile ?? profile.cloudflareTokenFile ? { cloudflareTokenFile: args.cloudflareTokenFile ?? profile.cloudflareTokenFile } : {}),
     ...(token ? { token } : {}),
     ...(args.bash ?? profile.bash ? { bash: args.bash ?? profile.bash } : {}),
+    ...(bashTranscript !== 'compact' ? { bashTranscript } : {}),
+    ...(codexSessions !== 'off' ? { codexSessions } : {}),
+    ...(codexDir ? { codexDir } : {}),
     ...(bashSession ? { bashSession } : {}),
     ...(requireBashSession ? { requireBashSession: true } : {}),
     ...(args.write ?? profile.write ? { write: args.write ?? profile.write } : {}),
@@ -2415,6 +2499,9 @@ async function main() {
   const host = optionValue(args, profile, 'host', ['CODEXPRO_HOST'], '127.0.0.1');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
+  const bashTranscript = bashTranscriptOption(args, profile);
+  const codexSessions = codexSessionsOption(args, profile);
+  const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
@@ -2433,8 +2520,11 @@ async function main() {
     CODEXPRO_HOST: host,
     CODEXPRO_PORT: port,
     CODEXPRO_BASH_MODE: bash,
+    CODEXPRO_BASH_TRANSCRIPT: bashTranscript,
     CODEXPRO_BASH_SESSION_ID: bashSession,
     CODEXPRO_REQUIRE_BASH_SESSION: requireBashSession ? '1' : '0',
+    CODEXPRO_CODEX_SESSIONS: codexSessions,
+    CODEXPRO_CODEX_DIR: codexDir,
     CODEXPRO_WRITE_MODE: write,
     CODEXPRO_TOOL_MODE: toolMode,
     CODEXPRO_WIDGET_DOMAIN: widgetDomain,
@@ -2460,6 +2550,8 @@ async function main() {
   printBox('CodexPro start', [
     labelValue('Workspace', root),
     labelValue('Mode', `${mode}  tools=${toolMode}  write=${write}  bash=${bash}`),
+    labelValue('Bash transcript', bashTranscript),
+    labelValue('Codex sessions', codexSessions),
     ...(bashSession ? [labelValue('Bash session', `${bashSession}${requireBashSession ? ' required' : ''}`)] : []),
     labelValue('Local URL', `http://${host}:${port}/mcp`),
     labelValue(
@@ -2485,6 +2577,18 @@ async function main() {
   const localBase = `http://${host}:${port}`;
   await waitForHealth(`${localBase}/healthz`, token);
   statusLine('ok', `Local MCP ready at ${localBase}/mcp`);
+  const runtimeOptions = {
+    localBase,
+    tunnel,
+    mode,
+    toolMode,
+    write,
+    bash,
+    bashTranscript,
+    codexSessions,
+    bashSession,
+    requireBashSession
+  };
 
   if (tunnel === 'none') {
     if (effectiveArgs.installCloudflared) {
@@ -2500,9 +2604,12 @@ async function main() {
       root,
       write,
       bash,
+      bashTranscript,
+      codexSessions,
       bashSession,
       requireBashSession
     });
+    saveRuntimeConnection(root, details, runtimeOptions);
     await runControlPanel(details);
     return;
   }
@@ -2540,9 +2647,12 @@ async function main() {
       root,
       write,
       bash,
+      bashTranscript,
+      codexSessions,
       bashSession,
       requireBashSession
     });
+    saveRuntimeConnection(root, details, runtimeOptions);
     await runControlPanel(details);
     return;
   }
@@ -2561,9 +2671,12 @@ async function main() {
       root,
       write,
       bash,
+      bashTranscript,
+      codexSessions,
       bashSession,
       requireBashSession
     });
+    saveRuntimeConnection(root, details, runtimeOptions);
     await runControlPanel(details);
     return;
   }
@@ -2581,9 +2694,12 @@ async function main() {
       root,
       write,
       bash,
+      bashTranscript,
+      codexSessions,
       bashSession,
       requireBashSession
     });
+    saveRuntimeConnection(root, details, runtimeOptions);
     await runControlPanel(details);
     return;
   }
@@ -2646,9 +2762,12 @@ async function main() {
     root,
     write,
     bash,
+    bashTranscript,
+    codexSessions,
     bashSession,
     requireBashSession
   });
+  saveRuntimeConnection(root, details, runtimeOptions);
   await runControlPanel(details);
 }
 

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -317,6 +317,12 @@ function realDir(input) {
   return fs.realpathSync(resolved);
 }
 
+function resolveCodexDir(root, input) {
+  if (!input) return '';
+  const expanded = expandHome(input);
+  return path.isAbsolute(expanded) ? path.resolve(expanded) : path.resolve(root, expanded);
+}
+
 function commandExists(command) {
   const result = spawnSync(process.platform === 'win32' ? 'where' : 'command', process.platform === 'win32' ? [command] : ['-v', command], {
     shell: process.platform !== 'win32',
@@ -2501,7 +2507,7 @@ async function main() {
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
   const bashTranscript = bashTranscriptOption(args, profile);
   const codexSessions = codexSessionsOption(args, profile);
-  const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
+  const codexDir = resolveCodexDir(root, optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], ''));
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -134,6 +134,7 @@ async function callTool(client, name, args = {}) {
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-smoke-'));
+const profileHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-profile-home-'));
 await fs.mkdir(path.join(root, '.codex', 'skills', 'http-smoke-skill'), { recursive: true });
 await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKILL.md'), [
   '---',
@@ -157,7 +158,8 @@ const child = spawn('node', ['dist/http.js'], {
     CODEXPRO_BASH_MODE: 'safe',
     CODEXPRO_WRITE_MODE: 'handoff',
     CODEXPRO_TOOL_MODE: 'full',
-    CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test'
+    CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test',
+    CODEXPRO_HOME: profileHome
   },
   stdio: ['ignore', 'pipe', 'pipe']
 });
@@ -183,13 +185,88 @@ try {
     throw new Error(`expected URL-token healthz to return 200, got ${queryAuthorized.status}`);
   }
 
+  const favicon = await fetch(`${baseUrl}/favicon.ico`);
+  if (favicon.status !== 200 || !favicon.headers.get('content-type')?.includes('image/svg+xml')) {
+    throw new Error(`expected unauthenticated favicon to return SVG 200, got ${favicon.status} ${favicon.headers.get('content-type')}`);
+  }
+
   const home = await fetch(`${baseUrl}/?codexpro_token=${encodeURIComponent(token)}`);
   const homeText = await home.text();
   if (home.status !== 200 || !home.headers.get('content-type')?.includes('text/html')) {
     throw new Error(`expected authenticated onboarding page to return HTML 200, got ${home.status}`);
   }
-  if (!homeText.includes('CodexPro local bridge') || !homeText.includes('ChatGPT setup')) {
-    throw new Error('onboarding page did not include expected setup copy');
+  if (!homeText.includes('CodexPro Admin') || !homeText.includes('CLI controls') || !homeText.includes('Connect ChatGPT')) {
+    throw new Error('onboarding page did not include expected admin setup copy');
+  }
+  if (!homeText.includes('Connection profile') || !homeText.includes('data-profile-form')) {
+    throw new Error('onboarding page did not include the saved profile editor');
+  }
+  if (homeText.includes(token)) {
+    throw new Error('onboarding page leaked the raw auth token');
+  }
+
+  const profileBefore = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`);
+  const profileBeforeJson = await profileBefore.json();
+  if (profileBefore.status !== 200 || profileBeforeJson.exists !== false) {
+    throw new Error(`expected empty admin profile response, got ${profileBefore.status} ${JSON.stringify(profileBeforeJson)}`);
+  }
+  if (JSON.stringify(profileBeforeJson).includes(token)) {
+    throw new Error('admin profile GET leaked the raw auth token');
+  }
+
+  const invalidProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tunnel: 'ngrok',
+      hostname: 'codexpro-http-smoke.ngrok-free.app',
+      requireBashSession: true,
+      bashSession: ''
+    })
+  });
+  if (invalidProfile.status !== 400) {
+    throw new Error(`expected invalid guarded profile to return 400, got ${invalidProfile.status}`);
+  }
+
+  const profileSave = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tunnel: 'ngrok',
+      hostname: 'https://codexpro-http-smoke.ngrok-free.app/mcp',
+      port,
+      mode: 'agent',
+      bash: 'safe',
+      bashTranscript: 'full',
+      codexSessions: 'metadata',
+      codexDir: path.join(root, '.codex'),
+      bashSession: 'http-main',
+      requireBashSession: true,
+      write: 'workspace',
+      toolMode: 'full',
+      widgetDomain: 'https://widgets.codexpro.test',
+      ngrokConfig: path.join(root, 'ngrok.yml'),
+      cloudflareTokenFile: '~/.codexpro/cloudflare-tunnel-token'
+    })
+  });
+  const profileSaveJson = await profileSave.json();
+  if (profileSave.status !== 200 || profileSaveJson.saved !== true) {
+    throw new Error(`expected admin profile save to pass, got ${profileSave.status} ${JSON.stringify(profileSaveJson)}`);
+  }
+  if (JSON.stringify(profileSaveJson).includes(token)) {
+    throw new Error('admin profile save response leaked the raw auth token');
+  }
+  const savedProfile = JSON.parse(await fs.readFile(profileSaveJson.profile_path, 'utf8'));
+  if (
+    savedProfile.tunnel !== 'ngrok' ||
+    savedProfile.hostname !== 'codexpro-http-smoke.ngrok-free.app' ||
+    savedProfile.bashTranscript !== 'full' ||
+    savedProfile.codexSessions !== 'metadata' ||
+    savedProfile.bashSession !== 'http-main' ||
+    savedProfile.requireBashSession !== true ||
+    savedProfile.token !== token
+  ) {
+    throw new Error(`admin profile save wrote unexpected profile: ${JSON.stringify(savedProfile)}`);
   }
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -55,6 +55,22 @@ function waitForExit(child, timeoutMs = 5000) {
   });
 }
 
+async function waitForHealthJson(url, timeoutMs = 15000) {
+  const started = Date.now();
+  let lastError = '';
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return await response.json();
+      lastError = `${response.status} ${await response.text()}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`timeout waiting for ${url}\n${lastError}`);
+}
+
 async function expectHttpTokenRequired(name, overrides = {}) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), `codexpro-http-no-token-${name}-`));
   const port = await getFreePort();
@@ -393,6 +409,45 @@ try {
   await fs.stat(path.join(root, '.ai-bridge', 'pro-context.md'));
 } finally {
   child.kill('SIGTERM');
+}
+
+const cliRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-cli-http-smoke-'));
+await fs.mkdir(path.join(cliRoot, '.codex'), { recursive: true });
+const cliPort = await getFreePort();
+const cliChild = spawn(process.execPath, [
+  'scripts/codexpro.mjs',
+  'start',
+  '--root',
+  cliRoot,
+  '--tunnel',
+  'none',
+  '--no-auth',
+  '--port',
+  String(cliPort),
+  '--codex-sessions',
+  'metadata',
+  '--codex-dir',
+  '.codex'
+], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_HOME: await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-cli-http-home-'))
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+try {
+  await waitForHealthJson(`http://127.0.0.1:${cliPort}/healthz`);
+  const expectedCliCodexDir = path.join(await fs.realpath(cliRoot), '.codex');
+  await withClient(`http://127.0.0.1:${cliPort}/mcp`, async (client) => {
+    const config = await callTool(client, 'server_config');
+    if (config.structuredContent.codexDir !== expectedCliCodexDir) {
+      throw new Error(`relative --codex-dir resolved to ${config.structuredContent.codexDir}, expected ${expectedCliCodexDir}`);
+    }
+  });
+} finally {
+  cliChild.kill('SIGTERM');
+  await waitForExit(cliChild).catch(() => {});
 }
 
 console.log('✓ http smoke test passed');

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -63,6 +63,8 @@ const saved = run([
   'agent',
   '--tool-mode',
   'full',
+  '--bash-transcript',
+  'full',
   '--widget-domain',
   'https://widgets.codexpro.test',
   '--token',
@@ -73,7 +75,7 @@ if (!saved.includes('Saved workspace settings')) {
 }
 
 const shown = run(['settings', 'show', '--root', root], env);
-for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '19087', '<saved>']) {
+for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '19087', 'Bash transcript', 'full', '<saved>']) {
   if (!shown.includes(expected)) {
     throw new Error(`settings show missing ${expected}\n${shown}`);
   }
@@ -82,7 +84,7 @@ if (shown.includes('codexpro-settings-token')) {
   throw new Error(`settings show leaked token\n${shown}`);
 }
 const profile = await readProfile(root, home);
-if (profile.toolMode !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
+if (profile.toolMode !== 'full' || profile.bashTranscript !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
   throw new Error(`settings profile did not persist tool/widget options: ${JSON.stringify(profile)}`);
 }
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -79,6 +79,13 @@ await fs.writeFile(path.join(codexSessionDir, `rollout-2026-06-19T01-02-03-${old
   JSON.stringify({ timestamp: '2026-06-19T01:02:03Z', type: 'session_meta', payload: { id: olderCodexSessionId, cwd: tmp } }),
   JSON.stringify({ timestamp: '2026-06-19T01:02:04Z', type: 'response_item', payload: { type: 'message', role: 'user', content: 'Older session still readable by id' } })
 ].join('\n') + '\n', 'utf8');
+const largeCodexSessionId = '019cc367-aaaa-7333-8444-123456789def';
+await fs.writeFile(path.join(codexSessionDir, `rollout-2026-06-18T01-02-03-${largeCodexSessionId}.jsonl`), [
+  JSON.stringify({ timestamp: '2026-06-18T01:02:03Z', type: 'session_meta', payload: { id: largeCodexSessionId, cwd: tmp } }),
+  JSON.stringify({ timestamp: '2026-06-18T01:02:04Z', type: 'response_item', payload: { type: 'message', role: 'user', content: 'Large metadata session' } }),
+  JSON.stringify({ timestamp: '2026-06-18T01:02:05Z', type: 'response_item', payload: { type: 'function_call_output', output: 'x'.repeat(140000) } }),
+  JSON.stringify({ timestamp: '2026-06-18T01:02:06Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: 'Large tail summary' } })
+].join('\n') + '\n', 'utf8');
 await fs.mkdir(path.join(tmp, '.codex', 'skills', 'smoke-skill'), { recursive: true });
 await fs.writeFile(path.join(tmp, '.codex', 'skills', 'smoke-skill', 'SKILL.md'), [
   '---',
@@ -398,6 +405,32 @@ async function assertToolMode(mode, expected, hidden) {
 await assertToolMode('', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
 await assertToolMode('minimal', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
 
+const standardCodexSessionsClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_ROOT: tmp,
+    CODEXPRO_ALLOWED_ROOTS: tmp,
+    CODEXPRO_CODEX_SESSIONS: 'metadata',
+    CODEXPRO_CODEX_DIR: codexHistoryDir
+  }
+});
+await standardCodexSessionsClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-standard-codex-sessions-smoke', version: '0.1.0' }
+});
+standardCodexSessionsClient.notify('notifications/initialized');
+const standardCodexSessionTools = await standardCodexSessionsClient.request('tools/list', {});
+const standardCodexSessionToolNames = standardCodexSessionTools.tools.map((tool) => tool.name);
+if (!standardCodexSessionToolNames.includes('codex_sessions')) {
+  throw new Error(`standard mode with Codex sessions enabled missed codex_sessions: ${standardCodexSessionToolNames.join(', ')}`);
+}
+if (standardCodexSessionToolNames.includes('read_codex_session')) {
+  throw new Error(`metadata mode should not expose read_codex_session: ${standardCodexSessionToolNames.join(', ')}`);
+}
+standardCodexSessionsClient.close();
+
 const fullTranscriptClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'], {
   cwd: path.resolve('.'),
   env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_BASH_TRANSCRIPT: 'full' }
@@ -485,6 +518,11 @@ const olderCodexTranscript = await codexSessionsClient.request('tools/call', {
 });
 if (!olderCodexTranscript.content?.[0]?.text?.includes('Older session still readable by id')) {
   throw new Error(`read_codex_session only searched visible list window: ${olderCodexTranscript.content?.[0]?.text}`);
+}
+const largeTailSessions = await codexSessionsClient.request('tools/call', { name: 'codex_sessions', arguments: { query: 'Large tail summary', max_sessions: 5 } });
+const largeTailSession = largeTailSessions.structuredContent.sessions?.find?.((item) => item.session_id === largeCodexSessionId);
+if (!largeTailSession || largeTailSession.summary !== 'Large tail summary') {
+  throw new Error(`codex_sessions did not parse summary from bounded tail window: ${JSON.stringify(largeTailSessions.structuredContent)}`);
 }
 codexSessionsClient.close();
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -63,6 +63,22 @@ const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-smoke-'));
 await fs.writeFile(path.join(tmp, 'demo.txt'), 'alpha\nread\nread\nomega\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'config.txt'), 'OPENAI_API_KEY=sk-realSecretValue123\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'AGENTS.md'), '# Smoke Agents\n\n- Preserve demo.txt.\n', 'utf8');
+const codexHistoryDir = path.join(tmp, 'codex-history');
+const codexSessionDir = path.join(codexHistoryDir, 'sessions', '2026', '06', '20');
+await fs.mkdir(codexSessionDir, { recursive: true });
+const codexSessionPath = path.join(codexSessionDir, 'rollout-2026-06-20T01-02-03-019cc369-bd7c-7891-b371-7b20b4fe0b18.jsonl');
+await fs.writeFile(codexSessionPath, [
+  JSON.stringify({ timestamp: '2026-06-20T01:02:03Z', type: 'session_meta', payload: { id: '019cc369-bd7c-7891-b371-7b20b4fe0b18', cwd: tmp } }),
+  JSON.stringify({ timestamp: '2026-06-20T01:02:04Z', type: 'response_item', payload: { type: 'message', role: 'user', content: 'Fix the smoke session browser' } }),
+  JSON.stringify({ timestamp: '2026-06-20T01:02:05Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: 'Session browser plan.' } }),
+  JSON.stringify({ timestamp: '2026-06-20T01:02:06Z', type: 'response_item', payload: { type: 'function_call', name: 'bash' } }),
+  JSON.stringify({ timestamp: '2026-06-20T01:02:07Z', type: 'response_item', payload: { type: 'function_call_output', output: 'ok' } })
+].join('\n') + '\n', 'utf8');
+const olderCodexSessionId = '019cc368-1111-7222-8333-123456789abc';
+await fs.writeFile(path.join(codexSessionDir, `rollout-2026-06-19T01-02-03-${olderCodexSessionId}.jsonl`), [
+  JSON.stringify({ timestamp: '2026-06-19T01:02:03Z', type: 'session_meta', payload: { id: olderCodexSessionId, cwd: tmp } }),
+  JSON.stringify({ timestamp: '2026-06-19T01:02:04Z', type: 'response_item', payload: { type: 'message', role: 'user', content: 'Older session still readable by id' } })
+].join('\n') + '\n', 'utf8');
 await fs.mkdir(path.join(tmp, '.codex', 'skills', 'smoke-skill'), { recursive: true });
 await fs.writeFile(path.join(tmp, '.codex', 'skills', 'smoke-skill', 'SKILL.md'), [
   '---',
@@ -263,13 +279,20 @@ const codexContext = await client.request('tools/call', { name: 'codex_context',
 if (!codexContext.structuredContent.agents_files.includes('AGENTS.md')) throw new Error('codex_context did not include AGENTS.md');
 if (codexContext.structuredContent.agents_files.length !== 1) throw new Error(`codex_context returned duplicate AGENTS files: ${codexContext.structuredContent.agents_files.join(', ')}`);
 if (!codexContext.content?.[0]?.text?.includes('Smoke Agents')) throw new Error('codex_context did not include AGENTS.md content');
-await client.request('tools/call', { name: 'bash', arguments: { workspace_id: ws, command: 'pwd' } });
+const pwdBash = await client.request('tools/call', { name: 'bash', arguments: { workspace_id: ws, command: 'pwd' } });
+const pwdBashText = pwdBash.content?.[0]?.text ?? '';
+if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwdBashText.includes('## stderr')) {
+  throw new Error(`default bash transcript should be compact: ${pwdBashText}`);
+}
+if (!pwdBash.structuredContent.stdout?.includes(tmp)) {
+  throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
+}
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'find . -fprint leaked.txt' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'git show HEAD:.env' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'ls $HOME' }, /blocked/i);
 const clientBuild = await client.request('tools/call', { name: 'bash', arguments: { workspace_id: ws, command: 'npm run build:clients', timeout_ms: 60000 } });
-if (!clientBuild.content?.[0]?.text?.includes('clients ok')) {
+if (!clientBuild.structuredContent.stdout?.includes('clients ok')) {
   throw new Error('safe bash did not run npm run build:clients');
 }
 const exported = await client.request('tools/call', { name: 'export_pro_context', arguments: { workspace_id: ws, selected_paths: ['demo.txt'], max_files: 4, max_total_bytes: 80000 } });
@@ -374,6 +397,74 @@ async function assertToolMode(mode, expected, hidden) {
 
 await assertToolMode('', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
 await assertToolMode('minimal', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
+
+const fullTranscriptClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_BASH_TRANSCRIPT: 'full' }
+});
+await fullTranscriptClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-full-bash-transcript-smoke', version: '0.1.0' }
+});
+fullTranscriptClient.notify('notifications/initialized');
+const fullTranscriptBash = await fullTranscriptClient.request('tools/call', { name: 'bash', arguments: { command: 'pwd' } });
+const fullTranscriptText = fullTranscriptBash.content?.[0]?.text ?? '';
+if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(tmp)) {
+  throw new Error(`full bash transcript mode did not preserve raw stdout in chat text: ${fullTranscriptText}`);
+}
+fullTranscriptClient.close();
+
+const codexSessionsClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--tool-mode', 'full'], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_ROOT: tmp,
+    CODEXPRO_ALLOWED_ROOTS: tmp,
+    CODEXPRO_CODEX_SESSIONS: 'read',
+    CODEXPRO_CODEX_DIR: codexHistoryDir
+  }
+});
+await codexSessionsClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-codex-sessions-smoke', version: '0.1.0' }
+});
+codexSessionsClient.notify('notifications/initialized');
+const codexSessionTools = await codexSessionsClient.request('tools/list', {});
+const codexSessionToolNames = codexSessionTools.tools.map((tool) => tool.name);
+for (const expectedName of ['codex_sessions', 'read_codex_session']) {
+  if (!codexSessionToolNames.includes(expectedName)) {
+    throw new Error(`codex session opt-in mode missing ${expectedName}: ${codexSessionToolNames.join(', ')}`);
+  }
+}
+const codexSessions = await codexSessionsClient.request('tools/call', { name: 'codex_sessions', arguments: { max_sessions: 5 } });
+const session = codexSessions.structuredContent.sessions?.[0];
+if (!session || session.session_id !== '019cc369-bd7c-7891-b371-7b20b4fe0b18' || session.title !== 'Fix the smoke session browser' || session.project_dir !== tmp) {
+  throw new Error(`codex_sessions did not return parsed Codex metadata: ${JSON.stringify(codexSessions.structuredContent)}`);
+}
+if (session.resume_command !== 'codex resume 019cc369-bd7c-7891-b371-7b20b4fe0b18') {
+  throw new Error(`codex_sessions returned wrong resume command: ${JSON.stringify(session)}`);
+}
+const codexTranscript = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: { session_id: '019cc369-bd7c-7891-b371-7b20b4fe0b18', max_messages: 10 }
+});
+if (!codexTranscript.content?.[0]?.text?.includes('Fix the smoke session browser') || !codexTranscript.content?.[0]?.text?.includes('[Tool: bash]')) {
+  throw new Error(`read_codex_session did not return bounded transcript text: ${codexTranscript.content?.[0]?.text}`);
+}
+const topOneSessions = await codexSessionsClient.request('tools/call', { name: 'codex_sessions', arguments: { max_sessions: 1 } });
+if (topOneSessions.structuredContent.sessions?.some?.((item) => item.session_id === olderCodexSessionId)) {
+  throw new Error(`codex_sessions max_sessions did not limit visible results: ${JSON.stringify(topOneSessions.structuredContent)}`);
+}
+const olderCodexTranscript = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: { session_id: olderCodexSessionId, max_messages: 10 }
+});
+if (!olderCodexTranscript.content?.[0]?.text?.includes('Older session still readable by id')) {
+  throw new Error(`read_codex_session only searched visible list window: ${olderCodexTranscript.content?.[0]?.text}`);
+}
+codexSessionsClient.close();
 
 const sessionGuardClient = new McpStdioClient('node', [
   'dist/stdio.js',

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -415,6 +415,28 @@ if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(tm
 }
 fullTranscriptClient.close();
 
+const emptyCodexDirClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_ROOT: tmp,
+    CODEXPRO_ALLOWED_ROOTS: tmp,
+    CODEXPRO_CODEX_DIR: ''
+  }
+});
+await emptyCodexDirClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-empty-codex-dir-smoke', version: '0.1.0' }
+});
+emptyCodexDirClient.notify('notifications/initialized');
+const emptyCodexDirConfig = await emptyCodexDirClient.request('tools/call', { name: 'server_config', arguments: {} });
+const expectedDefaultCodexDir = path.join(os.homedir(), '.codex');
+if (emptyCodexDirConfig.structuredContent.codexDir !== expectedDefaultCodexDir) {
+  throw new Error(`empty CODEXPRO_CODEX_DIR resolved to ${emptyCodexDirConfig.structuredContent.codexDir}, expected ${expectedDefaultCodexDir}`);
+}
+emptyCodexDirClient.close();
+
 const codexSessionsClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--tool-mode', 'full'], {
   cwd: path.resolve('.'),
   env: {

--- a/src/codexSessions.ts
+++ b/src/codexSessions.ts
@@ -9,6 +9,8 @@ import { CodexProError } from "./guard.js";
 const CODEX_IDE_CONTEXT_PREFIX = "# Context from my IDE setup:";
 const CODEX_REQUEST_MARKER = "my request for codex";
 const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
+const META_HEAD_BYTES = 64 * 1024;
+const META_TAIL_BYTES = 64 * 1024;
 
 export interface CodexSessionMeta {
   provider_id: "codex";
@@ -85,16 +87,46 @@ async function collectJsonlFiles(root: string, files: string[], maxDepth: number
   }
 }
 
-async function readHeadTailLines(filePath: string, headLimit: number, tailLimit: number): Promise<{ head: string[]; tail: string[] }> {
-  const head: string[] = [];
-  const tail: string[] = [];
-  const rl = createInterface({ input: createReadStream(filePath, { encoding: "utf8" }), crlfDelay: Infinity });
-  for await (const line of rl) {
-    if (head.length < headLimit) head.push(line);
-    tail.push(line);
-    if (tail.length > tailLimit) tail.shift();
+async function readFileSlice(filePath: string, start: number, length: number): Promise<string> {
+  if (length <= 0) return "";
+  const handle = await fsp.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, start);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
   }
-  return { head, tail };
+}
+
+function splitJsonlLines(text: string): string[] {
+  return text.split(/\r?\n/).filter((line) => line.length > 0);
+}
+
+async function readHeadTailLines(filePath: string, headLimit: number, tailLimit: number): Promise<{ head: string[]; tail: string[] }> {
+  const fileStat = await fsp.stat(filePath);
+  const headLength = Math.min(fileStat.size, META_HEAD_BYTES);
+  const tailOffset = Math.max(0, fileStat.size - META_TAIL_BYTES);
+  const tailLength = fileStat.size - tailOffset;
+  const [headText, tailText] = await Promise.all([
+    readFileSlice(filePath, 0, headLength),
+    tailOffset === 0 && tailLength === headLength ? Promise.resolve("") : readFileSlice(filePath, tailOffset, tailLength)
+  ]);
+
+  const headLines = splitJsonlLines(headText);
+  if (headLength < fileStat.size && !headText.endsWith("\n")) headLines.pop();
+
+  const tailSource = tailText
+    ? tailOffset > 0
+      ? tailText.slice(Math.max(0, tailText.indexOf("\n") + 1))
+      : tailText
+    : headText;
+  const tailLines = splitJsonlLines(tailSource);
+
+  return {
+    head: headLines.slice(0, headLimit),
+    tail: tailLines.slice(-tailLimit)
+  };
 }
 
 function parseTimestamp(value: unknown): number | undefined {

--- a/src/codexSessions.ts
+++ b/src/codexSessions.ts
@@ -1,0 +1,378 @@
+import { createReadStream, statSync, type Dirent } from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import type { CodexProConfig } from "./config.js";
+import { CodexProError } from "./guard.js";
+
+const CODEX_IDE_CONTEXT_PREFIX = "# Context from my IDE setup:";
+const CODEX_REQUEST_MARKER = "my request for codex";
+const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
+
+export interface CodexSessionMeta {
+  provider_id: "codex";
+  session_id: string;
+  title?: string;
+  summary?: string;
+  project_dir?: string;
+  created_at?: number;
+  last_active_at?: number;
+  source_path: string;
+  resume_command: string;
+}
+
+export interface CodexSessionMessage {
+  role: string;
+  content: string;
+  ts?: number;
+}
+
+export interface CodexSessionListResult {
+  codex_dir: string;
+  roots: string[];
+  sessions: CodexSessionMeta[];
+  total_found: number;
+}
+
+export interface CodexSessionReadResult {
+  session: CodexSessionMeta;
+  messages: CodexSessionMessage[];
+  truncated: boolean;
+  text: string;
+}
+
+function codexDir(config: CodexProConfig): string {
+  return path.resolve(config.codexDir || path.join(os.homedir(), ".codex"));
+}
+
+function sessionRoots(config: CodexProConfig): string[] {
+  const root = codexDir(config);
+  return [path.join(root, "sessions"), path.join(root, "archived_sessions")];
+}
+
+function ensureEnabled(config: CodexProConfig, read = false): void {
+  if (config.codexSessions === "off") {
+    throw new CodexProError("Codex session tools are disabled. Start with --codex-sessions metadata or --codex-sessions read to opt in.");
+  }
+  if (read && config.codexSessions !== "read") {
+    throw new CodexProError("Reading Codex session transcripts is disabled. Start with --codex-sessions read to opt in.");
+  }
+}
+
+function isSubpath(child: string, parent: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function collectJsonlFiles(root: string, files: string[], maxDepth: number, maxFiles: number, depth = 0): Promise<void> {
+  if (depth > maxDepth || files.length >= maxFiles) return;
+  let entries: Dirent[];
+  try {
+    entries = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (files.length >= maxFiles) return;
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      await collectJsonlFiles(fullPath, files, maxDepth, maxFiles, depth + 1);
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      files.push(fullPath);
+    }
+  }
+}
+
+async function readHeadTailLines(filePath: string, headLimit: number, tailLimit: number): Promise<{ head: string[]; tail: string[] }> {
+  const head: string[] = [];
+  const tail: string[] = [];
+  const rl = createInterface({ input: createReadStream(filePath, { encoding: "utf8" }), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (head.length < headLimit) head.push(line);
+    tail.push(line);
+    if (tail.length > tailLimit) tail.shift();
+  }
+  return { head, tail };
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (typeof item === "string") return item;
+      if (item && typeof item === "object" && "text" in item) return String((item as { text?: unknown }).text ?? "");
+      return "";
+    }).filter(Boolean).join("\n");
+  }
+  if (value && typeof value === "object" && "text" in value) {
+    return String((value as { text?: unknown }).text ?? "");
+  }
+  return "";
+}
+
+function truncate(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function basename(value?: string): string | undefined {
+  if (!value) return undefined;
+  const cleaned = value.replace(/[\\/]+$/, "");
+  const base = path.basename(cleaned);
+  return base || undefined;
+}
+
+function codexRequestHeadingPayload(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("#")) return null;
+  const heading = trimmed.replace(/^#+\s*/, "");
+  const lowered = heading.toLowerCase();
+  if (!lowered.startsWith(CODEX_REQUEST_MARKER)) return null;
+  const suffix = heading.slice(CODEX_REQUEST_MARKER.length).trimStart();
+  if (!suffix) return "";
+  if (!/^[:：\-—]/.test(suffix)) return null;
+  return suffix.replace(/^[:：\-—\s]+/, "").trim();
+}
+
+function extractCodexPromptFromIdeContext(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith(CODEX_IDE_CONTEXT_PREFIX)) return undefined;
+  const lines = trimmed.replace(/\r\n/g, "\n").split("\n");
+  let prompt: string | undefined;
+  for (const [index, line] of lines.entries()) {
+    const inline = codexRequestHeadingPayload(line);
+    if (inline === null) continue;
+    if (inline) {
+      prompt = inline;
+      continue;
+    }
+    const following = lines.slice(index + 1).join("\n").trim();
+    prompt = following || undefined;
+  }
+  return prompt;
+}
+
+function titleCandidateFromUserMessage(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.startsWith("# AGENTS.md") || trimmed.startsWith("<environment_context>")) return undefined;
+  if (trimmed.startsWith(CODEX_IDE_CONTEXT_PREFIX)) return extractCodexPromptFromIdeContext(trimmed);
+  return trimmed;
+}
+
+function inferSessionIdFromFilename(filePath: string): string | undefined {
+  const match = path.basename(filePath).match(UUID_RE);
+  return match?.[0];
+}
+
+function parseJsonLine(line: string): any | undefined {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+}
+
+function isSubagentSource(payload: any): boolean {
+  return Boolean(payload?.source && typeof payload.source === "object" && "subagent" in payload.source);
+}
+
+async function parseSessionMeta(filePath: string): Promise<CodexSessionMeta | undefined> {
+  const { head, tail } = await readHeadTailLines(filePath, 16, 48);
+  let sessionId: string | undefined;
+  let projectDir: string | undefined;
+  let createdAt: number | undefined;
+  let firstUserMessage: string | undefined;
+
+  for (const line of head) {
+    const value = parseJsonLine(line);
+    if (!value) continue;
+    createdAt ??= parseTimestamp(value.timestamp);
+    if (value.type === "session_meta" && value.payload) {
+      if (isSubagentSource(value.payload)) return undefined;
+      sessionId ??= value.payload.id || value.payload.session_id || value.payload.sessionId;
+      projectDir ??= value.payload.cwd || value.payload.project_dir || value.payload.projectDir;
+      createdAt ??= parseTimestamp(value.payload.timestamp);
+    }
+    if (!firstUserMessage && value.type === "response_item" && value.payload?.type === "message" && value.payload?.role === "user") {
+      const text = extractText(value.payload.content);
+      firstUserMessage = titleCandidateFromUserMessage(text);
+    }
+  }
+
+  let lastActiveAt: number | undefined;
+  let summary: string | undefined;
+  for (const line of [...tail].reverse()) {
+    const value = parseJsonLine(line);
+    if (!value) continue;
+    lastActiveAt ??= parseTimestamp(value.timestamp);
+    if (!summary && value.type === "response_item" && value.payload?.type === "message") {
+      const text = extractText(value.payload.content);
+      if (text.trim()) summary = text;
+    }
+    if (lastActiveAt && summary) break;
+  }
+
+  const id = String(sessionId || inferSessionIdFromFilename(filePath) || "").trim();
+  if (!id) return undefined;
+  const title = firstUserMessage ? truncate(firstUserMessage, 96) : basename(projectDir);
+
+  return {
+    provider_id: "codex",
+    session_id: id,
+    ...(title ? { title } : {}),
+    ...(summary ? { summary: truncate(summary, 180) } : {}),
+    ...(projectDir ? { project_dir: projectDir } : {}),
+    ...(createdAt ? { created_at: createdAt } : {}),
+    ...(lastActiveAt ? { last_active_at: lastActiveAt } : {}),
+    source_path: filePath,
+    resume_command: `codex resume ${id}`
+  };
+}
+
+async function collectSessionMetas(config: CodexProConfig): Promise<CodexSessionMeta[]> {
+  const files: string[] = [];
+  for (const root of sessionRoots(config)) {
+    await collectJsonlFiles(root, files, 6, 3000);
+  }
+
+  const sessions: CodexSessionMeta[] = [];
+  for (const file of files) {
+    const meta = await parseSessionMeta(file);
+    if (meta) sessions.push(meta);
+  }
+  return sessions;
+}
+
+export async function listCodexSessions(
+  config: CodexProConfig,
+  options: { maxSessions?: number; query?: string } = {}
+): Promise<CodexSessionListResult> {
+  ensureEnabled(config);
+  const roots = sessionRoots(config);
+  const sessions = await collectSessionMetas(config);
+
+  const query = options.query?.trim().toLowerCase();
+  const filtered = query
+    ? sessions.filter((session) => [
+        session.session_id,
+        session.title,
+        session.summary,
+        session.project_dir,
+        session.source_path
+      ].filter(Boolean).join("\n").toLowerCase().includes(query))
+    : sessions;
+
+  filtered.sort((a, b) => (b.last_active_at ?? b.created_at ?? 0) - (a.last_active_at ?? a.created_at ?? 0));
+  const maxSessions = Math.max(1, Math.min(Number(options.maxSessions ?? 30), 200));
+  return {
+    codex_dir: codexDir(config),
+    roots,
+    sessions: filtered.slice(0, maxSessions),
+    total_found: filtered.length
+  };
+}
+
+async function resolveSessionSource(config: CodexProConfig, sessionId?: string, sourcePath?: string): Promise<CodexSessionMeta> {
+  ensureEnabled(config, true);
+  const roots = sessionRoots(config).map((root) => path.resolve(root));
+
+  if (sourcePath) {
+    const resolved = path.resolve(sourcePath);
+    const canonical = await fsp.realpath(resolved).catch(() => resolved);
+    if (!roots.some((root) => isSubpath(canonical, root))) {
+      throw new CodexProError("Codex session source_path is outside configured Codex session roots.");
+    }
+    const meta = await parseSessionMeta(canonical);
+    if (!meta) throw new CodexProError("Could not parse Codex session metadata from source_path.");
+    if (sessionId && meta.session_id !== sessionId) throw new CodexProError("Codex session id does not match source_path.");
+    return meta;
+  }
+
+  if (!sessionId) throw new CodexProError("session_id or source_path is required.");
+  const sessions = await collectSessionMetas(config);
+  const match = sessions.find((session) => session.session_id === sessionId);
+  if (!match) throw new CodexProError(`Codex session not found: ${sessionId}`);
+  return match;
+}
+
+async function loadSessionMessages(filePath: string, maxMessages: number, maxTotalBytes: number): Promise<{ messages: CodexSessionMessage[]; truncated: boolean }> {
+  const size = statSync(filePath).size;
+  if (size > 20_000_000) {
+    throw new CodexProError(`Codex session file is too large (${size} bytes).`);
+  }
+
+  const messages: CodexSessionMessage[] = [];
+  let usedBytes = 0;
+  let truncated = false;
+  const rl = createInterface({ input: createReadStream(filePath, { encoding: "utf8" }), crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    const value = parseJsonLine(line);
+    if (value?.type !== "response_item" || !value.payload) continue;
+    const payload = value.payload;
+    let role = "";
+    let content = "";
+    if (payload.type === "message") {
+      role = String(payload.role || "unknown");
+      content = extractText(payload.content);
+    } else if (payload.type === "function_call") {
+      role = "assistant";
+      content = `[Tool: ${payload.name || "unknown"}]`;
+    } else if (payload.type === "function_call_output") {
+      role = "tool";
+      content = String(payload.output || "");
+    } else {
+      continue;
+    }
+    if (!content.trim()) continue;
+    const nextBytes = Buffer.byteLength(content, "utf8");
+    if (messages.length >= maxMessages || usedBytes + nextBytes > maxTotalBytes) {
+      truncated = true;
+      break;
+    }
+    usedBytes += nextBytes;
+    const ts = parseTimestamp(value.timestamp);
+    messages.push({ role, content, ...(ts !== undefined ? { ts } : {}) });
+  }
+
+  return { messages, truncated };
+}
+
+export async function readCodexSession(
+  config: CodexProConfig,
+  options: { sessionId?: string; sourcePath?: string; maxMessages?: number; maxTotalBytes?: number } = {}
+): Promise<CodexSessionReadResult> {
+  const session = await resolveSessionSource(config, options.sessionId, options.sourcePath);
+  const maxMessages = Math.max(1, Math.min(Number(options.maxMessages ?? 80), 400));
+  const maxTotalBytes = Math.max(4_000, Math.min(Number(options.maxTotalBytes ?? 80_000), 400_000));
+  const { messages, truncated } = await loadSessionMessages(session.source_path, maxMessages, maxTotalBytes);
+  const transcript = messages.map((message) => {
+    const when = message.ts ? ` ${new Date(message.ts).toISOString()}` : "";
+    return `### ${message.role}${when}\n\n${message.content}`;
+  }).join("\n\n");
+  const text = [
+    "# Codex Session",
+    "",
+    `Session: ${session.session_id}`,
+    session.title ? `Title: ${session.title}` : "",
+    session.project_dir ? `CWD: ${session.project_dir}` : "",
+    `Source: ${session.source_path}`,
+    `Resume: ${session.resume_command}`,
+    truncated ? "Transcript truncated by configured limits." : "",
+    "",
+    "## Transcript",
+    "",
+    transcript || "No readable transcript messages found."
+  ].filter((line) => line !== "").join("\n");
+  return { session, messages, truncated, text };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 
 export type BashMode = "off" | "safe" | "full";
+export type BashTranscriptMode = "compact" | "full";
+export type CodexSessionsMode = "off" | "metadata" | "read";
 export type WriteMode = "off" | "handoff" | "workspace";
 export type ToolMode = "minimal" | "standard" | "full";
 
@@ -15,8 +17,11 @@ export interface CodexProConfig {
   authToken?: string;
   requireHttpToken: boolean;
   bashMode: BashMode;
+  bashTranscript: BashTranscriptMode;
   bashSessionId?: string;
   requireBashSession: boolean;
+  codexSessions: CodexSessionsMode;
+  codexDir: string;
   writeMode: WriteMode;
   toolMode: ToolMode;
   inheritEnv: boolean;
@@ -142,6 +147,17 @@ function bashModeFrom(value: string | undefined): BashMode {
   return "safe";
 }
 
+function bashTranscriptFrom(value: string | undefined): BashTranscriptMode {
+  if (value === "compact" || value === "full") return value;
+  return "compact";
+}
+
+function codexSessionsFrom(value: string | undefined): CodexSessionsMode {
+  if (value === "metadata" || value === "read") return value;
+  if (value === "1" || value === "true" || value === "yes" || value === "on") return "metadata";
+  return "off";
+}
+
 function bashSessionIdFrom(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
@@ -211,7 +227,10 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
   const portArg = typeof args.port === "string" ? args.port : undefined;
   const hostArg = typeof args.host === "string" ? args.host : undefined;
   const bashArg = typeof args.bash === "string" ? args.bash : undefined;
+  const bashTranscriptArg = typeof args["bash-transcript"] === "string" ? args["bash-transcript"] : undefined;
   const bashSessionArg = typeof args["bash-session"] === "string" ? args["bash-session"] : undefined;
+  const codexSessionsArg = typeof args["codex-sessions"] === "string" ? args["codex-sessions"] : undefined;
+  const codexDirArg = typeof args["codex-dir"] === "string" ? args["codex-dir"] : undefined;
   const requireBashSessionArg =
     args["require-bash-session"] === true
       ? "true"
@@ -244,8 +263,11 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     authToken,
     requireHttpToken,
     bashMode: bashModeFrom(bashArg ?? process.env.CODEXPRO_BASH_MODE),
+    bashTranscript: bashTranscriptFrom(bashTranscriptArg ?? process.env.CODEXPRO_BASH_TRANSCRIPT),
     bashSessionId,
     requireBashSession,
+    codexSessions: codexSessionsFrom(codexSessionsArg ?? process.env.CODEXPRO_CODEX_SESSIONS),
+    codexDir: expandHome(codexDirArg ?? process.env.CODEXPRO_CODEX_DIR ?? path.join(os.homedir(), ".codex")),
     writeMode: writeModeFrom(writeArg ?? process.env.CODEXPRO_WRITE_MODE),
     toolMode: toolModeFrom(toolModeArg ?? process.env.CODEXPRO_TOOL_MODE),
     inheritEnv: process.env.CODEXPRO_INHERIT_ENV === "1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -267,7 +267,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     bashSessionId,
     requireBashSession,
     codexSessions: codexSessionsFrom(codexSessionsArg ?? process.env.CODEXPRO_CODEX_SESSIONS),
-    codexDir: expandHome(codexDirArg ?? process.env.CODEXPRO_CODEX_DIR ?? path.join(os.homedir(), ".codex")),
+    codexDir: expandHome(codexDirArg || process.env.CODEXPRO_CODEX_DIR || path.join(os.homedir(), ".codex")),
     writeMode: writeModeFrom(writeArg ?? process.env.CODEXPRO_WRITE_MODE),
     toolMode: toolModeFrom(toolModeArg ?? process.env.CODEXPRO_TOOL_MODE),
     inheritEnv: process.env.CODEXPRO_INHERIT_ENV === "1",

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import { timingSafeEqual } from "node:crypto";
-import express from "express";
+import express, { type NextFunction, type Request, type Response } from "express";
 import cors from "cors";
+import { z } from "zod";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { loadConfig, type CodexProConfig } from "./config.js";
+import {
+  profilePathForRoot,
+  readRuntimeConnection,
+  readWorkspaceProfile,
+  sanitizeWorkspaceProfile,
+  saveWorkspaceProfile,
+  type ConnectorMode,
+  type TunnelMode,
+  type WorkspaceProfile
+} from "./profileStore.js";
 import { createCodexProServer } from "./server.js";
 
 function escapeHtml(value: unknown): string {
@@ -16,229 +27,1337 @@ function escapeHtml(value: unknown): string {
     .replaceAll('"', "&quot;");
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function copyCommand(title: string, description: string, command: string, displayCommand = command, copyKind = ""): string {
+  const copyAttrs = copyKind
+    ? `data-copy-kind="${escapeHtml(copyKind)}" data-copy-base="${escapeHtml(command)}"`
+    : `data-copy="${escapeHtml(command)}"`;
+  return `<div class="control">
+    <div>
+      <strong>${escapeHtml(title)}</strong>
+      <p>${escapeHtml(description)}</p>
+      <code>${escapeHtml(displayCommand)}</code>
+    </div>
+    <button type="button" class="copy-mini" ${copyAttrs}>Copy</button>
+  </div>`;
+}
+
+const TUNNELS = ["cloudflare", "ngrok", "cloudflare-named", "none"] as const;
+const MODES = ["agent", "handoff", "pro"] as const;
+const BASH_MODES = ["safe", "off", "full"] as const;
+const BASH_TRANSCRIPTS = ["compact", "full"] as const;
+const CODEX_SESSIONS = ["off", "metadata", "read"] as const;
+const WRITE_MODES = ["workspace", "handoff", "off"] as const;
+const TOOL_MODES = ["standard", "minimal", "full"] as const;
+
+const textField = (max: number) =>
+  z.preprocess((value) => (typeof value === "string" ? value.trim() : value), z.string().max(max).optional());
+
+const AdminProfilePatch = z.object({
+  tunnel: z.enum(TUNNELS).optional(),
+  hostname: textField(253),
+  port: z.coerce.number().int().min(1).max(65535).optional(),
+  mode: z.enum(MODES).optional(),
+  bash: z.enum(BASH_MODES).optional(),
+  bashTranscript: z.enum(BASH_TRANSCRIPTS).optional(),
+  codexSessions: z.enum(CODEX_SESSIONS).optional(),
+  codexDir: textField(4096),
+  bashSession: textField(64).refine(
+    (value) => !value || /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(value),
+    "bashSession must be 1-64 characters using letters, numbers, dot, underscore, or dash, and must start with a letter or number."
+  ),
+  requireBashSession: z.boolean().optional(),
+  write: z.enum(WRITE_MODES).optional(),
+  toolMode: z.enum(TOOL_MODES).optional(),
+  widgetDomain: textField(2048),
+  tunnelName: textField(128),
+  ngrokConfig: textField(4096),
+  cloudflareConfig: textField(4096),
+  cloudflareTokenFile: textField(4096),
+  noInstallCloudflared: z.boolean().optional()
+}).strict();
+
+type AdminProfilePatch = z.infer<typeof AdminProfilePatch>;
+
+interface ProfileFormValues {
+  port: string;
+  mode: ConnectorMode;
+  tunnel: TunnelMode;
+  hostname: string;
+  tunnelName: string;
+  ngrokConfig: string;
+  cloudflareConfig: string;
+  cloudflareTokenFile: string;
+  bash: "off" | "safe" | "full";
+  bashTranscript: "compact" | "full";
+  codexSessions: "off" | "metadata" | "read";
+  codexDir: string;
+  bashSession: string;
+  requireBashSession: boolean;
+  write: "off" | "handoff" | "workspace";
+  toolMode: "minimal" | "standard" | "full";
+  widgetDomain: string;
+  noInstallCloudflared: boolean;
+}
+
+function oneOf<T extends readonly string[]>(value: unknown, values: T, fallback: T[number]): T[number] {
+  return typeof value === "string" && values.includes(value) ? value : fallback;
+}
+
+function runtimeTunnelFallback(): TunnelMode {
+  if (process.env.CODEXPRO_TUNNEL && TUNNELS.includes(process.env.CODEXPRO_TUNNEL as TunnelMode)) {
+    return process.env.CODEXPRO_TUNNEL as TunnelMode;
+  }
+  return process.env.CODEXPRO_TUNNEL_MODE === "0" ? "none" : "cloudflare";
+}
+
+function normalizePublicHostname(value: string | undefined): string {
+  const raw = value?.trim().replace(/\/+$/, "") ?? "";
+  if (!raw) return "";
+  const url = new URL(raw.includes("://") ? raw : `https://${raw}`);
+  if (url.protocol !== "https:") throw new Error("hostname must use https when a scheme is provided.");
+  if (url.search || url.hash) throw new Error("hostname must not include query strings or fragments.");
+  if (url.pathname !== "/" && url.pathname !== "/mcp") throw new Error("hostname must be a host, URL root, or /mcp URL.");
+  return url.host;
+}
+
+function normalizeWidgetDomain(value: string | undefined): string {
+  const raw = value?.trim() ?? "";
+  if (!raw) return "";
+  const url = new URL(raw);
+  if (url.protocol !== "https:") throw new Error("widgetDomain must use https.");
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error("widgetDomain must be an origin only, for example https://widgets.example.com.");
+  }
+  return url.origin;
+}
+
+function profileValues(config: CodexProConfig, profile = readWorkspaceProfile(config.defaultRoot)): ProfileFormValues {
+  const hostname =
+    profile.hostname ??
+    process.env.CODEXPRO_PUBLIC_HOSTNAME ??
+    process.env.CODEXPRO_HOSTNAME ??
+    process.env.NGROK_DOMAIN ??
+    "";
+  return {
+    port: String(profile.port ?? config.port),
+    mode: oneOf(profile.mode ?? process.env.CODEXPRO_MODE, MODES, "agent"),
+    tunnel: oneOf(profile.tunnel, TUNNELS, runtimeTunnelFallback()),
+    hostname: String(hostname),
+    tunnelName: String(profile.tunnelName ?? ""),
+    ngrokConfig: String(profile.ngrokConfig ?? ""),
+    cloudflareConfig: String(profile.cloudflareConfig ?? ""),
+    cloudflareTokenFile: String(profile.cloudflareTokenFile ?? ""),
+    bash: oneOf(profile.bash ?? config.bashMode, BASH_MODES, config.bashMode),
+    bashTranscript: oneOf(profile.bashTranscript ?? config.bashTranscript, BASH_TRANSCRIPTS, config.bashTranscript),
+    codexSessions: oneOf(profile.codexSessions ?? config.codexSessions, CODEX_SESSIONS, config.codexSessions),
+    codexDir: String(profile.codexDir ?? config.codexDir),
+    bashSession: String(profile.bashSession ?? config.bashSessionId ?? ""),
+    requireBashSession: Boolean(profile.requireBashSession ?? config.requireBashSession),
+    write: oneOf(profile.write ?? config.writeMode, WRITE_MODES, config.writeMode),
+    toolMode: oneOf(profile.toolMode ?? config.toolMode, TOOL_MODES, config.toolMode),
+    widgetDomain: String(profile.widgetDomain ?? config.widgetDomain),
+    noInstallCloudflared: Boolean(profile.noInstallCloudflared)
+  };
+}
+
+const OPTION_LABELS: Record<string, string> = {
+  cloudflare: "Cloudflare quick tunnel",
+  ngrok: "ngrok stable URL",
+  "cloudflare-named": "Cloudflare named tunnel",
+  none: "Local only",
+  agent: "Agent",
+  handoff: "Handoff",
+  pro: "Pro bundle",
+  safe: "Safe",
+  off: "Off",
+  full: "Full",
+  compact: "Compact",
+  metadata: "Metadata",
+  read: "Read",
+  workspace: "Workspace",
+  minimal: "Minimal",
+  standard: "Standard"
+};
+
+function optionLabel(value: string): string {
+  return OPTION_LABELS[value] ?? value;
+}
+
+function selectOptions(values: readonly string[], current: string): string {
+  return values
+    .map((value) => `<option value="${escapeHtml(value)}"${value === current ? " selected" : ""}>${escapeHtml(optionLabel(value))}</option>`)
+    .join("");
+}
+
+function serverUrlDisplay(endpoint: string | undefined, authEnabled: boolean): string {
+  if (!endpoint) return "";
+  if (!authEnabled) return endpoint;
+  const glue = endpoint.includes("?") ? "&" : "?";
+  return `${endpoint}${glue}codexpro_token=<redacted>`;
+}
+
+function currentTunnelMessage(tunnel: TunnelMode, endpoint: string): string {
+  if (endpoint) {
+    if (tunnel === "cloudflare") return "Cloudflare generated this URL for the current run. Quick tunnel URLs change after restart.";
+    if (tunnel === "ngrok") return "ngrok is using the saved public hostname for this run.";
+    if (tunnel === "cloudflare-named") return "Cloudflare named tunnel is using the saved public hostname for this run.";
+    return "Local-only endpoint for clients that can reach this machine.";
+  }
+  if (tunnel === "cloudflare") return "Cloudflare quick tunnels print a generated URL after the tunnel opens.";
+  if (tunnel === "ngrok") return "Enter your reserved ngrok domain, or set NGROK_DOMAIN before starting CodexPro.";
+  if (tunnel === "cloudflare-named") return "Enter the Cloudflare hostname routed to your named tunnel.";
+  return "No public tunnel is saved; local MCP clients can use the local URL.";
+}
+
+function profileForm(config: CodexProConfig): string {
+  const profile = readWorkspaceProfile(config.defaultRoot);
+  const values = profileValues(config, profile);
+  const runtime = readRuntimeConnection(config.defaultRoot);
+  const profilePath = profile.profilePath ?? profilePathForRoot(config.defaultRoot);
+  const savedLabel = profile.profilePath ? "saved" : "not saved yet";
+  const runtimeEndpoint = typeof runtime.endpoint === "string" ? runtime.endpoint : "";
+  const runtimeTunnel = oneOf(runtime.tunnel ?? values.tunnel, TUNNELS, values.tunnel);
+  const runtimeUrl = serverUrlDisplay(runtimeEndpoint, Boolean(config.authToken));
+  const savedEndpoint = values.hostname ? `https://${values.hostname}/mcp` : "";
+  const savedUrl = serverUrlDisplay(savedEndpoint, Boolean(config.authToken));
+  const ngrokHostname = process.env.NGROK_DOMAIN ?? (values.tunnel === "ngrok" ? values.hostname : "");
+  const cloudflareHostname =
+    process.env.CODEXPRO_PUBLIC_HOSTNAME ??
+    process.env.CODEXPRO_HOSTNAME ??
+    (values.tunnel === "cloudflare-named" ? values.hostname : "");
+  const currentUrlBlock = runtimeUrl
+    ? `<div class="current-url">
+        <div>
+          <span>Current Server URL</span>
+          <code>${escapeHtml(runtimeUrl)}</code>
+          <p>${escapeHtml(currentTunnelMessage(runtimeTunnel, runtimeEndpoint))}</p>
+        </div>
+        <button type="button" class="copy-mini" data-copy-kind="server-url" data-copy-base="${escapeHtml(runtimeEndpoint)}">Copy</button>
+      </div>`
+    : `<div class="current-url idle">
+        <div>
+          <span>${savedUrl ? "Saved Server URL preview" : "Current Server URL"}</span>
+          <code>${savedUrl ? escapeHtml(savedUrl) : "No public URL detected for this run"}</code>
+          <p>${escapeHtml(savedUrl ? "This is based on the saved hostname. It becomes current after the launcher starts that tunnel." : currentTunnelMessage(values.tunnel, ""))}</p>
+        </div>
+        ${savedEndpoint ? `<button type="button" class="copy-mini" data-copy-kind="server-url" data-copy-base="${escapeHtml(savedEndpoint)}">Copy</button>` : ""}
+      </div>`;
+  return `<section class="panel profile-panel" id="profile">
+      <div class="section-head">
+        <div>
+          <h2>Connection profile</h2>
+          <p>Use this for the next start. Current tunnel URLs appear here when the launcher knows them.</p>
+        </div>
+        <span class="pill ${profile.profilePath ? "" : "warn"}">${escapeHtml(savedLabel)}</span>
+      </div>
+      <form class="profile-form" data-profile-form>
+        ${currentUrlBlock}
+        <fieldset class="profile-group">
+          <legend>Connection</legend>
+          <p>Choose how ChatGPT reaches this local MCP server. Stable providers use the saved hostname; quick Cloudflare generates the URL at launch.</p>
+          <div class="form-grid">
+            <label><span>Tunnel</span><select name="tunnel" data-tunnel-select data-ngrok-hostname="${escapeHtml(ngrokHostname)}" data-cloudflare-hostname="${escapeHtml(cloudflareHostname)}">${selectOptions(TUNNELS, values.tunnel)}</select></label>
+            <label><span>Public hostname</span><input name="hostname" value="${escapeHtml(values.hostname)}" data-hostname-input data-autofilled="0"></label>
+            <label><span>Port</span><input name="port" type="number" min="1" max="65535" value="${escapeHtml(values.port)}"></label>
+            <label><span>Mode</span><select name="mode">${selectOptions(MODES, values.mode)}</select></label>
+          </div>
+          <p class="field-help" data-hostname-help>${escapeHtml(currentTunnelMessage(values.tunnel, runtimeEndpoint))}</p>
+        </fieldset>
+        <fieldset class="profile-group">
+          <legend>Runtime policy</legend>
+          <p>Save the default access level for the next launch. These settings do not mutate the process that is already running.</p>
+          <div class="form-grid">
+            <label><span>Bash</span><select name="bash">${selectOptions(BASH_MODES, values.bash)}</select></label>
+            <label><span>Write mode</span><select name="write">${selectOptions(WRITE_MODES, values.write)}</select></label>
+            <label><span>Tool mode</span><select name="toolMode">${selectOptions(TOOL_MODES, values.toolMode)}</select></label>
+            <label><span>Codex sessions</span><select name="codexSessions">${selectOptions(CODEX_SESSIONS, values.codexSessions)}</select></label>
+            <label><span>Codex directory</span><input name="codexDir" value="${escapeHtml(values.codexDir)}"></label>
+            <label><span>Bash session</span><input name="bashSession" value="${escapeHtml(values.bashSession)}"></label>
+          </div>
+          <label class="check-row"><input name="requireBashSession" type="checkbox" value="true"${values.requireBashSession ? " checked" : ""}><span>Require matching bash session id</span></label>
+        </fieldset>
+        <fieldset class="profile-group readonly-group">
+          <legend>Read-only this run</legend>
+          <div class="readonly-grid">
+            <div><span>Bash transcript</span><code>${escapeHtml(values.bashTranscript)}</code></div>
+            <div><span>Widget origin</span><code>${escapeHtml(values.widgetDomain)}</code></div>
+          </div>
+        </fieldset>
+        <div class="actions">
+          <button type="submit" class="primary">Save profile</button>
+          <span class="mono">${escapeHtml(profilePath)}</span>
+        </div>
+        <p class="note" data-profile-status>Tokens stay hidden. Restart CodexPro for saved profile changes to apply.</p>
+      </form>
+    </section>`;
+}
+
+function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile, input: AdminProfilePatch): WorkspaceProfile {
+  const current = profileValues(config, existing);
+  const next: ProfileFormValues = {
+    ...current,
+    ...input,
+    port: input.port ? String(input.port) : current.port,
+    requireBashSession: input.requireBashSession ?? current.requireBashSession,
+    noInstallCloudflared: input.noInstallCloudflared ?? current.noInstallCloudflared
+  };
+  next.hostname = normalizePublicHostname(next.hostname);
+  next.widgetDomain = normalizeWidgetDomain(next.widgetDomain);
+  if ((next.tunnel === "ngrok" || next.tunnel === "cloudflare-named") && !next.hostname) {
+    throw new Error("hostname is required for ngrok and cloudflare-named profiles.");
+  }
+  if (next.requireBashSession && !next.bashSession) {
+    throw new Error("requireBashSession requires a bashSession value.");
+  }
+
+  const token = typeof existing.token === "string" && existing.token ? existing.token : config.authToken ?? "";
+  const cloudflareToken = typeof existing.cloudflareToken === "string" && existing.cloudflareToken ? existing.cloudflareToken : "";
+  return {
+    port: next.port,
+    mode: next.mode,
+    tunnel: next.tunnel,
+    ...(next.hostname ? { hostname: next.hostname } : {}),
+    ...(next.tunnelName ? { tunnelName: next.tunnelName } : {}),
+    ...(next.ngrokConfig ? { ngrokConfig: next.ngrokConfig } : {}),
+    ...(next.cloudflareConfig ? { cloudflareConfig: next.cloudflareConfig } : {}),
+    ...(next.cloudflareTokenFile ? { cloudflareTokenFile: next.cloudflareTokenFile } : {}),
+    ...(token ? { token } : {}),
+    ...(cloudflareToken ? { cloudflareToken } : {}),
+    bash: next.bash,
+    ...(next.bashTranscript !== "compact" ? { bashTranscript: next.bashTranscript } : {}),
+    ...(next.codexSessions !== "off" ? { codexSessions: next.codexSessions } : {}),
+    ...(next.codexDir ? { codexDir: next.codexDir } : {}),
+    ...(next.bashSession ? { bashSession: next.bashSession } : {}),
+    ...(next.requireBashSession ? { requireBashSession: true } : {}),
+    write: next.write,
+    toolMode: next.toolMode,
+    ...(next.widgetDomain ? { widgetDomain: next.widgetDomain } : {}),
+    ...(next.noInstallCloudflared ? { noInstallCloudflared: true } : {})
+  };
+}
+
+function profileResponse(config: CodexProConfig): Record<string, unknown> {
+  const profile = readWorkspaceProfile(config.defaultRoot);
+  const runtime = readRuntimeConnection(config.defaultRoot);
+  return {
+    ok: true,
+    profile_path: profile.profilePath ?? profilePathForRoot(config.defaultRoot),
+    exists: Boolean(profile.profilePath),
+    profile: sanitizeWorkspaceProfile(profile),
+    effective: profileValues(config, profile),
+    runtime_connection: runtime,
+    runtime: {
+      defaultRoot: config.defaultRoot,
+      port: config.port,
+      bashMode: config.bashMode,
+      bashTranscript: config.bashTranscript,
+      codexSessions: config.codexSessions,
+      writeMode: config.writeMode,
+      toolMode: config.toolMode,
+      widgetDomain: config.widgetDomain,
+      authEnabled: Boolean(config.authToken)
+    }
+  };
+}
+
+function jsonError(res: Response, status: number, code: string, message: string, issues?: unknown): void {
+  res.status(status).json({
+    ok: false,
+    error: { code, message, ...(issues ? { issues } : {}) }
+  });
+}
+
+const LOCAL_FAVICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#2563eb"/>
+  <rect x="8" y="8" width="48" height="48" rx="12" fill="#ffffff" fill-opacity=".12" stroke="#ffffff" stroke-opacity=".38"/>
+  <path d="M38.4 40.3c-1.8 1.1-3.9 1.7-6.3 1.7-6.1 0-10.3-4.2-10.3-10s4.2-10 10.4-10c2.4 0 4.5.6 6.2 1.7l-2.1 4.1c-1.1-.7-2.3-1-3.8-1-2.9 0-4.9 2.1-4.9 5.2s2 5.2 4.9 5.2c1.5 0 2.8-.4 3.9-1.1l2 4.2Z" fill="#ffffff"/>
+</svg>`;
+
 function onboardingPage(config: CodexProConfig): string {
   const localMcp = `http://${config.host}:${config.port}/mcp`;
+  const localMcpDisplay = config.authToken ? `${localMcp}?codexpro_token=<redacted>` : localMcp;
   const allowedRoots = config.allowedRoots.map((root) => `<li>${escapeHtml(root)}</li>`).join("");
   const authLabel = config.authToken ? "Token protected" : "Disabled";
   const writeTone = config.writeMode === "workspace" ? "agent" : config.writeMode;
+  const rootArg = shellQuote(config.defaultRoot);
+  const sessionArg = shellQuote(config.bashSessionId || "main");
+  const githubUrl = "https://github.com/rebel0789/codexpro";
+  const npmUrl = "https://www.npmjs.com/package/codexpro";
+  const docsUrl = "https://rebel0789.github.io/codexpro/";
+  const chatgptUrl = "https://chatgpt.com/#settings/Connectors";
+  const controls = [
+    copyCommand("Re-run setup wizard", "Use the CLI for broader profile edits that are intentionally not exposed here.", "codexpro setup"),
+    copyCommand("Copy local MCP URL", "Useful for a local MCP client. ChatGPT usually needs the public tunnel URL copied by the terminal.", localMcp, localMcpDisplay, "local-mcp"),
+    copyCommand("Start without bash", "Restart with file tools but no ChatGPT-triggered bash tool.", `codexpro start --root ${rootArg} --no-bash`),
+    copyCommand("Require explicit bash target", "Restart so bash calls must include this matching session_id.", `codexpro start --root ${rootArg} --bash-session ${sessionArg} --require-bash-session`),
+    copyCommand("Show Codex session list", "Restart with read-only local Codex session metadata in full tool mode.", `codexpro start --root ${rootArg} --tool-mode full --codex-sessions metadata`),
+    copyCommand("Read Codex transcripts", "Restart with bounded local transcript reads from Codex JSONL history.", `codexpro start --root ${rootArg} --tool-mode full --codex-sessions read`),
+    copyCommand("Use full bash transcript", "Restart with the raw stdout/stderr transcript instead of compact tool cards.", `codexpro start --root ${rootArg} --bash-transcript full`)
+  ].join("");
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CodexPro Local Setup</title>
+  <link rel="icon" href="/favicon.ico">
+  <title>CodexPro Admin</title>
   <style>
+    /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
+    /* Hallmark · macrostructure: Workbench · genre: modern-minimal · theme: CC Switch-inspired light manager · tone: technical admin · nav: section switcher · footer: Ft2 · contrast: pass (40-41) · mobile: pass (34, 49, 50-57) */
     :root {
-      color-scheme: dark;
-      --bg: #07090d;
-      --panel: #10141b;
-      --panel-2: #151a23;
-      --line: rgba(148, 163, 184, 0.18);
-      --line-strong: rgba(148, 163, 184, 0.3);
-      --text: #f4f7fb;
-      --soft: #cbd5e1;
-      --muted: #8a96a8;
-      --quiet: #667085;
-      --blue: #7dd3fc;
-      --teal: #5eead4;
-      --green: #86efac;
-      --amber: #fde68a;
+      color-scheme: light;
+      --font-display: "Inter", "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-body: "Inter", "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-mono: "Fira Code", "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --color-paper: oklch(98.5% 0.004 250);
+      --color-surface: oklch(100% 0 0);
+      --color-panel: oklch(100% 0 0);
+      --color-panel-2: oklch(96.5% 0.008 252);
+      --color-row: oklch(99.2% 0.004 250);
+      --color-rule: oklch(88% 0.012 250);
+      --color-rule-strong: oklch(78% 0.018 250);
+      --color-ink: oklch(23% 0.026 255);
+      --color-soft: oklch(39% 0.026 255);
+      --color-muted: oklch(53% 0.022 255);
+      --color-subtle: oklch(64% 0.018 255);
+      --color-accent: oklch(58% 0.19 256);
+      --color-accent-strong: oklch(50% 0.22 256);
+      --color-accent-ink: oklch(99% 0.004 250);
+      --color-action: var(--color-accent);
+      --color-action-strong: var(--color-accent-strong);
+      --color-good: oklch(56% 0.14 154);
+      --color-warn: oklch(54% 0.17 256);
+      --color-focus: oklch(61% 0.2 256);
+      --surface-accent: oklch(95% 0.036 256);
+      --surface-good: oklch(94.5% 0.035 154);
+      --surface-warn: oklch(95% 0.036 256);
+      --surface-hover: oklch(93.5% 0.025 256);
+      --shadow-panel: 0 18px 50px oklch(24% 0.03 255 / 0.10);
+      --shadow-row: 0 8px 18px oklch(24% 0.03 255 / 0.06);
+      --space-1: 0.25rem;
+      --space-2: 0.5rem;
+      --space-3: 0.75rem;
+      --space-4: 1rem;
+      --space-5: 1.25rem;
+      --space-6: 1.5rem;
+      --space-7: 2rem;
+      --space-8: 2.5rem;
+      --space-9: 3rem;
+      --radius-1: 6px;
+      --radius-2: 8px;
+      --dur-micro: 120ms;
+      --dur-short: 180ms;
+      --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+      --ease-in: cubic-bezier(0.7, 0, 0.84, 0);
     }
     * { box-sizing: border-box; }
+    html,
+    body {
+      overflow-x: clip;
+    }
     body {
       margin: 0;
       min-height: 100vh;
-      background:
-        radial-gradient(circle at 18% 0, rgba(94, 234, 212, 0.14), transparent 28rem),
-        radial-gradient(circle at 100% 10%, rgba(125, 211, 252, 0.1), transparent 26rem),
-        var(--bg);
-      color: var(--text);
-      font: 14px/1.55 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--color-paper);
+      color: var(--color-ink);
+      font: 14px/1.55 var(--font-body);
       letter-spacing: 0;
     }
-    main {
-      width: min(960px, calc(100vw - 32px));
-      margin: 0 auto;
-      padding: 48px 0;
+    a {
+      color: inherit;
+      text-decoration: none;
     }
-    .hero {
-      display: grid;
-      gap: 18px;
-      margin-bottom: 18px;
-      padding: 26px;
-      border: 1px solid var(--line);
-      border-radius: 14px;
-      background: linear-gradient(180deg, rgba(255,255,255,0.055), rgba(255,255,255,0.018)), var(--panel);
-      box-shadow: 0 24px 60px rgba(0,0,0,0.34);
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+    main {
+      width: min(1240px, calc(100% - (var(--space-4) * 2)));
+      margin: 0 auto;
+      padding: var(--space-5) 0 var(--space-8);
+    }
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-4);
+      margin-bottom: var(--space-3);
+      padding: var(--space-2) 0 var(--space-3);
     }
     .brand {
       display: flex;
       align-items: center;
-      gap: 10px;
-      color: var(--muted);
-      font-size: 12px;
-      font-weight: 800;
-      text-transform: uppercase;
+      gap: var(--space-3);
+      min-width: 0;
     }
     .logo {
       display: inline-grid;
       place-items: center;
-      width: 30px;
-      height: 30px;
-      border: 1px solid rgba(125, 211, 252, 0.3);
-      border-radius: 9px;
-      color: var(--blue);
-      background: rgba(125, 211, 252, 0.08);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      width: 42px;
+      height: 42px;
+      flex: 0 0 auto;
+      border: 1px solid var(--color-accent);
+      border-radius: 12px;
+      background: var(--color-accent);
+      color: var(--color-accent-ink);
+      box-shadow: var(--shadow-row);
+      font: 900 15px/1 var(--font-mono);
+    }
+    .logo img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+    }
+    .brand-kicker {
+      display: block;
+      color: var(--color-muted);
+      font-size: 12px;
+      font-weight: 800;
+      line-height: 1.1;
+      text-transform: uppercase;
+    }
+    .brand-title {
+      display: block;
+      overflow-wrap: anywhere;
+      color: var(--color-accent);
+      font: 900 28px/1 var(--font-display);
+    }
+    .quick-links {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: var(--space-2);
+      flex-wrap: wrap;
+    }
+    .resource-link,
+    .action-link,
+    .copy-mini,
+    .primary {
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--radius-2);
+      white-space: nowrap;
+      transition: background-color var(--dur-short) var(--ease-out),
+        border-color var(--dur-short) var(--ease-out),
+        color var(--dur-short) var(--ease-out),
+        transform var(--dur-micro) var(--ease-out);
+    }
+    .resource-link,
+    .action-link {
+      border: 1px solid var(--color-rule);
+      background: var(--color-surface);
+      color: var(--color-soft);
+      font-size: 12px;
+      font-weight: 800;
+      padding: 0 var(--space-3);
+      box-shadow: var(--shadow-row);
+    }
+    .action-link.primary-link {
+      border-color: var(--color-action);
+      background: var(--color-action);
+      color: var(--color-accent-ink);
+    }
+    .section-tabs {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-1);
+      flex-wrap: wrap;
+      margin: 0 0 var(--space-5);
+      padding: var(--space-1);
+      border: 1px solid var(--color-rule);
+      border-radius: 16px;
+      background: var(--color-surface);
+      box-shadow: var(--shadow-panel);
+    }
+    .section-tabs a {
+      min-height: 40px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 12px;
+      color: var(--color-muted);
+      font-size: 13px;
+      font-weight: 900;
+      white-space: nowrap;
+      padding: 0 var(--space-4);
+    }
+    .section-tabs a[aria-current="page"] {
+      background: var(--color-accent);
+      color: var(--color-accent-ink);
+      box-shadow: var(--shadow-row);
+    }
+    .overview {
+      display: grid;
+      grid-template-columns: minmax(0, 1.08fr) minmax(330px, 0.52fr);
+      gap: var(--space-5);
+      align-items: start;
+      margin-bottom: var(--space-5);
+    }
+    .intro-stack {
+      display: grid;
+      gap: var(--space-5);
+      min-width: 0;
+    }
+    .intro {
+      min-width: 0;
+      padding: var(--space-6);
+      border: 1px solid var(--color-rule);
+      border-radius: 18px;
+      background: var(--color-surface);
+      box-shadow: var(--shadow-panel);
     }
     h1 {
       margin: 0;
-      max-width: 760px;
-      font-size: clamp(32px, 6vw, 56px);
-      line-height: 0.98;
+      max-width: 18ch;
+      font: 900 2rem/1.05 var(--font-display);
       letter-spacing: 0;
+      overflow-wrap: anywhere;
     }
     .lead {
-      max-width: 700px;
-      margin: 0;
-      color: var(--soft);
-      font-size: 16px;
-    }
-    .grid {
-      display: grid;
-      grid-template-columns: 1.05fr 0.95fr;
-      gap: 18px;
-    }
-    .card {
-      min-width: 0;
-      padding: 18px;
-      border: 1px solid var(--line);
-      border-radius: 12px;
-      background: rgba(16, 20, 27, 0.82);
-    }
-    h2 {
-      margin: 0 0 12px;
+      max-width: 64ch;
+      margin: var(--space-4) 0 0;
+      color: var(--color-soft);
       font-size: 15px;
     }
-    .steps {
-      display: grid;
-      gap: 10px;
+    .scope-note {
+      margin-top: var(--space-5);
+      padding-top: var(--space-4);
+      border-top: 1px solid var(--color-rule);
+      color: var(--color-muted);
+      font-size: 13px;
+    }
+    .run-card,
+    .panel {
+      min-width: 0;
+      border: 1px solid var(--color-rule);
+      border-radius: 18px;
+      background: var(--color-panel);
+      box-shadow: var(--shadow-panel);
+    }
+    .run-card,
+    .panel {
+      padding: var(--space-5);
+    }
+    .run-card h2,
+    .panel h2 {
       margin: 0;
-      padding: 0;
-      list-style: none;
+      color: var(--color-ink);
+      font: 700 16px/1.25 var(--font-display);
+      letter-spacing: 0;
     }
-    .steps li {
+    .workspace-grid {
       display: grid;
-      grid-template-columns: 26px minmax(0, 1fr);
-      gap: 10px;
+      grid-template-columns: minmax(0, 1.08fr) minmax(310px, 0.58fr);
+      gap: var(--space-5);
       align-items: start;
-      color: var(--soft);
     }
-    .num {
-      display: inline-grid;
-      place-items: center;
-      width: 24px;
-      height: 24px;
-      border: 1px solid var(--line-strong);
-      border-radius: 999px;
-      color: var(--teal);
-      font: 800 11px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    .side-stack {
+      display: grid;
+      gap: var(--space-5);
+    }
+    .section-head {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: var(--space-4);
+      margin-bottom: var(--space-4);
+    }
+    .section-head p,
+    .panel > p {
+      margin: var(--space-1) 0 0;
+      color: var(--color-muted);
+      font-size: 13px;
     }
     .status {
       display: grid;
-      gap: 8px;
     }
     .row {
       display: grid;
-      grid-template-columns: 112px minmax(0, 1fr);
-      gap: 10px;
-      padding: 10px 0;
-      border-bottom: 1px solid var(--line);
+      grid-template-columns: 132px minmax(0, 1fr);
+      gap: var(--space-3);
+      padding: var(--space-3) 0;
+      border-bottom: 1px solid var(--color-rule);
     }
     .row:last-child { border-bottom: 0; }
     .label {
-      color: var(--quiet);
-      font-size: 12px;
+      color: var(--color-subtle);
+      font-size: 11px;
       font-weight: 800;
       text-transform: uppercase;
     }
-    code, .mono {
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      color: var(--soft);
+    code,
+    .mono {
+      font-family: var(--font-mono);
+      color: var(--color-soft);
       overflow-wrap: anywhere;
+      font-variant-numeric: tabular-nums;
     }
     .pill {
       display: inline-flex;
       width: fit-content;
-      padding: 3px 8px;
-      border: 1px solid rgba(134, 239, 172, 0.28);
+      align-items: center;
+      min-height: 26px;
+      padding: 0 var(--space-2);
+      border: 1px solid var(--color-good);
       border-radius: 999px;
-      color: var(--green);
-      background: rgba(134, 239, 172, 0.08);
+      background: var(--surface-good);
+      color: var(--color-good);
+      font-size: 12px;
+      font-weight: 800;
+      line-height: 1;
+    }
+    .warn {
+      border-color: var(--color-warn);
+      background: var(--surface-warn);
+      color: var(--color-warn);
+    }
+    .controls {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-3);
+    }
+    .control {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: var(--space-3);
+      align-items: center;
+      min-width: 0;
+      min-height: 112px;
+      padding: var(--space-4);
+      border: 1px solid var(--color-rule);
+      border-radius: 18px;
+      background: var(--color-row);
+      box-shadow: var(--shadow-row);
+    }
+    .control strong {
+      display: block;
+      margin-bottom: var(--space-1);
+      color: var(--color-ink);
+      font-size: 13px;
+    }
+    .control p {
+      margin: 0 0 var(--space-2);
+      color: var(--color-muted);
+      font-size: 12px;
+    }
+    .control code {
+      display: block;
+      padding: var(--space-2);
+      border: 1px solid var(--color-rule);
+      border-radius: 10px;
+      background: var(--color-panel-2);
+      line-height: 1.45;
+    }
+    .steps {
+      display: grid;
+      gap: var(--space-3);
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .guide-list {
+      display: grid;
+      gap: var(--space-3);
+    }
+    .guide-item {
+      display: grid;
+      grid-template-columns: 28px minmax(0, 1fr);
+      gap: var(--space-3);
+      padding: var(--space-3);
+      border: 1px solid var(--color-rule);
+      border-radius: 14px;
+      background: var(--color-row);
+    }
+    .guide-item strong {
+      display: block;
+      color: var(--color-ink);
+      font-size: 13px;
+    }
+    .guide-item p {
+      margin: var(--space-1) 0 0;
+      color: var(--color-muted);
+      font-size: 12px;
+    }
+    .steps li {
+      display: grid;
+      grid-template-columns: 28px minmax(0, 1fr);
+      gap: var(--space-3);
+      align-items: start;
+      color: var(--color-soft);
+    }
+    .num {
+      display: inline-grid;
+      place-items: center;
+      width: 26px;
+      height: 26px;
+      border: 1px solid var(--color-accent);
+      border-radius: 999px;
+      background: var(--color-accent);
+      color: var(--color-accent-ink);
+      font: 800 11px/1 var(--font-mono);
+    }
+    .roots {
+      margin: var(--space-3) 0 0;
+      padding-left: var(--space-5);
+      color: var(--color-muted);
+    }
+    .profile-form {
+      display: grid;
+      gap: var(--space-4);
+    }
+    .current-url {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: var(--space-3);
+      align-items: center;
+      min-width: 0;
+      padding: var(--space-4);
+      border: 1px solid var(--color-accent);
+      border-radius: 18px;
+      background: var(--surface-accent);
+    }
+    .current-url.idle {
+      border-color: var(--color-rule);
+      background: var(--color-row);
+    }
+    .current-url span,
+    .readonly-grid span {
+      display: block;
+      margin-bottom: var(--space-1);
+      color: var(--color-muted);
+      font-size: 11px;
+      font-weight: 900;
+      text-transform: uppercase;
+    }
+    .current-url code {
+      display: block;
+      color: var(--color-ink);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    .current-url p {
+      margin: var(--space-2) 0 0;
+      color: var(--color-soft);
+      font-size: 12px;
+    }
+    .profile-group {
+      min-width: 0;
+      margin: 0;
+      padding: var(--space-4);
+      border: 1px solid var(--color-rule);
+      border-radius: 18px;
+      background: var(--color-row);
+      box-shadow: var(--shadow-row);
+    }
+    .profile-group legend {
+      padding: 0 var(--space-2);
+      color: var(--color-ink);
+      font: 900 13px/1 var(--font-display);
+    }
+    .profile-group p {
+      margin: 0 0 var(--space-3);
+      color: var(--color-muted);
+      font-size: 12px;
+    }
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-3);
+    }
+    .profile-form label {
+      display: grid;
+      gap: var(--space-2);
+      color: var(--color-soft);
       font-size: 12px;
       font-weight: 800;
     }
-    .warn {
-      border-color: rgba(253, 230, 138, 0.28);
-      color: var(--amber);
-      background: rgba(253, 230, 138, 0.08);
+    .profile-form label span {
+      color: var(--color-muted);
+      text-transform: uppercase;
     }
-    .roots {
-      margin: 8px 0 0;
-      padding-left: 18px;
-      color: var(--muted);
+    .profile-form input,
+    .profile-form select {
+      width: 100%;
+      min-height: 44px;
+      border: 1px solid var(--color-rule);
+      border-radius: 12px;
+      outline: 2px solid transparent;
+      outline-offset: 1px;
+      background: var(--color-surface);
+      color: var(--color-ink);
+      font: 13px/1.25 var(--font-body);
+      padding: 0 var(--space-3);
     }
-    .footer {
-      margin-top: 14px;
-      color: var(--quiet);
+    .field-help {
+      min-height: 1lh;
+      margin: var(--space-3) 0 0 !important;
+      color: var(--color-soft) !important;
+      font-size: 12px !important;
+    }
+    .check-row {
+      width: fit-content;
+      display: inline-flex !important;
+      grid-template-columns: none !important;
+      align-items: center;
+      gap: var(--space-2) !important;
+      margin-top: var(--space-3);
+      padding: var(--space-2) var(--space-3);
+      border: 1px solid var(--color-rule);
+      border-radius: 999px;
+      background: var(--color-surface);
+      color: var(--color-soft);
+    }
+    .check-row input {
+      width: 18px;
+      min-height: 18px;
+      height: 18px;
+      padding: 0;
+      accent-color: var(--color-accent);
+    }
+    .check-row span {
+      color: var(--color-soft) !important;
+      text-transform: none !important;
+    }
+    .readonly-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-3);
+    }
+    .readonly-grid > div {
+      min-width: 0;
+      padding: var(--space-3);
+      border: 1px solid var(--color-rule);
+      border-radius: 14px;
+      background: var(--color-surface);
+    }
+    .readonly-grid code {
+      display: block;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      min-width: 0;
+      flex-wrap: wrap;
+    }
+    .primary {
+      border: 1px solid var(--color-accent);
+      background: var(--color-accent);
+      color: var(--color-accent-ink);
+      cursor: pointer;
+      font: 800 13px/1 var(--font-body);
+      padding: 0 var(--space-4);
+      box-shadow: var(--shadow-row);
+    }
+    .copy-mini {
+      border: 1px solid var(--color-action);
+      background: var(--color-action);
+      color: var(--color-accent-ink);
+      cursor: pointer;
+      font: 800 12px/1 var(--font-body);
+      padding: 0 var(--space-3);
+    }
+    .note {
+      min-height: 1lh;
+      margin: var(--space-1) 0 0;
+      color: var(--color-subtle);
       font-size: 12px;
     }
-    @media (max-width: 760px) {
-      main { padding: 24px 0; }
-      .grid { grid-template-columns: 1fr; }
-      .hero { padding: 20px; }
-      .row { grid-template-columns: 1fr; gap: 2px; }
+    .scope-list {
+      display: grid;
+      gap: var(--space-2);
+      margin: var(--space-3) 0 0;
+      padding: 0;
+      list-style: none;
+    }
+    .scope-list li {
+      display: grid;
+      grid-template-columns: 112px minmax(0, 1fr);
+      gap: var(--space-3);
+      padding-block: var(--space-2);
+      border-bottom: 1px solid var(--color-rule);
+      color: var(--color-muted);
+    }
+    .scope-list li:last-child {
+      border-bottom: 0;
+    }
+    .scope-list strong {
+      color: var(--color-soft);
+      font-family: var(--font-mono);
+      font-size: 12px;
+    }
+    .details-panel {
+      margin-top: var(--space-5);
+    }
+    details summary {
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-3);
+      cursor: pointer;
+      color: var(--color-ink);
+      font: 800 14px/1 var(--font-body);
+      list-style: none;
+    }
+    details summary::-webkit-details-marker {
+      display: none;
+    }
+    details summary::after {
+      content: "+";
+      color: var(--color-accent);
+      font: 800 18px/1 var(--font-mono);
+    }
+    details[open] summary {
+      margin-bottom: var(--space-4);
+    }
+    details[open] summary::after {
+      content: "-";
+    }
+    .foot {
+      margin-top: var(--space-6);
+      padding-top: var(--space-4);
+      border-top: 1px solid var(--color-rule);
+      color: var(--color-subtle);
+      font-size: 12px;
+    }
+    :focus {
+      outline: none;
+    }
+    :focus-visible {
+      outline: 2px solid var(--color-focus);
+      outline-offset: 2px;
+    }
+    .profile-form input:focus-visible,
+    .profile-form select:focus-visible {
+      outline: 2px solid var(--color-focus);
+      outline-offset: 1px;
+    }
+    .resource-link:active,
+    .action-link:active,
+    .copy-mini:active,
+    .primary:active {
+      transform: translateY(1px);
+    }
+    .resource-link[aria-disabled="true"],
+    .action-link[aria-disabled="true"],
+    .copy-mini:disabled,
+    .primary:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+    @media (hover: hover) and (pointer: fine) {
+      .resource-link:hover,
+      .action-link:hover,
+      .copy-mini:hover,
+      .primary:hover {
+        border-color: var(--color-accent);
+        background: var(--surface-hover);
+        color: var(--color-accent-strong);
+        transform: translateY(-1px);
+      }
+      .action-link.primary-link:hover,
+      .copy-mini:hover,
+      .primary:hover {
+        border-color: var(--color-action-strong);
+        background: var(--color-action-strong);
+        color: var(--color-accent-ink);
+      }
+      .section-tabs a:hover {
+        background: var(--surface-hover);
+        color: var(--color-accent-strong);
+      }
+      .profile-form input:hover,
+      .profile-form select:hover {
+        border-color: var(--color-rule-strong);
+        background: var(--color-panel-2);
+      }
+    }
+    @media (min-width: 52rem) {
+      h1 {
+        font-size: 2.45rem;
+      }
+    }
+    @media (max-width: 58rem) {
+      .overview,
+      .workspace-grid {
+        grid-template-columns: 1fr;
+      }
+      .topbar {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+      .quick-links {
+        justify-content: flex-start;
+      }
+      .section-tabs {
+        justify-content: flex-start;
+      }
+    }
+    @media (max-width: 42rem) {
+      main {
+        width: min(100% - (var(--space-3) * 2), 1180px);
+        padding-block: var(--space-4) var(--space-7);
+      }
+      .intro,
+      .run-card,
+      .panel {
+        padding: var(--space-4);
+      }
+      h1 {
+        font-size: 1.85rem;
+      }
+      .row,
+      .scope-list li {
+        grid-template-columns: 1fr;
+        gap: var(--space-1);
+      }
+      .controls,
+      .form-grid {
+        grid-template-columns: 1fr;
+      }
+      .control {
+        grid-template-columns: 1fr;
+      }
+      .current-url,
+      .readonly-grid {
+        grid-template-columns: 1fr;
+      }
+      .actions {
+        align-items: stretch;
+        flex-direction: column;
+      }
+      .primary {
+        width: 100%;
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        animation-duration: 150ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 150ms !important;
+      }
     }
   </style>
 </head>
 <body>
   <main>
-    <section class="hero">
-      <div class="brand"><span class="logo">C</span><span>CodexPro local bridge</span></div>
-      <h1>Local server is ready.</h1>
-      <p class="lead">Use the Server URL copied by the terminal in ChatGPT Developer Mode. Keep the terminal running while ChatGPT edits, searches, or runs commands in this workspace.</p>
+    <header class="topbar">
+      <div class="brand">
+        <span class="logo" aria-hidden="true"><img src="/favicon.ico" alt=""></span>
+        <span>
+          <span class="brand-kicker">Local admin</span>
+          <span class="brand-title">CodexPro</span>
+        </span>
+      </div>
+      <nav class="quick-links" aria-label="CodexPro resources">
+        <a class="action-link primary-link" href="${chatgptUrl}" target="_blank" rel="noreferrer">Open ChatGPT</a>
+        <a class="resource-link" href="${githubUrl}" target="_blank" rel="noreferrer">Open GitHub</a>
+        <a class="resource-link" href="${npmUrl}" target="_blank" rel="noreferrer">NPM</a>
+        <a class="resource-link" href="${docsUrl}" target="_blank" rel="noreferrer">Docs</a>
+      </nav>
+    </header>
+    <nav class="section-tabs" aria-label="Admin sections">
+      <a href="#profile" aria-current="page">Profile</a>
+      <a href="#status">Status</a>
+      <a href="#connect">ChatGPT</a>
+      <a href="#access">Access</a>
+      <a href="#cli">CLI</a>
+    </nav>
+    <section class="overview">
+      ${profileForm(config)}
+      <aside class="side-stack">
+        <section class="panel guide-panel" id="guide">
+          <div class="section-head">
+            <div>
+              <h2>Quick path</h2>
+              <p>For a new local admin session, do these in order.</p>
+            </div>
+          </div>
+          <div class="guide-list">
+            <div class="guide-item"><span class="num">1</span><span><strong>Check the profile</strong><p>Save the tunnel, port, mode, bash, write, tool, Codex sessions, and working directory defaults for the next launch.</p></span></div>
+            <div class="guide-item"><span class="num">2</span><span><strong>Copy the Server URL</strong><p>Use the current public URL shown in the profile when available, or the one printed by the terminal after launch.</p></span></div>
+            <div class="guide-item"><span class="num">3</span><span><strong>Open ChatGPT settings</strong><p>Create an app connection, choose Server URL, paste the public URL, and use no extra authentication.</p></span></div>
+            <div class="guide-item"><span class="num">4</span><span><strong>Restart for policy changes</strong><p>Saved profile changes apply when CodexPro starts again. This keeps the live server predictable.</p></span></div>
+          </div>
+        </section>
+        <article class="run-card" id="status" aria-label="Current runtime">
+          <h2>Current session</h2>
+          <div class="status">
+            <div class="row"><span class="label">Workspace</span><span class="mono">${escapeHtml(config.defaultRoot)}</span></div>
+            <div class="row"><span class="label">Local MCP</span><span class="mono">${escapeHtml(localMcp)}</span></div>
+            <div class="row"><span class="label">Write mode</span><span class="pill ${config.writeMode === "workspace" ? "" : "warn"}">${escapeHtml(writeTone)}</span></div>
+            <div class="row"><span class="label">Tool mode</span><span class="pill ${config.toolMode === "standard" ? "" : "warn"}">${escapeHtml(config.toolMode)}</span></div>
+            <div class="row"><span class="label">Bash mode</span><span class="pill ${config.bashMode === "safe" ? "" : "warn"}">${escapeHtml(config.bashMode)}</span></div>
+            <div class="row"><span class="label">Transcript</span><span class="pill ${config.bashTranscript === "compact" ? "" : "warn"}">${escapeHtml(config.bashTranscript)}</span></div>
+            <div class="row"><span class="label">Bash session</span><span class="pill ${config.requireBashSession ? "warn" : ""}">${escapeHtml(config.bashSessionId ? `${config.bashSessionId}${config.requireBashSession ? " required" : ""}` : "not set")}</span></div>
+            <div class="row"><span class="label">Codex sessions</span><span class="pill ${config.codexSessions === "off" ? "" : "warn"}">${escapeHtml(config.codexSessions)}</span></div>
+            <div class="row"><span class="label">Widget domain</span><span class="mono">${escapeHtml(config.widgetDomain)}</span></div>
+            <div class="row"><span class="label">Auth</span><span class="pill">${escapeHtml(authLabel)}</span></div>
+          </div>
+        </article>
+      </aside>
     </section>
-    <section class="grid">
-      <article class="card">
-        <h2>ChatGPT setup</h2>
-        <ol class="steps">
-          <li><span class="num">1</span><span>Open ChatGPT settings, Apps, then Create app.</span></li>
-          <li><span class="num">2</span><span>Set Connection to <code>Server URL</code>.</span></li>
-          <li><span class="num">3</span><span>Paste the copied CodexPro URL into the Server URL field.</span></li>
-          <li><span class="num">4</span><span>Use <code>No Authentication / None</code>. The private token is already inside the copied URL.</span></li>
-          <li><span class="num">5</span><span>Start with: <code>Use CodexPro as a coding agent. Call server_config, then open_current_workspace.</code></span></li>
-        </ol>
-      </article>
-      <article class="card">
-        <h2>Current session</h2>
-        <div class="status">
-          <div class="row"><span class="label">Workspace</span><span class="mono">${escapeHtml(config.defaultRoot)}</span></div>
-          <div class="row"><span class="label">Local MCP</span><span class="mono">${escapeHtml(localMcp)}</span></div>
-          <div class="row"><span class="label">Write mode</span><span class="pill ${config.writeMode === "workspace" ? "" : "warn"}">${escapeHtml(writeTone)}</span></div>
-          <div class="row"><span class="label">Tool mode</span><span class="pill ${config.toolMode === "standard" ? "" : "warn"}">${escapeHtml(config.toolMode)}</span></div>
-          <div class="row"><span class="label">Bash mode</span><span class="pill ${config.bashMode === "safe" ? "" : "warn"}">${escapeHtml(config.bashMode)}</span></div>
-          <div class="row"><span class="label">Bash session</span><span class="pill ${config.requireBashSession ? "warn" : ""}">${escapeHtml(config.bashSessionId ? `${config.bashSessionId}${config.requireBashSession ? " required" : ""}` : "not set")}</span></div>
-          <div class="row"><span class="label">Widget domain</span><span class="mono">${escapeHtml(config.widgetDomain)}</span></div>
-          <div class="row"><span class="label">Auth</span><span class="pill">${escapeHtml(authLabel)}</span></div>
+    <section class="workspace-grid">
+      <section class="panel" id="connect">
+        <div class="section-head">
+          <div>
+            <h2>Connect ChatGPT</h2>
+            <p>Create an app connection that points at the public Server URL copied by the terminal.</p>
+          </div>
         </div>
-      </article>
+        <ol class="steps">
+          <li><span class="num">1</span><span>Open ChatGPT settings and create an app connection.</span></li>
+          <li><span class="num">2</span><span>Set Connection to <code>Server URL</code>.</span></li>
+          <li><span class="num">3</span><span>Paste the public CodexPro URL from the terminal.</span></li>
+          <li><span class="num">4</span><span>Use <code>No Authentication / None</code>; the private token is already in the copied URL.</span></li>
+        </ol>
+        <p class="note"><a class="action-link" href="${chatgptUrl}" target="_blank" rel="noreferrer">Open ChatGPT settings</a></p>
+      </section>
+      <aside class="side-stack">
+        <section class="panel" id="access">
+          <h2>Admin boundary</h2>
+          <ul class="scope-list">
+            <li><strong>/setup</strong><span>this setup and settings page</span></li>
+            <li><strong>/admin/profile</strong><span>saved workspace profile API</span></li>
+            <li><strong>/healthz</strong><span>authenticated status check</span></li>
+            <li><strong>/mcp</strong><span>MCP endpoint for ChatGPT and local clients</span></li>
+          </ul>
+        </section>
+      </aside>
     </section>
-    <section class="card" style="margin-top:18px">
-      <h2>Allowed roots</h2>
+    <section class="panel cli-panel details-panel" id="cli">
+      <div class="section-head">
+        <div>
+          <h2>CLI controls</h2>
+          <p>Copy these when you need to restart with a different runtime policy. They do not mutate the running process from the browser.</p>
+        </div>
+      </div>
+      <div class="controls">${controls}</div>
+    </section>
+    <details class="panel details-panel">
+      <summary>Allowed roots</summary>
       <ul class="roots">${allowedRoots}</ul>
-      <p class="footer">This page does not print the CodexPro token. Use the terminal control panel to copy the full Server URL again.</p>
-    </section>
+      <p class="note">CodexPro rejects workspace access outside these roots.</p>
+    </details>
+    <footer class="foot">Local admin surface for status, saved profile settings, CLI restart commands, and MCP access. Public sharing still happens through your chosen tunnel.</footer>
   </main>
+  <script>
+    document.querySelectorAll("[data-copy], [data-copy-kind]").forEach((button) => {
+      button.addEventListener("click", async () => {
+        let value = button.getAttribute("data-copy") || "";
+        if (button.getAttribute("data-copy-kind") === "local-mcp") {
+          const base = button.getAttribute("data-copy-base") || value;
+          const params = new URLSearchParams(window.location.search);
+          const token = params.get("codexpro_token") || params.get("token") || "";
+          value = token ? base + "?codexpro_token=" + encodeURIComponent(token) : base;
+        } else if (button.getAttribute("data-copy-kind") === "server-url") {
+          const base = button.getAttribute("data-copy-base") || value;
+          const params = new URLSearchParams(window.location.search);
+          const token = params.get("codexpro_token") || params.get("token") || "";
+          value = token ? base + "?codexpro_token=" + encodeURIComponent(token) : base;
+        }
+        try {
+          await navigator.clipboard.writeText(value);
+          button.textContent = "Copied";
+          setTimeout(() => { button.textContent = "Copy"; }, 1400);
+        } catch {
+          button.textContent = "Select";
+        }
+      });
+    });
+    const profileForm = document.querySelector("[data-profile-form]");
+    const tunnelSelect = document.querySelector("[data-tunnel-select]");
+    const hostnameInput = document.querySelector("[data-hostname-input]");
+    const hostnameHelp = document.querySelector("[data-hostname-help]");
+    const tokenEnabled = ${config.authToken ? "true" : "false"};
+    function serverPreviewFor(hostname) {
+      const clean = String(hostname || "").trim().replace(/^https?:\\/\\//, "").replace(/\\/mcp\\/?$/, "").replace(/\\/+$/, "");
+      if (!clean) return "";
+      return "https://" + clean + "/mcp" + (tokenEnabled ? "?codexpro_token=<redacted>" : "");
+    }
+    function updateTunnelHelp() {
+      if (!tunnelSelect || !hostnameInput || !hostnameHelp) return;
+      const tunnel = tunnelSelect.value;
+      const ngrokHost = tunnelSelect.getAttribute("data-ngrok-hostname") || "";
+      const cloudflareHost = tunnelSelect.getAttribute("data-cloudflare-hostname") || "";
+      if (tunnel === "ngrok" && !hostnameInput.value && ngrokHost) {
+        hostnameInput.value = ngrokHost;
+        hostnameInput.setAttribute("data-autofilled", "1");
+      }
+      if (tunnel === "cloudflare-named" && !hostnameInput.value && cloudflareHost) {
+        hostnameInput.value = cloudflareHost;
+        hostnameInput.setAttribute("data-autofilled", "1");
+      }
+      if ((tunnel === "cloudflare" || tunnel === "none") && hostnameInput.getAttribute("data-autofilled") === "1") {
+        hostnameInput.value = "";
+        hostnameInput.setAttribute("data-autofilled", "0");
+      }
+      const preview = serverPreviewFor(hostnameInput.value);
+      if (tunnel === "cloudflare") {
+        hostnameHelp.textContent = "Cloudflare quick tunnel generates the public URL at launch and this page shows it when the launcher reports it.";
+      } else if (tunnel === "ngrok") {
+        hostnameHelp.textContent = preview ? "Next Server URL preview: " + preview : "Enter the reserved ngrok domain from your local ngrok setup.";
+      } else if (tunnel === "cloudflare-named") {
+        hostnameHelp.textContent = preview ? "Next Server URL preview: " + preview : "Enter the hostname routed to your Cloudflare named tunnel.";
+      } else {
+        hostnameHelp.textContent = "Local-only mode does not expose a public ChatGPT Server URL.";
+      }
+    }
+    tunnelSelect?.addEventListener("change", updateTunnelHelp);
+    hostnameInput?.addEventListener("input", () => {
+      hostnameInput.setAttribute("data-autofilled", "0");
+      updateTunnelHelp();
+    });
+    updateTunnelHelp();
+    if (profileForm) {
+      profileForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const status = document.querySelector("[data-profile-status]");
+        const data = Object.fromEntries(new FormData(form).entries());
+        const payload = {
+          tunnel: data.tunnel,
+          hostname: data.hostname,
+          port: Number(data.port),
+          mode: data.mode,
+          bash: data.bash,
+          write: data.write,
+          toolMode: data.toolMode,
+          codexSessions: data.codexSessions,
+          codexDir: data.codexDir,
+          bashSession: data.bashSession,
+          requireBashSession: Boolean(form.elements.requireBashSession?.checked)
+        };
+        if (status) status.textContent = "Saving...";
+        try {
+          const response = await fetch("/admin/profile" + window.location.search, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload)
+          });
+          const result = await response.json().catch(() => ({}));
+          if (!response.ok) throw new Error(result.error?.message || "Save failed");
+          if (status) status.textContent = "Saved. Restart CodexPro for these profile settings to apply.";
+        } catch (error) {
+          if (status) status.textContent = error instanceof Error ? error.message : "Save failed";
+        }
+      });
+    }
+  </script>
 </body>
 </html>`;
 }
@@ -263,6 +1382,34 @@ async function main(): Promise<void> {
     return expected.length === actual.length && timingSafeEqual(expected, actual);
   }
 
+  const adminRateWindow = new Map<string, { count: number; resetAt: number }>();
+
+  function adminRateLimit(req: Request, res: Response, next: NextFunction): void {
+    const now = Date.now();
+    const key = req.ip || req.socket.remoteAddress || "local";
+    const current = adminRateWindow.get(key);
+    if (!current || current.resetAt <= now) {
+      adminRateWindow.set(key, { count: 1, resetAt: now + 60_000 });
+      next();
+      return;
+    }
+    current.count += 1;
+    if (current.count > 30) {
+      jsonError(res, 429, "rate_limited", "Too many profile save attempts. Try again in a minute.");
+      return;
+    }
+    next();
+  }
+
+  function adminBodyLimit(req: Request, res: Response, next: NextFunction): void {
+    const length = Number(req.headers["content-length"] ?? 0);
+    if (Number.isFinite(length) && length > 32_768) {
+      jsonError(res, 413, "payload_too_large", "Profile request body is too large.");
+      return;
+    }
+    next();
+  }
+
   app.use((req, res, next) => {
     if (!logRequests) {
       next();
@@ -275,6 +1422,10 @@ async function main(): Promise<void> {
     next();
   });
   app.use(cors({ exposedHeaders: ["Mcp-Session-Id"] }));
+  app.get("/favicon.ico", (_req, res) => {
+    res.setHeader("Cache-Control", "public, max-age=86400");
+    res.type("image/svg+xml").send(LOCAL_FAVICON);
+  });
   app.use((req, res, next) => {
     if (!config.authToken) {
       next();
@@ -294,7 +1445,6 @@ async function main(): Promise<void> {
     }
     next();
   });
-  app.use(express.json({ limit: "20mb" }));
 
   type TransportRecord = {
     transport: StreamableHTTPServerTransport;
@@ -352,8 +1502,10 @@ async function main(): Promise<void> {
       defaultRoot: config.defaultRoot,
       allowedRoots: config.allowedRoots,
       bashMode: config.bashMode,
+      bashTranscript: config.bashTranscript,
       bashSessionId: config.bashSessionId ?? null,
       requireBashSession: config.requireBashSession,
+      codexSessions: config.codexSessions,
       writeMode: config.writeMode,
       toolMode: config.toolMode,
       widgetDomain: config.widgetDomain,
@@ -363,7 +1515,36 @@ async function main(): Promise<void> {
     });
   });
 
-  app.post("/mcp", async (req, res) => {
+  app.get("/admin/profile", (_req, res) => {
+    res.json(profileResponse(config));
+  });
+
+  app.post("/admin/profile", adminRateLimit, adminBodyLimit, express.json({ limit: "32kb" }), (req, res) => {
+    const parsed = AdminProfilePatch.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      jsonError(res, 400, "invalid_profile", "Invalid profile settings.", parsed.error.flatten());
+      return;
+    }
+    try {
+      const existing = readWorkspaceProfile(config.defaultRoot);
+      const payload = buildProfilePayload(config, existing, parsed.data);
+      const profilePath = saveWorkspaceProfile(config.defaultRoot, payload);
+      res.json({
+        ...profileResponse(config),
+        saved: true,
+        profile_path: profilePath,
+        message: "Saved. Restart CodexPro for these profile settings to apply."
+      });
+    } catch (error) {
+      jsonError(res, 400, "invalid_profile", error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  app.all("/admin/profile", (_req, res) => {
+    jsonError(res, 405, "method_not_allowed", "Use GET or POST for /admin/profile.");
+  });
+
+  app.post("/mcp", express.json({ limit: "20mb" }), async (req, res) => {
     try {
       const sessionId = req.headers["mcp-session-id"] as string | undefined;
       let transport: StreamableHTTPServerTransport;

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -1,0 +1,138 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { BashMode, BashTranscriptMode, CodexSessionsMode, ToolMode, WriteMode } from "./config.js";
+import { expandHome } from "./config.js";
+
+export type TunnelMode = "none" | "cloudflare" | "cloudflare-named" | "ngrok";
+export type ConnectorMode = "agent" | "handoff" | "pro";
+
+export interface WorkspaceProfile {
+  version?: number;
+  root?: string;
+  updatedAt?: string;
+  profilePath?: string;
+  port?: string;
+  mode?: ConnectorMode | string;
+  tunnel?: TunnelMode | string;
+  hostname?: string;
+  tunnelName?: string;
+  ngrokConfig?: string;
+  cloudflareConfig?: string;
+  cloudflareTokenFile?: string;
+  cloudflareToken?: string;
+  token?: string;
+  bash?: BashMode | string;
+  bashTranscript?: BashTranscriptMode | string;
+  codexSessions?: CodexSessionsMode | string;
+  codexDir?: string;
+  bashSession?: string;
+  requireBashSession?: boolean;
+  write?: WriteMode | string;
+  toolMode?: ToolMode | string;
+  widgetDomain?: string;
+  noInstallCloudflared?: boolean;
+}
+
+export interface RuntimeConnection {
+  version?: number;
+  root?: string;
+  updatedAt?: string;
+  endpoint?: string;
+  localBase?: string;
+  localStatusUrl?: string;
+  tunnel?: TunnelMode | string;
+  mode?: ConnectorMode | string;
+  bash?: BashMode | string;
+  bashTranscript?: BashTranscriptMode | string;
+  codexSessions?: CodexSessionsMode | string;
+  bashSession?: string;
+  requireBashSession?: boolean;
+  write?: WriteMode | string;
+  toolMode?: ToolMode | string;
+}
+
+export function codexProHome(): string {
+  const customHome = process.env.CODEXPRO_HOME;
+  return customHome ? path.resolve(expandHome(customHome)) : path.join(os.homedir(), ".codexpro");
+}
+
+export function profileDir(): string {
+  return path.join(codexProHome(), "profiles");
+}
+
+export function profileIdForRoot(root: string): string {
+  return createHash("sha256").update(root).digest("hex").slice(0, 24);
+}
+
+export function profilePathForRoot(root: string): string {
+  return path.join(profileDir(), `${profileIdForRoot(root)}.json`);
+}
+
+export function runtimeDir(): string {
+  return path.join(codexProHome(), "runtime");
+}
+
+export function runtimeStatusPathForRoot(root: string): string {
+  return path.join(runtimeDir(), `${profileIdForRoot(root)}.json`);
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+export function readWorkspaceProfile(root: string): WorkspaceProfile {
+  const profilePath = profilePathForRoot(root);
+  if (!fs.existsSync(profilePath)) return {};
+  const profile = readJsonFile(profilePath);
+  if (!profile || typeof profile !== "object" || Array.isArray(profile)) return {};
+  const typed = profile as WorkspaceProfile;
+  if (typed.root && typed.root !== root) return {};
+  return { ...typed, profilePath };
+}
+
+export function saveWorkspaceProfile(root: string, profile: WorkspaceProfile): string {
+  const dir = profileDir();
+  const filePath = profilePathForRoot(root);
+  const { profilePath: _profilePath, ...rest } = profile;
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const payload: WorkspaceProfile = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    ...rest,
+    root
+  };
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Best-effort permission repair for filesystems that support chmod.
+  }
+  return filePath;
+}
+
+export function sanitizeWorkspaceProfile(profile: WorkspaceProfile): WorkspaceProfile {
+  if (!profile || !Object.keys(profile).length) return {};
+  const { token, cloudflareToken, ...rest } = profile;
+  return {
+    ...rest,
+    ...(token ? { token: "<saved>" } : {}),
+    ...(cloudflareToken ? { cloudflareToken: "<saved>" } : {})
+  };
+}
+
+export function readRuntimeConnection(root: string): RuntimeConnection {
+  const runtimePath = runtimeStatusPathForRoot(root);
+  if (!fs.existsSync(runtimePath)) return {};
+  const runtime = readJsonFile(runtimePath);
+  if (!runtime || typeof runtime !== "object" || Array.isArray(runtime)) return {};
+  const typed = runtime as RuntimeConnection;
+  if (typed.root && typed.root !== root) return {};
+  return typed;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -242,6 +242,13 @@ const FULL_TOOL_NAMES = [
   "handoff_to_codex"
 ] as const;
 
+function codexSessionToolNames(config: CodexProConfig): string[] {
+  if (config.codexSessions === "off") return [];
+  return config.codexSessions === "read"
+    ? ["codex_sessions", "read_codex_session"]
+    : ["codex_sessions"];
+}
+
 function toolNamesForMode(config: CodexProConfig): string[] {
   const names: string[] =
     config.toolMode === "full"
@@ -249,9 +256,8 @@ function toolNamesForMode(config: CodexProConfig): string[] {
       : config.toolMode === "minimal"
         ? [...MINIMAL_TOOL_NAMES]
         : [...STANDARD_TOOL_NAMES];
-  if (config.toolMode === "full" && config.codexSessions !== "off") {
-    names.push("codex_sessions");
-    if (config.codexSessions === "read") names.push("read_codex_session");
+  for (const name of codexSessionToolNames(config)) {
+    if (!names.includes(name)) names.push(name);
   }
   return names;
 }
@@ -260,6 +266,8 @@ const MINIMAL_TOOLS = new Set<string>(MINIMAL_TOOL_NAMES);
 const STANDARD_TOOLS = new Set<string>(STANDARD_TOOL_NAMES);
 
 function shouldRegisterTool(config: CodexProConfig, name: string): boolean {
+  if (name === "codex_sessions") return config.codexSessions !== "off";
+  if (name === "read_codex_session") return config.codexSessions === "read";
   if (config.toolMode === "full") return true;
   if (config.toolMode === "minimal") return MINIMAL_TOOLS.has(name);
   return STANDARD_TOOLS.has(name);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { gitDiff, gitLog, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./workspaceOps.js";
 import { buildProContext, exportProContext } from "./proContext.js";
 import { codexproInventory, loadSkill } from "./capabilitiesOps.js";
+import { listCodexSessions, readCodexSession } from "./codexSessions.js";
 import { TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
 
@@ -25,6 +26,32 @@ function textResult(text: string, structuredContent: Record<string, unknown> = {
     structuredContent: redactStructured(structuredContent),
     _meta: meta
   };
+}
+
+function countTextLines(value: string | undefined): number {
+  if (!value) return 0;
+  return value.split(/\r?\n/).filter((line) => line.length > 0).length;
+}
+
+function bashTextResult(config: CodexProConfig, result: Awaited<ReturnType<typeof runBash>>): string {
+  if (config.bashTranscript === "full") {
+    return `# Bash\n\n\`\`\`bash\n$ ${result.command}\n\`\`\`\n\nCWD: ${result.cwd}\nExit: ${result.exitCode}${result.signal ? ` (${result.signal})` : ""}\nDuration: ${result.durationMs} ms\n\n## stdout\n\n\`\`\`text\n${result.stdout || ""}\n\`\`\`\n\n## stderr\n\n\`\`\`text\n${result.stderr || ""}\n\`\`\``;
+  }
+
+  const stdoutLines = countTextLines(result.stdout);
+  const stderrLines = countTextLines(result.stderr);
+  return [
+    "# Bash",
+    "",
+    `\`${result.command}\``,
+    "",
+    `CWD: ${result.cwd}`,
+    `Exit: ${result.exitCode}${result.signal ? ` (${result.signal})` : ""}`,
+    `Duration: ${result.durationMs} ms`,
+    `Output: stdout ${stdoutLines} line${stdoutLines === 1 ? "" : "s"}, stderr ${stderrLines} line${stderrLines === 1 ? "" : "s"}.`,
+    "",
+    "Raw stdout/stderr are in the structured CodexPro card. Start with `--bash-transcript full` to print raw output in chat."
+  ].join("\n");
 }
 
 function errorResult(error: unknown): any {
@@ -216,9 +243,17 @@ const FULL_TOOL_NAMES = [
 ] as const;
 
 function toolNamesForMode(config: CodexProConfig): string[] {
-  if (config.toolMode === "full") return [...FULL_TOOL_NAMES];
-  if (config.toolMode === "minimal") return [...MINIMAL_TOOL_NAMES];
-  return [...STANDARD_TOOL_NAMES];
+  const names: string[] =
+    config.toolMode === "full"
+      ? [...FULL_TOOL_NAMES]
+      : config.toolMode === "minimal"
+        ? [...MINIMAL_TOOL_NAMES]
+        : [...STANDARD_TOOL_NAMES];
+  if (config.toolMode === "full" && config.codexSessions !== "off") {
+    names.push("codex_sessions");
+    if (config.codexSessions === "read") names.push("read_codex_session");
+  }
+  return names;
 }
 
 const MINIMAL_TOOLS = new Set<string>(MINIMAL_TOOL_NAMES);
@@ -252,10 +287,13 @@ function serverInstructions(config: CodexProConfig): string {
     "4. Edit with write/edit. After edits, call show_changes once for git status, diff stats, and review diff.",
     "5. Use bash only for meaningful verification commands such as npm test, npm run build, lint, typecheck, or an existing project script.",
     "6. Keep tool calls minimal. Prefer one targeted search plus show_changes instead of repeated broad bash/git calls.",
+    config.codexSessions !== "off"
+      ? `7. Codex session history access is enabled in ${config.codexSessions} mode. Use it only when the user asks for local Codex session history.`
+      : "",
     config.requireBashSession && config.bashSessionId
-      ? `7. Bash session guard is enabled. Every bash call must include session_id="${config.bashSessionId}".`
+      ? `8. Bash session guard is enabled. Every bash call must include session_id="${config.bashSessionId}".`
       : config.bashSessionId
-        ? `7. Bash session label for this server is "${config.bashSessionId}".`
+        ? `8. Bash session label for this server is "${config.bashSessionId}".`
         : "",
     "",
     `Current modes: tool=${config.toolMode}, bash=${config.bashMode}, write=${config.writeMode}.`
@@ -547,8 +585,11 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         widgetDomain: config.widgetDomain,
         authEnabled: Boolean(config.authToken),
         bashMode: config.bashMode,
+        bashTranscript: config.bashTranscript,
         bashSessionId: config.bashSessionId ?? null,
         requireBashSession: config.requireBashSession,
+        codexSessions: config.codexSessions,
+        codexDir: config.codexDir,
         writeMode: config.writeMode,
         toolMode: config.toolMode,
         inheritEnv: config.inheritEnv,
@@ -1258,7 +1299,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         timeoutMs: args.timeout_ms,
         sessionId: args.session_id
       });
-      const text = `# Bash\n\n\`\`\`bash\n$ ${result.command}\n\`\`\`\n\nCWD: ${result.cwd}\nExit: ${result.exitCode}${result.signal ? ` (${result.signal})` : ""}\nDuration: ${result.durationMs} ms\n\n## stdout\n\n\`\`\`text\n${result.stdout || ""}\n\`\`\`\n\n## stderr\n\n\`\`\`text\n${result.stderr || ""}\n\`\`\``;
+      const text = bashTextResult(config, result);
       return textResult(text, { workspace_id: workspace.id, root: workspace.root, ...result, bash_session_id: result.bashSessionId ?? null });
     }
   );
@@ -1544,6 +1585,86 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       });
     }
   );
+
+  if (config.codexSessions !== "off") {
+    registerCodexTool(
+      config,
+      server,
+      "codex_sessions",
+      {
+        title: "Codex Sessions",
+        description:
+          "Opt-in, read-only local Codex session history browser. Lists metadata from the user's configured Codex session JSONL files without reading full transcripts.",
+        inputSchema: {
+          max_sessions: z.number().int().min(1).max(200).optional().describe("Maximum sessions to return. Default: 30."),
+          query: z.string().optional().describe("Optional case-insensitive search over session id, title, summary, cwd, and source path.")
+        },
+        annotations: READ_ONLY_ANNOTATIONS,
+        _meta: {
+          ...toolCardMeta(),
+          "openai/toolInvocation/invoking": "Listing local Codex sessions...",
+          "openai/toolInvocation/invoked": "Codex sessions ready"
+        }
+      },
+      async (args) => {
+        const result = await listCodexSessions(config, {
+          maxSessions: args.max_sessions,
+          query: args.query
+        });
+        const rows = result.sessions.length
+          ? result.sessions.map((session) => `- ${session.session_id}  ${session.title || "(untitled)"}${session.project_dir ? `  cwd=${session.project_dir}` : ""}`).join("\n")
+          : "- No Codex sessions found.";
+        const text = `# Codex Sessions\n\nCodex dir: ${result.codex_dir}\nMode: ${config.codexSessions}\nTotal matched: ${result.total_found}\n\n${rows}`;
+        return textResult(text, {
+          codex_dir: result.codex_dir,
+          roots: result.roots,
+          sessions: result.sessions,
+          total_found: result.total_found,
+          codex_sessions_mode: config.codexSessions
+        });
+      }
+    );
+
+    if (config.codexSessions === "read") {
+      registerCodexTool(
+        config,
+        server,
+        "read_codex_session",
+        {
+          title: "Read Codex Session",
+          description:
+            "Opt-in, read-only local Codex transcript reader. Requires --codex-sessions read and returns a bounded transcript from a local Codex session JSONL file.",
+          inputSchema: {
+            session_id: z.string().optional().describe("Codex session id from codex_sessions."),
+            source_path: z.string().optional().describe("Source path from codex_sessions. Must be inside the configured Codex session roots."),
+            max_messages: z.number().int().min(1).max(400).optional().describe("Maximum transcript messages. Default: 80."),
+            max_total_bytes: z.number().int().min(4000).max(400000).optional().describe("Maximum transcript content bytes. Default: 80000.")
+          },
+          annotations: READ_ONLY_ANNOTATIONS,
+          _meta: {
+            ...toolCardMeta(),
+            "openai/toolInvocation/invoking": "Reading local Codex session...",
+            "openai/toolInvocation/invoked": "Codex session read"
+          }
+        },
+        async (args) => {
+          const result = await readCodexSession(config, {
+            sessionId: args.session_id,
+            sourcePath: args.source_path,
+            maxMessages: args.max_messages,
+            maxTotalBytes: args.max_total_bytes
+          });
+          return textResult(result.text, {
+            session: result.session,
+            messages: result.messages,
+            message_count: result.messages.length,
+            truncated: result.truncated,
+            codex_sessions_mode: config.codexSessions
+          });
+        }
+      );
+    }
+  }
 
   registerCodexTool(
     config,

--- a/src/toolCardWidget.ts
+++ b/src/toolCardWidget.ts
@@ -711,7 +711,9 @@ export const toolCardWidgetHtml = String.raw`
     ].join("");
     const command = '<span class="prompt">$</span> ' + esc(data.command || "");
     const output = previewLines(data.stdout || data.stderr || "", 18);
-    const outputBox = output ? codebox("output preview", esc(truncate(output, 5000)), "terminal") : '<div class="empty">Command produced no output.</div>';
+    const outputBox = output
+      ? fold("Output preview", totalLines + " lines", codebox("output preview", esc(truncate(output, 5000)), "terminal"), false)
+      : '<div class="empty">Command produced no output.</div>';
     return '<article class="card">' + header(data, pills) + '<div class="body">' +
       '<div class="summary">' +
       summaryItem("Exit", data.exitCode ?? "-") +


### PR DESCRIPTION
## Summary

- Adds a workspace profile store and runtime connection status file so the local admin page can show the current or saved CodexPro Server URL without guessing.
- Reworks the local admin page into a blue/white profile-first dashboard with editable next-start controls for tunnel, hostname, port, mode, bash, write mode, tool mode, Codex sessions, Codex directory, and bash session.
- Keeps widget origin and bash transcript read-only in the browser, keeps raw tokens out of HTML/API responses, and removes fake admin UI placeholder values.
- Adds opt-in Codex session metadata/transcript support and updates CLI setup/settings/docs/smoke coverage around those controls.
- Addresses the Codex review P2s: opted-in session tools now register outside full mode, session metadata listing reads bounded head/tail windows instead of scanning entire transcript files, and relative Codex session directories are resolved against the selected workspace before spawning the child server.
- Fixes empty `CODEXPRO_CODEX_DIR` handling so the default remains `~/.codex` instead of resolving to the home directory.
- Ignores local-only generated folders: `.hallmark/`, `.playwright-cli/`, and `output/`.

## Validation

- `npm run build`
- `npm run smoke`
- `npm audit --audit-level=high` -> 0 vulnerabilities
- `npm pack --dry-run` -> `codexpro@0.28.5`, 63 files, 192.6 kB package size
- `git diff --check`
- Local authenticated health check passed on the loopback admin server
- Local runtime handoff file used real machine-local values and redacted token fields
- Current head: `1a3284f`

## Notes

Draft PR only. Do not merge until the admin UI and docs copy get final review.