### PR TITLE
[codex] Harden Codex CLI handoff execution on Windows

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -331,14 +331,30 @@ function commandPaths(command) {
     .filter(Boolean);
 }
 
+function isWindowsBatchFile(command) {
+  return process.platform === 'win32' && /\.(cmd|bat)$/i.test(command);
+}
+
+function isWindowsExecutableFile(command) {
+  return process.platform === 'win32' && /\.exe$/i.test(command);
+}
+
+function isWindowsCommandCandidate(command) {
+  return isWindowsExecutableFile(command) || isWindowsBatchFile(command);
+}
+
 function resolveCodexCommand() {
-  const explicit = process.env.CODEXPRO_CODEX_BIN;
-  if (explicit) return resolveExecutablePath(explicit);
+  const explicit = String(process.env.CODEXPRO_CODEX_BIN ?? '').trim();
+  if (explicit) {
+    if (isPathLike(explicit)) return resolveExecutablePath(explicit);
+    const candidates = commandPaths(explicit);
+    if (process.platform !== 'win32') return candidates[0] || explicit;
+    return candidates.find(isWindowsCommandCandidate) || explicit;
+  }
   if (process.platform !== 'win32') return 'codex';
 
   const candidates = commandPaths('codex');
-  const spawnable = candidates.find((candidate) => /\.(cmd|exe|bat)$/i.test(candidate));
-  return spawnable || 'codex';
+  return candidates.find(isWindowsCommandCandidate) || 'codex';
 }
 
 function isPathLike(command) {
@@ -1060,7 +1076,7 @@ function buildExecutorCommand(args, root, planPath, planText) {
       'Keep changes scoped to that plan.',
       'Do not modify .ai-bridge/current-plan.md.',
       'When finished, summarize changed files and verification.'
-    ].join('\n');
+    ].join(' ');
     return {
       agent,
       model,
@@ -1102,16 +1118,34 @@ function executorCommandPreview(commandInfo) {
   return shellCommandPreview([commandInfo.command, ...(commandInfo.displayArgs ?? commandInfo.args)]);
 }
 
+function quoteWindowsCmdArg(value) {
+  const text = String(value).replace(/\r?\n/g, ' ');
+  if (!text) return '""';
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function processInvocation(command, args) {
+  if (!isWindowsBatchFile(command)) return { command, args };
+  const commandLine = ['call', quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(' ');
+  return {
+    command: process.env.ComSpec || 'cmd.exe',
+    args: ['/d', '/s', '/c', commandLine],
+    windowsVerbatimArguments: true
+  };
+}
+
 function runProcessCaptured(command, args, options) {
   const timeoutMs = options.timeoutMs;
   const maxOutputBytes = options.maxOutputBytes;
   const started = Date.now();
   return new Promise((resolve) => {
-    const child = spawn(command, args, {
+    const invocation = processInvocation(command, args);
+    const child = spawn(invocation.command, invocation.args, {
       cwd: options.cwd,
       env: { ...process.env, NO_COLOR: '1' },
       stdio: ['ignore', 'pipe', 'pipe'],
-      shell: false
+      shell: false,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments
     });
     let stdout = '';
     let stderr = '';

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -314,6 +314,33 @@ function commandExists(command) {
   return result.status === 0;
 }
 
+function commandPaths(command) {
+  if (process.platform === 'win32') {
+    const result = spawnSync('where', [command], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    if (result.status !== 0) return [];
+    return String(result.stdout)
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  }
+  const result = spawnSync('command', ['-v', command], { encoding: 'utf8', shell: true, stdio: ['ignore', 'pipe', 'ignore'] });
+  if (result.status !== 0) return [];
+  return String(result.stdout)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function resolveCodexCommand() {
+  const explicit = process.env.CODEXPRO_CODEX_BIN;
+  if (explicit) return resolveExecutablePath(explicit);
+  if (process.platform !== 'win32') return 'codex';
+
+  const candidates = commandPaths('codex');
+  const spawnable = candidates.find((candidate) => /\.(cmd|exe|bat)$/i.test(candidate));
+  return spawnable || 'codex';
+}
+
 function isPathLike(command) {
   return command.includes('/') || command.includes('\\') || command.startsWith('.');
 }
@@ -1026,12 +1053,42 @@ function buildExecutorCommand(args, root, planPath, planText) {
     };
   }
   if (agent === 'codex') {
+    const codexLastMessagePath = path.join(path.dirname(planPath), 'codex-last-message.md');
+    const relativePlanPath = path.relative(root, planPath) || planPath;
+    const codexPrompt = [
+      `Read the handoff plan at ${relativePlanPath} and execute it in this workspace.`,
+      'Keep changes scoped to that plan.',
+      'Do not modify .ai-bridge/current-plan.md.',
+      'When finished, summarize changed files and verification.'
+    ].join('\n');
     return {
       agent,
       model,
-      command: 'codex',
-      args: ['exec', ...(model ? ['--model', model] : []), planText],
-      displayArgs: ['exec', ...(model ? ['--model', model] : []), '<plan_text>'],
+      command: resolveCodexCommand(),
+      args: [
+        'exec',
+        '--ephemeral',
+        '--sandbox',
+        'workspace-write',
+        '-c',
+        'approval_policy="never"',
+        '--output-last-message',
+        codexLastMessagePath,
+        ...(model ? ['--model', model] : []),
+        codexPrompt
+      ],
+      displayArgs: [
+        'exec',
+        '--ephemeral',
+        '--sandbox',
+        'workspace-write',
+        '-c',
+        'approval_policy="never"',
+        '--output-last-message',
+        path.relative(root, codexLastMessagePath),
+        ...(model ? ['--model', model] : []),
+        `<read ${relativePlanPath}>`
+      ],
       custom: false
     };
   }
@@ -1122,11 +1179,27 @@ function readGitDiff(root, maxBytes) {
   return trimBytes(diff, maxBytes).text;
 }
 
+function readGitStatus(root, maxBytes) {
+  const result = spawnSync('git', ['status', '--short'], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: Math.max(maxBytes * 2, 1_000_000),
+    shell: false
+  });
+  if (result.status !== 0) {
+    const reason = result.stderr || result.stdout || `git status exited ${result.status}`;
+    return `# git status unavailable\n\n${redactForLog(reason).trim()}\n`;
+  }
+  const status = result.stdout || '';
+  if (!status.trim()) return '';
+  return trimBytes(status, maxBytes).text;
+}
+
 function codeBlock(label, value) {
   return `## ${label}\n\n\`\`\`text\n${String(value || '').replace(/```/g, '`\\`\\`') || '(empty)'}\n\`\`\`\n`;
 }
 
-function writeExecutionOutputs(root, contextDir, commandInfo, result, diffText) {
+function writeExecutionOutputs(root, contextDir, commandInfo, result, diffText, gitStatusText) {
   const bridgeDir = resolveWorkspaceFile(root, contextDir);
   fs.mkdirSync(bridgeDir, { recursive: true, mode: 0o700 });
   const statusPath = path.join(bridgeDir, 'agent-status.md');
@@ -1147,6 +1220,8 @@ function writeExecutionOutputs(root, contextDir, commandInfo, result, diffText) 
     `Diff path: ${path.posix.join(contextDir, 'implementation-diff.patch')}`,
     `Execution log: ${path.posix.join(contextDir, 'execution-log.jsonl')}`,
     '',
+    codeBlock('Git status excerpt', gitStatusText),
+    '',
     codeBlock('Stdout excerpt', result.stdout),
     codeBlock('Stderr excerpt', result.stderr)
   ].filter(Boolean).join('\n');
@@ -1164,6 +1239,7 @@ function writeExecutionOutputs(root, contextDir, commandInfo, result, diffText) 
     duration_ms: result.durationMs,
     stdout_excerpt: result.stdout,
     stderr_excerpt: result.stderr,
+    git_status_excerpt: gitStatusText || undefined,
     diff_path: path.posix.join(contextDir, 'implementation-diff.patch'),
     status_path: path.posix.join(contextDir, 'agent-status.md')
   };
@@ -1248,7 +1324,8 @@ async function executeHandoffRequest(request, args, options = {}) {
     maxOutputBytes: request.maxOutputBytes
   });
   const diffText = readGitDiff(request.root, request.maxOutputBytes);
-  const outputs = writeExecutionOutputs(request.root, request.contextDir, request.commandInfo, result, diffText);
+  const gitStatusText = readGitStatus(request.root, request.maxOutputBytes);
+  const outputs = writeExecutionOutputs(request.root, request.contextDir, request.commandInfo, result, diffText, gitStatusText);
   statusLine(result.exitCode === 0 ? 'ok' : 'warn', `Agent exited with code ${result.exitCode ?? 'null'}${result.signal ? ` signal=${result.signal}` : ''}`);
   console.log(`Status: ${path.relative(request.root, outputs.statusPath)}`);
   console.log(`Diff:   ${path.relative(request.root, outputs.diffPath)}`);

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -139,7 +139,8 @@ const fakeCodexEnv = {
   ...process.env,
   NO_COLOR: '1',
   CODEXPRO_FAKE_CODEX_LOG: fakeCodexLog,
-  PATH: `${fakeCodexBin}${path.delimiter}${process.env.PATH ?? ''}`
+  PATH: `${fakeCodexBin}${path.delimiter}${process.env.PATH ?? process.env.Path ?? ''}`,
+  Path: `${fakeCodexBin}${path.delimiter}${process.env.Path ?? process.env.PATH ?? ''}`
 };
 
 const codexDryRun = run([
@@ -182,6 +183,41 @@ if (!codexLastMessage.includes('fake codex last message')) {
 }
 if (!codexApp.includes('codex adapter executed')) {
   throw new Error(`codex adapter did not execute fake codex\n${codexApp}`);
+}
+
+const explicitCodexEnv = {
+  ...fakeCodexEnv,
+  CODEXPRO_CODEX_BIN: 'codex'
+};
+const explicitCodexDryRun = run([
+  'execute-handoff',
+  '--root',
+  root,
+  '--agent',
+  'codex',
+  '--model',
+  'gpt-explicit',
+  '--dry-run'
+], { env: explicitCodexEnv });
+requireSuccess(explicitCodexDryRun, 'execute-handoff CODEXPRO_CODEX_BIN command-name dry-run');
+if (explicitCodexDryRun.stdout.includes(path.join(root, 'codex'))) {
+  throw new Error(`CODEXPRO_CODEX_BIN=codex resolved as a cwd-relative path\n${explicitCodexDryRun.stdout}`);
+}
+
+const explicitCodexExecuted = run([
+  'execute-handoff',
+  '--root',
+  root,
+  '--agent',
+  'codex',
+  '--model',
+  'gpt-explicit',
+  '--yes'
+], { env: explicitCodexEnv });
+requireSuccess(explicitCodexExecuted, 'execute-handoff CODEXPRO_CODEX_BIN command-name');
+const explicitFakeCodexArgs = JSON.parse(await fs.readFile(fakeCodexLog, 'utf8'));
+if (!explicitFakeCodexArgs.includes('gpt-explicit')) {
+  throw new Error(`CODEXPRO_CODEX_BIN command-name did not execute through PATH\n${JSON.stringify(explicitFakeCodexArgs)}`);
 }
 
 const watchRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-watch-handoff-'));

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -90,7 +90,7 @@ const diff = await fs.readFile(path.join(root, '.ai-bridge', 'implementation-dif
 const log = await fs.readFile(path.join(root, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
 const app = await fs.readFile(path.join(root, 'app.txt'), 'utf8');
 
-for (const expected of ['Agent Execution Status', 'Agent: custom', 'Exit code: 0', 'fake agent completed']) {
+for (const expected of ['Agent Execution Status', 'Agent: custom', 'Exit code: 0', 'Git status excerpt', 'app.txt', 'fake agent completed']) {
   if (!status.includes(expected)) throw new Error(`status missing ${expected}\n${status}`);
 }
 if (!diff.includes('implemented with local/test-model')) {
@@ -101,6 +101,87 @@ if (!log.includes('"event":"execute_handoff"') || !log.includes('"agent":"custom
 }
 if (!app.includes('implemented with local/test-model: yes')) {
   throw new Error(`fake agent did not edit app.txt\n${app}`);
+}
+
+const fakeCodexBin = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-fake-codex-bin-'));
+const fakeCodexLog = path.join(root, 'fake-codex-args.json');
+const fakeCodexScript = path.join(root, 'fake-codex.mjs');
+await fs.writeFile(fakeCodexScript, `
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+fs.writeFileSync(process.env.CODEXPRO_FAKE_CODEX_LOG, JSON.stringify(args, null, 2));
+if (args[0] !== 'exec') throw new Error('expected codex exec');
+if (!args.includes('--ephemeral')) throw new Error('missing --ephemeral');
+if (!args.includes('workspace-write')) throw new Error('missing workspace-write sandbox');
+if (!args.includes('approval_policy="never"')) throw new Error('missing approval_policy never');
+const outputIndex = args.indexOf('--output-last-message');
+if (outputIndex < 0) throw new Error('missing --output-last-message');
+if (!args.at(-1)?.includes('current-plan.md')) throw new Error('missing plan file prompt');
+fs.writeFileSync(args[outputIndex + 1], 'fake codex last message\\n');
+fs.appendFileSync('app.txt', 'codex adapter executed\\n');
+console.log('fake codex completed');
+`, 'utf8');
+
+if (process.platform === 'win32') {
+  await fs.writeFile(
+    path.join(fakeCodexBin, 'codex.cmd'),
+    `@echo off\r\n"${process.execPath}" "${fakeCodexScript}" %*\r\n`,
+    'utf8'
+  );
+} else {
+  const fakeCodexPath = path.join(fakeCodexBin, 'codex');
+  await fs.writeFile(fakeCodexPath, `#!/usr/bin/env sh\nexec "${process.execPath}" "${fakeCodexScript}" "$@"\n`, 'utf8');
+  await fs.chmod(fakeCodexPath, 0o755);
+}
+
+const fakeCodexEnv = {
+  ...process.env,
+  NO_COLOR: '1',
+  CODEXPRO_FAKE_CODEX_LOG: fakeCodexLog,
+  PATH: `${fakeCodexBin}${path.delimiter}${process.env.PATH ?? ''}`
+};
+
+const codexDryRun = run([
+  'execute-handoff',
+  '--root',
+  root,
+  '--agent',
+  'codex',
+  '--model',
+  'gpt-test',
+  '--dry-run'
+], { env: fakeCodexEnv });
+requireSuccess(codexDryRun, 'execute-handoff codex dry-run');
+for (const expected of ['codex', 'exec', '--ephemeral', 'workspace-write', 'approval_policy="never"', 'codex-last-message.md', 'current-plan.md']) {
+  if (!codexDryRun.stdout.includes(expected)) {
+    throw new Error(`codex dry-run missing ${expected}\n${codexDryRun.stdout}`);
+  }
+}
+
+const codexExecuted = run([
+  'execute-handoff',
+  '--root',
+  root,
+  '--agent',
+  'codex',
+  '--model',
+  'gpt-test',
+  '--yes'
+], { env: fakeCodexEnv });
+requireSuccess(codexExecuted, 'execute-handoff codex');
+
+const fakeCodexArgs = JSON.parse(await fs.readFile(fakeCodexLog, 'utf8'));
+const codexLastMessage = await fs.readFile(path.join(root, '.ai-bridge', 'codex-last-message.md'), 'utf8');
+const codexApp = await fs.readFile(path.join(root, 'app.txt'), 'utf8');
+if (!fakeCodexArgs.includes('gpt-test')) {
+  throw new Error(`codex adapter did not pass model\n${JSON.stringify(fakeCodexArgs)}`);
+}
+if (!codexLastMessage.includes('fake codex last message')) {
+  throw new Error(`codex adapter did not write last message\n${codexLastMessage}`);
+}
+if (!codexApp.includes('codex adapter executed')) {
+  throw new Error(`codex adapter did not execute fake codex\n${codexApp}`);
 }
 
 const watchRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-watch-handoff-'));


### PR DESCRIPTION
## Summary
- make the built-in Codex handoff executor resolve a spawnable Codex command on Windows
- pass a bounded prompt that asks Codex CLI to read `.ai-bridge/current-plan.md` instead of sending the full multiline plan as an argv value
- capture `git status --short` in handoff status/log output so untracked side effects are visible
- extend the handoff smoke test with a fake Codex CLI adapter check

## Why
Windows npm shims can make `spawn('codex')` fail with `EPERM`, and passing multiline handoff text as a command-line argument can be truncated by `.cmd` wrappers. Reading the handoff plan from the workspace file is more reliable and keeps the execution boundary explicit.

## Relationship to #17
This PR is intentionally scoped to the local handoff executor path. It does not change the admin profile UI, profile storage model, or Codex session/transcript features being developed in #17. If #17 lands first, this branch may need a small rebase because both PRs touch `scripts/codexpro.mjs`.

## Validation
- `npm run build`
- `node scripts/execute-handoff-smoke.mjs`
- `npm run smoke`
- `git diff --check`
- real Windows validation with `codex exec` against a temporary repo: Codex read `.ai-bridge/current-plan.md` and updated `README.md`

## Notes
The real Codex CLI validation also showed user-level Codex plugins/MCP configuration can create untracked side effects such as `.spec-workflow/`. This change does not try to disable user configuration globally; instead it records git status in handoff output so those side effects are visible.