### PR TITLE
[codex] improve product safety and setup UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.28.5
 
+- Added a compatibility alias for stale ChatGPT descriptors that still request `ui://widget/codexpro-tool-card-v8.html`, while keeping `ui://widget/codexpro-tool-card-v9.html` as the current advertised widget.
+- Stopped advertising the `bash` MCP tool when `CODEXPRO_BASH_MODE=off` / `codexpro start --no-bash` is active, so ChatGPT has less opportunity to attempt a shell tool call in no-bash sessions.
+- Stopped advertising direct `write` and `edit` tools unless `CODEXPRO_WRITE_MODE=workspace`; handoff/off modes keep handoff planning tools available for bounded `.ai-bridge` plan files without exposing generic source edit actions.
+- Added smoke coverage that compares `codexpro_self_test` expected tools against the actually registered MCP tool set, so disabled tools cannot silently remain visible in ChatGPT's tool list.
+- Tightened `CODEXPRO_CONTEXT_DIR` to workspace-relative hidden directories such as `.ai-bridge`, rejecting source/build/dependency/credential directories and absolute paths.
+- Made saved profile handling stricter: non-agent modes cannot inherit `write=workspace`, relative tunnel config/token paths resolve from the workspace, and `settings set` refuses to persist raw Cloudflare tunnel tokens.
+- Completed the local admin profile form for named Cloudflare/ngrok settings, including tunnel name, config paths, token-file path, and cloudflared auto-install preference.
 - Fixed path-scoped `show_changes` so unrelated workspace status is not reported for a clean requested path.
 - Kept duplicate `load_skill` matches ambiguous until the caller supplies the exact displayed skill path.
 - Added `codexpro_self_test`, a local-only diagnostic that checks modes, expected tools, safe bash policy, selected-only Pro context, and an optional `.ai-bridge/codexpro-self-test.md` write/edit probe without touching source files.

--- a/FAQ.md
+++ b/FAQ.md
@@ -10,6 +10,26 @@ CodexPro does not unlock Developer Mode, unlock models, bypass account limits, o
 
 Account access and model tool support are separate. A Plus or Pro account can have Apps / Developer Mode, while a specific model surface may still be unable to call connectors or MCP tools directly. Use the Pro context fallback for those sessions.
 
+## How is CodexPro different from DevSpace?
+
+They can look similar at the transport layer because both use a local MCP-style bridge and a workspace root.
+
+CodexPro is more focused: it is built around one clear product loop for ChatGPT users:
+
+```text
+install -> setup in one repo -> paste Server URL into ChatGPT -> inspect/edit/verify/review that repo
+```
+
+The main differences are:
+
+- CodexPro is ChatGPT Developer Mode first, not a generic workspace bridge.
+- Bash, write/edit, tool mode, Codex session reads, and handoff execution are separate safety controls.
+- Durable context is repo-backed through `AGENTS.md` and `.ai-bridge/*`, so important project memory stays reviewable in files.
+- The normal workflow emphasizes compact cards, diffs, `show_changes`, smoke tests, and handoff status files.
+- CodexPro keeps a strict boundary: no model proxying, account pooling, third-party Pro site scraping, quota bypassing, or OS sandbox claims.
+
+Short version: DevSpace-style tools may share the bridge idea; CodexPro is the cleaner ChatGPT-to-local-repo coding agent workflow with stricter defaults and clearer review surfaces.
+
 ## What is the recommended install path?
 
 Install globally once:
@@ -110,7 +130,9 @@ Safety defaults block common sensitive paths:
 - symlink escapes
 - paths outside the workspace
 
-Use handoff mode if you want ChatGPT to write a plan only and let Codex execute locally.
+Use handoff mode if you want ChatGPT to write a plan only and let Codex execute locally. In handoff mode, generic `write` and `edit` tools are not advertised to ChatGPT.
+
+Use `CODEXPRO_WRITE_MODE=off` when you want direct `write` and `edit` tools removed from the advertised MCP tool list while still allowing bounded handoff/context files.
 
 ## Can CodexPro bind bash to a specific session id?
 
@@ -129,7 +151,7 @@ Then `bash` calls must include `session_id: "main"`. This helps avoid accidental
 CodexPro can list local Codex session ids and titles when you explicitly opt in:
 
 ```bash
-codexpro start --tool-mode full --codex-sessions metadata
+codexpro start --codex-sessions metadata
 ```
 
 This reads local Codex JSONL history under `~/.codex/sessions` and `~/.codex/archived_sessions` and returns metadata plus `codex resume <session-id>` commands. Use `--codex-sessions read` only if you also want bounded transcript reads. It does not attach to a live Codex app conversation.
@@ -139,6 +161,8 @@ If you do not want ChatGPT to trigger shell commands while you work in Codex, st
 ```bash
 codexpro start --no-bash
 ```
+
+This removes the `bash` MCP tool from the advertised tool list. ChatGPT can still use non-bash CodexPro tools such as workspace open, read, search, and show_changes. Direct `write`/`edit` are advertised only in workspace write mode.
 
 If you only want ChatGPT to plan and leave execution to Codex or another local agent:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">CodexPro</h1>
 
 <p align="center">
-  Let ChatGPT web see your Codex-style repo context and act like a local coding agent.
+  Use ChatGPT like your local coding agent for one token-protected workspace.
 </p>
 
 <p align="center">
@@ -58,9 +58,9 @@ After setup, daily use from the same repo is just:
 codexpro start
 ```
 
-CodexPro turns ChatGPT Developer Mode into a local coding agent for that folder. It gives ChatGPT bounded MCP tools for file reads, code search, exact edits, git inspection, safe verification commands, and explicit Codex-style context from `AGENTS.md`, `.ai-bridge`, git state, and selected source files.
+CodexPro turns ChatGPT Developer Mode into a local coding agent for that folder. It gives ChatGPT bounded MCP tools for file reads, code search, exact edits, git inspection, safe verification commands, and explicit repo-backed context from `AGENTS.md`, `.ai-bridge`, git state, and selected source files.
 
-CodexPro is not a rate-limit bypass. It uses ChatGPT's official Developer Mode and MCP app path to connect your own ChatGPT session to your own local repo. ChatGPT and Codex remain separate product surfaces, each subject to its own plan limits, safety rules, and availability.
+CodexPro is not a rate-limit bypass, model proxy, hosted SaaS, or OS sandbox. It uses ChatGPT's official Developer Mode and MCP app path to connect your own ChatGPT session to your own local repo. ChatGPT and Codex remain separate product surfaces, each subject to its own plan limits, safety rules, and availability.
 
 ## Quick Choices
 
@@ -75,6 +75,15 @@ CodexPro is not a rate-limit bypass. It uses ChatGPT's official Developer Mode a
 | Compact chat transcript | default bash cards; use `--bash-transcript full` only when needed |
 | Local Codex history lookup | opt in with `--codex-sessions metadata` or `read` |
 
+## Product Boundary
+
+| CodexPro is | CodexPro is not |
+| --- | --- |
+| A local MCP bridge for the workspace you choose | A hosted coding service |
+| A way for ChatGPT Developer Mode to inspect, edit, verify, and hand off work | A model unlock, proxy, resale layer, or quota workaround |
+| A repo-backed context system using explicit files such as `AGENTS.md` and `.ai-bridge` | Permanent ChatGPT memory across every chat |
+| A developer tool with conservative defaults | An OS sandbox or substitute for repo/terminal judgment |
+
 ## Why CodexPro?
 
 | ChatGPT gets | CodexPro provides |
@@ -88,6 +97,20 @@ CodexPro is not a rate-limit bypass. It uses ChatGPT's official Developer Mode a
 If one workflow is unavailable and another product surface you already have access to is still available, CodexPro lets you keep working against the same local repo without modifying or evading either product's limits.
 
 If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some ChatGPT model surfaces may not be able to call connectors or MCP tools directly. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
+
+## CodexPro vs DevSpace-style bridges
+
+The high-level shape can look similar because both use a local MCP bridge, a tunnel, and a workspace root. CodexPro is narrower and more opinionated: it is built to make ChatGPT Developer Mode work like a practical local coding agent for one repo.
+
+| CodexPro focuses on | Why it matters |
+| --- | --- |
+| ChatGPT-first coding loop | The first-run path is install, setup in a repo, paste one Server URL, then let ChatGPT inspect, edit, verify, and review that workspace. |
+| Explicit safety modes | Bash, write/edit, tool catalog size, Codex session reads, and handoff execution are separate controls instead of one broad remote-control switch. |
+| Repo-backed continuity | `AGENTS.md` and `.ai-bridge/*` keep durable project context in the repo, not hidden in a chat transcript or one machine-local UI state. |
+| Reviewable outputs | Tool cards, diffs, `show_changes`, smoke tests, and handoff status files are designed so users can see what changed before trusting it. |
+| TOS-safe product boundary | CodexPro does not proxy models, pool accounts, scrape third-party Pro sites, bypass quotas, or pretend to be an OS sandbox. |
+
+So the short answer is: DevSpace-style bridges may share the transport idea, but CodexPro is positioned as the cleaner ChatGPT-to-local-repo coding product with stricter defaults, clearer admin controls, and a repo-first agent workflow.
 
 ## Preview
 
@@ -158,9 +181,9 @@ Standard mode exposes:
 - `search` — search code with ripgrep or a Node fallback.
 - `load_skill` — load bounded `SKILL.md` instructions for a discovered workspace, user, or plugin skill by name, with optional source/path disambiguation.
 - `read` — read text files with line numbers.
-- `write` — create/overwrite files and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
-- `edit` — exact text replacement and return a diff. Controlled by `CODEXPRO_WRITE_MODE`.
-- `bash` — run allowlisted shell commands in the workspace. Controlled by `CODEXPRO_BASH_MODE`.
+- `write` — create/overwrite files and return a diff. Advertised only when `CODEXPRO_WRITE_MODE=workspace`.
+- `edit` — exact text replacement and return a diff. Advertised only when `CODEXPRO_WRITE_MODE=workspace`.
+- `bash` — run allowlisted shell commands in the workspace. Hidden when `CODEXPRO_BASH_MODE=off`.
 - `show_changes` — one review-oriented summary with git status, diff stats, and optional diff.
 - `read_handoff` — read `.ai-bridge` files.
 - `export_pro_context` — write `.ai-bridge/pro-context.md` for models that cannot call MCP tools directly.
@@ -471,7 +494,7 @@ codexpro settings set --tunnel cloudflare
 codexpro settings delete --yes
 ```
 
-Use `codexpro settings` when you want to make ngrok the default, switch back to Cloudflare quick tunnels, reuse a saved setup from another repo, or delete the saved workspace preference. The saved token is redacted when settings are shown.
+Use `codexpro settings` when you want to make ngrok the default, switch back to Cloudflare quick tunnels, reuse a saved setup from another repo, or delete the saved workspace preference. The saved token is redacted when settings are shown. `settings set` does not persist raw Cloudflare tunnel tokens; save those to a local file and use `--cloudflare-token-file`.
 
 Terminal controls:
 
@@ -492,7 +515,7 @@ codexpro start                 # normal coding mode: read/write/edit/search/bash
 codexpro start --no-bash       # normal coding mode without ChatGPT-triggered shell commands
 codexpro start --bash-transcript full  # print raw stdout/stderr in chat instead of compact cards
 codexpro start --bash-session main --require-bash-session
-codexpro start --tool-mode full --codex-sessions metadata
+codexpro start --codex-sessions metadata
 codexpro setup                 # guided onboarding for new users
 codexpro start --mode handoff  # planning-only .ai-bridge handoff
 codexpro start --mode handoff --no-bash
@@ -1017,20 +1040,22 @@ Example MCP config:
 `CODEXPRO_WRITE_MODE=workspace` is the default normal coding mode. Use `handoff` when you want planning-only behavior and do not want ChatGPT to edit source files directly.
 
 ```text
-off        write/edit tools are disabled; handoff_to_agent and handoff_to_codex still write .ai-bridge/current-plan.md
-handoff    write/edit can only write inside .ai-bridge/
+off        write/edit tools are disabled and not advertised; handoff_to_agent and handoff_to_codex still write .ai-bridge/current-plan.md
+handoff    generic write/edit tools are disabled and not advertised; handoff tools write only bounded .ai-bridge plan/context files
 workspace  write/edit can write workspace files, except blocked paths
 ```
 
 The launcher defaults to `workspace` in normal coding mode and `handoff` in handoff/pro planning modes.
+
+`CODEXPRO_CONTEXT_DIR` controls the bounded handoff/context directory. It must be a workspace-relative hidden directory such as `.ai-bridge`; source, build, dependency, credential, absolute, and escaping paths are rejected.
 
 ## Tool modes
 
 `CODEXPRO_TOOL_MODE=standard` is the default. It exposes the normal coding loop plus `show_changes`, Pro context export, and generic agent handoff.
 
 ```text
-minimal   smallest surface for demos and simple coding: open/read/write/edit/bash/show_changes
-standard  default surface for normal coding plus handoff/export
+minimal   smallest surface for demos and simple coding: open/read/write/edit/bash/show_changes, with write/bash removed when their modes are disabled
+standard  default surface for normal coding plus handoff/export, with write/edit only in workspace write mode
 full      all tools, including inventory, workspace snapshots, raw git tools, codex_context, and compatibility wrappers
 ```
 
@@ -1054,7 +1079,7 @@ pytest, go test, cargo test, cargo check, cargo clippy, tsc, eslint, biome check
 
 Use the MCP `read` and `search` tools for file contents. The safe shell blocks obvious destructive commands, redirects, pipes, `curl`, `wget`, `ssh`, `docker`, `git push/reset/clean/checkout/switch/restore`, `find -exec`, `find -delete`, and file-content shell readers such as `cat`, `grep`, `rg`, `head`, and `tail`.
 
-`CODEXPRO_BASH_MODE=off` disables bash completely. `codexpro start --no-bash` is the CLI shortcut for the same setting.
+`CODEXPRO_BASH_MODE=off` disables bash completely and removes the `bash` MCP tool from the advertised tool list. `codexpro start --no-bash` is the CLI shortcut for the same setting.
 
 `CODEXPRO_BASH_MODE=full` allows arbitrary shell commands. Use this only for trusted local repos; MCP itself is not an OS sandbox.
 
@@ -1088,11 +1113,11 @@ By default, bash results use a compact transcript so ChatGPT does not fill the c
 codexpro start --bash-transcript full
 ```
 
-CodexPro can also expose an opt-in, read-only local Codex session browser when full tools are enabled:
+CodexPro can also expose an opt-in, read-only local Codex session browser in any tool mode:
 
 ```bash
-codexpro start --tool-mode full --codex-sessions metadata
-codexpro start --tool-mode full --codex-sessions read
+codexpro start --codex-sessions metadata
+codexpro start --codex-sessions read
 ```
 
 `metadata` adds a `codex_sessions` tool that lists local session ids, titles, cwd paths, source files, and `codex resume <session-id>` commands from `~/.codex/sessions` and `~/.codex/archived_sessions`. `read` also adds `read_codex_session` for bounded transcript reads. This is similar to local session managers that scan Codex JSONL history; it still does not attach to a live Codex app chat, execute inside that session, or bypass any product limits.
@@ -1147,7 +1172,7 @@ Act as a coding agent. Inspect the relevant files, make the requested source edi
 Keep changes scoped to the request. Do not use handoff_to_agent unless I explicitly ask for planning-only handoff.
 ```
 
-After upgrading CodexPro or changing the Server URL, refresh the app actions in ChatGPT before judging the card UI. Existing cards do not retroactively re-render after a widget URI change.
+After upgrading CodexPro or changing the Server URL, refresh/reconnect the app actions in ChatGPT, then trigger a fresh `open_current_workspace` call before judging the card UI. Existing chat cards do not retroactively re-render after a widget URI change. CodexPro still serves the old v8 widget URI as a compatibility alias, but current tool descriptors advertise v9.
 
 ## Prompt for a local agent
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,9 +25,24 @@ CodexPro can expose:
 - file metadata and selected file contents from allowed workspaces
 - git status and diffs
 - `.ai-bridge` planning files
-- optional shell command execution through the `bash` tool
-- optional write/edit capability depending on `CODEXPRO_WRITE_MODE`
+- optional shell command execution through the `bash` tool, hidden when bash mode is off
+- optional write/edit capability depending on `CODEXPRO_WRITE_MODE`, advertised only in workspace write mode
 - optional local handoff execution through `codexpro execute-handoff`, run from the user's terminal only
+
+## Failure Model
+
+Review changes against these failure modes before release:
+
+| Failure mode | Expected control |
+| --- | --- |
+| Public tunnel reachable without a secret | Public/non-loopback HTTP fails closed unless a CodexPro token is configured. |
+| Raw CodexPro or Cloudflare token appears in UI, logs, docs, or package output | Tokens are redacted in profile/status output and tunnel tokens use local files for persistence. |
+| ChatGPT can edit outside the intended repo | Allowed roots are explicit; path resolution rejects escapes, blocked globs, and symlink traversal. |
+| ChatGPT can run arbitrary shell by default | Bash defaults to safe mode, can be disabled, and full mode is a trusted-local-only choice. |
+| Handoff mode still exposes generic writes | Handoff/pro modes do not advertise generic `write`/`edit`; bounded handoff tools write `.ai-bridge` files only. |
+| Local Codex history is treated as ChatGPT memory | Codex session access is opt-in metadata/read mode and never attaches to a live Codex app session. |
+| Browser admin mutates live runtime unexpectedly | Admin profile changes apply on restart; active runtime policy stays stable for the current session. |
+| Remote MCP tool runs Codex/OpenCode/Pi directly | Agent execution remains a user-started CLI/watch process on the local machine. |
 
 The main risks are:
 
@@ -80,13 +95,14 @@ codexpro start \
 - Do not commit printed connector URLs that include `codexpro_token`.
 - Do not commit Cloudflare tunnel tokens.
 - Do not paste raw Cloudflare tunnel tokens into browser pages or screenshots. Use `--cloudflare-token-file` or the local page's Cloudflare token file field instead.
-- Use `--mode handoff` for planning workflows where ChatGPT should not edit source files.
+- Use `--mode handoff` for planning workflows where ChatGPT should not edit source files. Handoff mode does not advertise generic `write`/`edit` tools.
 - Preview local handoff execution with `codexpro execute-handoff --dry-run` before running an unfamiliar adapter or custom command.
 - Keep `execute-handoff` local. Do not wrap it in a remote MCP tool unless you add a stronger approval and sandbox story.
 - Use default agent mode only with trusted ChatGPT sessions and repo-specific roots.
 - Use `--no-bash` when ChatGPT should never trigger shell commands in the workspace.
 - Use `--bash-session <id> --require-bash-session` when bash should be enabled only for calls that explicitly target this local CodexPro terminal label.
 - Keep Codex session history access off unless needed. `--codex-sessions metadata` only lists local Codex JSONL metadata; `--codex-sessions read` allows bounded transcript reads.
+- Keep `CODEXPRO_CONTEXT_DIR` as a workspace-relative hidden directory such as `.ai-bridge`; CodexPro rejects source, build, dependency, credential, and absolute context directories.
 - Use `--bash full` only for trusted local repos.
 - Do not treat MCP session ids or bash session labels as Codex conversation ids. CodexPro does not execute inside a Codex app session.
 - Prefer a repo-specific `--root` instead of `--allow-home`.

--- a/design.md
+++ b/design.md
@@ -1,0 +1,77 @@
+# Design - CodexPro
+
+A locked product-system note for CodexPro docs and the local admin surface.
+Every redesign should keep the same trust story: ChatGPT can act on one local
+workspace through a token-protected MCP bridge, while shell, writes, Codex
+history, and handoff execution stay explicit user choices.
+
+## Genre
+
+modern-minimal developer tool
+
+## Positioning
+
+Use ChatGPT like your local coding agent.
+
+CodexPro should explain itself in this order:
+
+1. Install the CLI.
+2. Run setup inside one repo.
+3. Paste the copied Server URL into ChatGPT Developer Mode.
+4. Let ChatGPT inspect, edit, verify, or hand off work inside that workspace.
+5. Keep the safety boundary visible: it is a local bridge, not a quota bypass,
+   model proxy, hosted SaaS, or OS sandbox.
+
+## Macrostructure Family
+
+- Marketing/docs pages: left-led product workbench with a visible three-step
+  path, trust boundary, and reference sections below.
+- Local admin pages: compact control surface with connection profile first,
+  live runtime guardrails second, CLI-only controls below, and raw paths
+  visually secondary.
+- Content pages: long-document reference with short setup recipes first and
+  detailed options after.
+
+## Theme
+
+- Paper: near-white blue
+- Ink: deep neutral blue-black
+- Accent: Codex blue
+- Accent use: links, primary actions, selected tabs, status highlights
+- Avoid: orange/amber, purple gradients, fake terminal/browser frames, invented
+  metrics, and decorative glow.
+
+## Typography
+
+- Display: Geist-like system sans, heavy weight, normal style.
+- Body: system sans, normal style.
+- Mono: system monospace for commands, paths, tool names, and IDs only.
+- Headings stay compact. Hero copy should be short enough to read in one scan.
+
+## Spacing
+
+Use a 4-point rhythm. Dense admin controls can use row dividers and grouped
+fieldsets. Marketing sections can breathe, but the first viewport must still
+show installation and trust details.
+
+## Motion
+
+No cinematic motion. Use hover, active press, copy confirmation, and reduced
+motion support. Animate transform and opacity only.
+
+## Copy Rules
+
+- Say what CodexPro does, then say what it does not do.
+- Do not claim permanent ChatGPT memory. Say repo-backed context files.
+- Do not imply CodexPro unlocks models, bypasses limits, or automates approval
+  gates.
+- Do not expose raw local paths as marketing proof. Local admin can show them
+  because it is token-protected and opened by the local user.
+
+## Shared Components
+
+- Primary action: blue filled button.
+- Secondary action: white button with blue border.
+- Trust boundary: compact list or table near setup.
+- Commands: real text blocks with copy buttons, no fake terminal chrome.
+- Admin panels: white surfaces, 1px blue-gray rules, no nested-card clutter.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>CodexPro - ChatGPT web with local coding-agent powers</title>
+    <title>CodexPro - Use ChatGPT like your local coding agent</title>
     <meta
       name="description"
-      content="CodexPro gives ChatGPT Developer Mode local coding-agent powers through MCP, including Codex-style context, source edits, git inspection, and safe verification."
+      content="CodexPro connects ChatGPT Developer Mode to one local workspace through MCP so ChatGPT can inspect, edit, verify, and hand off code safely."
     />
     <meta property="og:title" content="CodexPro" />
-    <meta property="og:description" content="Let ChatGPT web see Codex-style repo context and act like a local coding agent." />
+    <meta property="og:description" content="Use ChatGPT like your local coding agent for one token-protected workspace." />
     <meta property="og:image" content="https://rebel0789.github.io/codexpro/og.svg" />
     <meta name="theme-color" content="#0b1220" />
     <link rel="alternate" hreflang="zh-CN" href="https://rebel0789.github.io/codexpro/zh.html" />
@@ -37,11 +37,11 @@
     <main id="top">
       <section class="hero">
         <div class="hero-copy">
-          <p class="launch-pill"><img src="./star.svg" alt="" aria-hidden="true" />Simple install</p>
+          <p class="launch-pill"><img src="./star.svg" alt="" aria-hidden="true" />Local MCP bridge</p>
           <p class="eyebrow">Install in your repo</p>
-          <h1>Connect ChatGPT to your local code.</h1>
+          <h1>Use ChatGPT like your local coding agent.</h1>
           <p class="hero-lede">
-            Install the CLI, run setup in your project, then paste the copied Server URL into ChatGPT Developer Mode. CodexPro handles the local server, token, tunnel, and workspace tools.
+            Install the CLI, run setup inside one project, then paste the copied Server URL into ChatGPT Developer Mode. ChatGPT gets bounded tools for that workspace: context, search, exact edits, git review, safe verification, and handoff files.
           </p>
           <div class="install-line" role="group" aria-label="Install command">
             <code>npm install -g codexpro
@@ -49,10 +49,10 @@ codexpro setup</code>
             <button class="copy-button" data-copy="npm install -g codexpro&#10;codexpro setup">Copy</button>
           </div>
           <div class="hero-proof" aria-label="Core capabilities">
-            <span>AGENTS.md context</span>
-            <span>.ai-bridge handoff</span>
-            <span>compact cards</span>
-            <span>opt-in Codex session metadata</span>
+            <span>one workspace</span>
+            <span>token-protected URL</span>
+            <span>safe bash default</span>
+            <span>repo-backed context</span>
           </div>
           <div class="hero-actions">
             <a class="button primary" href="#quickstart">Install CodexPro</a>
@@ -61,43 +61,37 @@ codexpro setup</code>
           </div>
         </div>
 
-        <div class="hero-visual" aria-label="CodexPro workspace preview">
-          <div class="workspace-demo">
+        <div class="hero-visual" aria-label="CodexPro connection model">
+          <div class="workspace-demo blueprint">
             <div class="demo-status">
               <span class="status-dot" aria-hidden="true"></span>
               <div class="status-label">
-                <strong>Workspace bridge</strong>
-                <small>/path/to/repo · token protected</small>
+                <strong>One local workspace</strong>
+                <small>your repo · your ChatGPT session · your machine</small>
               </div>
-              <span class="status-badge">setup</span>
+              <span class="status-badge">bounded</span>
             </div>
-            <div class="demo-grid">
-              <div class="chat-pane">
-                <small>Install</small>
-                <p><code>npm install -g codexpro</code><br /><code>codexpro setup</code></p>
-                <div class="message-chip">Server URL copied automatically</div>
+            <div class="connection-map" aria-label="Connection flow">
+              <div>
+                <span>01</span>
+                <strong>Local repo</strong>
+                <p>AGENTS.md, git state, selected files, and .ai-bridge plans.</p>
               </div>
-              <div class="tool-pane">
-                <small>Then ChatGPT can</small>
-                <div class="tool-card-mini active">
-                  <span>read/search</span>
-                  <strong>inspect files and find code</strong>
-                </div>
-                <div class="tool-card-mini">
-                  <span>edit/review</span>
-                  <strong>exact replacement inside workspace</strong>
-                </div>
-                <div class="tool-card-mini">
-                  <span>verify</span>
-                  <strong>compact npm test / lint / build result</strong>
-                </div>
+              <div>
+                <span>02</span>
+                <strong>CodexPro</strong>
+                <p>Token-protected MCP server with workspace, bash, write, and tool modes.</p>
+              </div>
+              <div>
+                <span>03</span>
+                <strong>ChatGPT app</strong>
+                <p>Read, search, edit, review, verify, or hand off through Developer Mode.</p>
               </div>
             </div>
-            <div class="repo-pane">
-              <div class="repo-row"><span>README.md</span><strong>selected context only</strong></div>
-              <div class="repo-row"><span>src/server.ts</span><strong>workspace-scoped edit</strong></div>
-              <div class="repo-row"><span>.ai-bridge/current-plan.md</span><strong>handoff ready</strong></div>
-              <div class="repo-row"><span>~/.codex/sessions</span><strong>metadata mode only</strong></div>
+            <div class="trust-row">
+              <div><span>Not a model proxy</span><strong>uses your own ChatGPT account</strong></div>
+              <div><span>Not a quota bypass</span><strong>product limits still apply</strong></div>
+              <div><span>Not an OS sandbox</span><strong>keep roots scoped to the repo</strong></div>
             </div>
           </div>
           <div class="floating-note">
@@ -129,7 +123,7 @@ codexpro setup</code>
       <section class="section value-section">
         <div>
           <p class="eyebrow">Use the account you already have</p>
-          <h2>Give ChatGPT a real local workspace.</h2>
+          <h2>Give ChatGPT a real local workspace, not another paste buffer.</h2>
           <p>
             CodexPro is for builders who already pay for ChatGPT and want that subscription to do more than answer questions. It gives ChatGPT a local workspace bridge: file reads, exact edits, source writes, search, git status, git diff, and allowlisted verification commands.
           </p>
@@ -189,6 +183,37 @@ codexpro setup</code>
             <pre><code>.ai-bridge/agent-status.md
 .ai-bridge/implementation-diff.patch
 .ai-bridge/execution-log.jsonl</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section class="section two-col">
+        <div>
+          <p class="eyebrow">Compared with DevSpace-style bridges</p>
+          <h2>CodexPro is the ChatGPT-first local coding loop.</h2>
+          <p>
+            The transport can look similar: local MCP server, workspace root, and a tunnel. CodexPro is more opinionated. It is built for one job: make ChatGPT Developer Mode useful against one local repo without widening the trust boundary.
+          </p>
+          <p>
+            That means setup first, explicit safety modes, repo-backed context files, reviewable diffs, compact cards, and no model proxying, account pooling, quota bypassing, third-party Pro scraping, or OS sandbox claims.
+          </p>
+        </div>
+        <div class="value-matrix">
+          <div>
+            <small>Product loop</small>
+            <strong>Install, setup in one repo, paste Server URL, then let ChatGPT inspect/edit/verify.</strong>
+          </div>
+          <div>
+            <small>Control surface</small>
+            <strong>Bash, write/edit, tool mode, Codex session reads, and handoff execution are separate switches.</strong>
+          </div>
+          <div>
+            <small>Context model</small>
+            <strong>AGENTS.md and .ai-bridge keep durable project memory in files you can review.</strong>
+          </div>
+          <div>
+            <small>Trust model</small>
+            <strong>Your ChatGPT account, your local repo, your explicit tunnel and token.</strong>
           </div>
         </div>
       </section>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,5 +1,5 @@
-/* Hallmark preflight: P4 H4 E4 S4 R4 V4. Genre: modern minimal developer tool. */
-/* Hallmark critique: remove fake chrome, reduce decorative glow, preserve truthful local-workspace flows. */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
+/* Hallmark · macrostructure: Product Workbench · genre: modern-minimal · theme: Codex blue · tone: premium technical · designed-as-app */
 
 :root {
   color-scheme: dark;
@@ -13,12 +13,334 @@
   --faint: #82776d;
   --cyan: #70d6ff;
   --green: #34d399;
-  --amber: #f6c453;
-  --clay: #e86f43;
+  --amber: #2563eb;
+  --clay: #1d4ed8;
   --rose: #fb7185;
   --shadow: 0 28px 80px rgba(2, 6, 23, 0.38);
   --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   --sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Noto Sans CJK SC", sans-serif;
+}
+
+/* CodexPro product-system tokens and component additions. */
+:root {
+  color-scheme: light;
+  --bg: #f7fbff;
+  --panel: #ffffff;
+  --panel-2: #eff6ff;
+  --line: #d8e5f4;
+  --line-soft: rgba(37, 99, 235, 0.14);
+  --text: #0f172a;
+  --muted: #506176;
+  --faint: #7a899c;
+  --cyan: #2563eb;
+  --green: #0f766e;
+  --amber: #2563eb;
+  --clay: #1d4ed8;
+  --rose: #3154d4;
+  --shadow: 0 18px 46px rgba(15, 23, 42, 0.08);
+  --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Noto Sans CJK SC", sans-serif;
+}
+
+body {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.08), transparent 32rem),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.035), transparent 48rem),
+    var(--bg);
+  color: var(--text);
+}
+
+body::before {
+  background-image:
+    linear-gradient(rgba(37, 99, 235, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.055) 1px, transparent 1px);
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 70%);
+}
+
+.site-header {
+  background: linear-gradient(180deg, rgba(247, 251, 255, 0.95), rgba(247, 251, 255, 0.74));
+}
+
+.brand,
+h1,
+h2,
+h3,
+.strip strong,
+.step strong,
+.rules strong,
+.mode-row strong,
+.value-matrix strong,
+.faq-grid h3,
+dd {
+  color: var(--text);
+}
+
+nav a:hover {
+  background: rgba(37, 99, 235, 0.07);
+}
+
+.nav-star,
+.star-button,
+.star-link,
+.launch-pill,
+.hero-proof span,
+.message-chip,
+.tag,
+.link-row .star-link,
+.site-footer .star-link {
+  border-color: rgba(37, 99, 235, 0.22);
+  background: rgba(37, 99, 235, 0.075);
+  color: var(--cyan);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline-color: var(--cyan);
+}
+
+.primary {
+  border-color: var(--cyan);
+  background: var(--cyan);
+  color: #ffffff;
+}
+
+.secondary,
+.copy-button {
+  background: #ffffff;
+  color: var(--cyan);
+}
+
+.install-line,
+.workspace-demo,
+.floating-note,
+.strip,
+.compare-grid article,
+.steps,
+.command-stack > div,
+.reference-grid article,
+.tool-reference,
+.link-row,
+.rules > div,
+.safety,
+.mode-row > div,
+.faq-grid article,
+.value-matrix > div {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow);
+}
+
+.hero-proof span {
+  border-color: rgba(37, 99, 235, 0.16);
+  background: rgba(37, 99, 235, 0.065);
+  color: var(--cyan);
+}
+
+.hero-visual {
+  min-height: auto;
+}
+
+.workspace-demo {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.055), transparent 54%),
+    #ffffff;
+}
+
+.demo-status {
+  border-bottom-color: var(--line);
+  background: #ffffff;
+}
+
+.demo-status small {
+  color: var(--muted);
+}
+
+.floating-note {
+  position: static;
+  width: auto;
+  margin-top: 14px;
+}
+
+.install-line code,
+.step pre,
+.command-stack pre,
+.compare-grid pre,
+.reference-grid pre,
+.control code,
+pre {
+  border-color: rgba(37, 99, 235, 0.15);
+  background: #eef6ff;
+  color: #14315f;
+}
+
+.workspace-demo {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.08), transparent 52%),
+    #ffffff;
+}
+
+.workspace-demo::before {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.demo-status {
+  border-bottom-color: var(--line);
+  background: rgba(239, 246, 255, 0.8);
+}
+
+.demo-status small,
+.repo-row strong,
+.floating-note small,
+.command-stack small,
+dt,
+.reference-grid p,
+.faq-grid p {
+  color: var(--muted);
+}
+
+.status-badge,
+.status-dot {
+  border-color: rgba(37, 99, 235, 0.2);
+  color: var(--cyan);
+}
+
+.status-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 8px rgba(15, 118, 110, 0.08);
+}
+
+.blueprint {
+  padding-bottom: 0;
+}
+
+.connection-map {
+  display: grid;
+  gap: 1px;
+  margin: 18px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.connection-map > div {
+  min-width: 0;
+  background: #ffffff;
+  padding: 22px;
+}
+
+.connection-map span,
+.trust-row span {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.connection-map strong,
+.trust-row strong {
+  display: block;
+  color: var(--text);
+  line-height: 1.25;
+}
+
+.connection-map p {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.trust-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0 18px 18px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.trust-row > div {
+  min-width: 0;
+  background: #f8fbff;
+  padding: 18px;
+}
+
+.floating-note {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.09), transparent 72%),
+    #ffffff;
+}
+
+.floating-note span,
+.floating-note strong,
+.tool-card-mini strong,
+.repo-row span,
+.chat-pane p {
+  color: var(--text);
+}
+
+.strip {
+  background: var(--line);
+}
+
+.strip div,
+.step,
+.rules > div {
+  background: #ffffff;
+}
+
+.value-matrix > div,
+.faq-grid article {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.055), transparent 62%),
+    #ffffff;
+}
+
+.reference-grid.compact {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.compare-grid {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.18fr) minmax(0, 0.98fr);
+}
+
+.reference-grid {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+}
+
+.faq-grid {
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+}
+
+.tool-list span,
+.link-row a,
+.site-footer a {
+  border-color: rgba(37, 99, 235, 0.18);
+  background: #ffffff;
+  color: var(--text);
+}
+
+.safety li {
+  color: var(--text);
+}
+
+.site-footer {
+  border-top-color: var(--line);
+}
+
+@media (max-width: 900px) {
+  .compare-grid,
+  .reference-grid,
+  .reference-grid.compact,
+  .faq-grid,
+  .trust-row {
+    grid-template-columns: 1fr;
+  }
 }
 
 * {
@@ -39,7 +361,7 @@ body {
   overflow-x: clip;
   background:
     linear-gradient(180deg, rgba(112, 214, 255, 0.08), transparent 34rem),
-    linear-gradient(180deg, rgba(246, 196, 83, 0.055), transparent 54rem),
+    linear-gradient(180deg, rgba(37, 99, 235, 0.04), transparent 54rem),
     var(--bg);
   color: var(--text);
   font-family: var(--sans);
@@ -125,7 +447,7 @@ main {
   height: 34px;
   flex: 0 0 auto;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px rgba(246, 196, 83, 0.42);
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.24);
 }
 
 nav {
@@ -166,9 +488,9 @@ button:focus-visible {
 .nav-star {
   display: inline-flex;
   align-items: center;
-  border-color: rgba(251, 191, 36, 0.32);
-  background: rgba(251, 191, 36, 0.08);
-  color: #fef3c7;
+  border-color: rgba(37, 99, 235, 0.24);
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
 }
 
 .nav-star img,
@@ -183,9 +505,9 @@ button:focus-visible {
 .hero-proof span {
   display: inline-flex;
   align-items: center;
-  border: 1px solid rgba(246, 196, 83, 0.28);
-  background: rgba(246, 196, 83, 0.08);
-  color: #fde68a;
+  border: 1px solid rgba(37, 99, 235, 0.22);
+  background: rgba(37, 99, 235, 0.075);
+  color: #1d4ed8;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
@@ -309,7 +631,7 @@ p {
 }
 
 .primary {
-  border-color: rgba(246, 196, 83, 0.34);
+  border-color: rgba(37, 99, 235, 0.34);
   background: #fff7ed;
   color: #25140c;
 }
@@ -458,9 +780,9 @@ p {
 
 .message-chip {
   width: fit-content;
-  border: 1px solid rgba(246, 196, 83, 0.28);
+  border: 1px solid rgba(37, 99, 235, 0.22);
   border-radius: 999px;
-  color: #fde68a;
+  color: #1d4ed8;
   font-family: var(--mono);
   font-size: 12px;
   padding: 8px 10px;
@@ -537,7 +859,7 @@ p {
   width: min(330px, 86%);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(246, 196, 83, 0.12), transparent 72%),
+    linear-gradient(180deg, rgba(37, 99, 235, 0.09), transparent 72%),
     rgba(13, 16, 24, 0.94);
   padding: 18px;
 }
@@ -951,9 +1273,9 @@ dd {
 
 .link-row .star-link,
 .site-footer .star-link {
-  border-color: rgba(251, 191, 36, 0.34);
-  background: rgba(251, 191, 36, 0.08);
-  color: #fef3c7;
+  border-color: rgba(37, 99, 235, 0.22);
+  background: rgba(37, 99, 235, 0.075);
+  color: #1d4ed8;
 }
 
 .safety {
@@ -1109,4 +1431,141 @@ dd {
     right: auto;
     width: calc(100% - 36px);
   }
+}
+
+/* Final cascade layer: keep CodexPro blue/white and non-chrome visual language. */
+body {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.08), transparent 32rem),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.035), transparent 48rem),
+    var(--bg);
+  color: var(--text);
+}
+
+.site-header {
+  background: linear-gradient(180deg, rgba(247, 251, 255, 0.95), rgba(247, 251, 255, 0.74));
+}
+
+.install-line,
+.workspace-demo,
+.floating-note,
+.compare-grid article,
+.steps,
+.command-stack > div,
+.reference-grid article,
+.tool-reference,
+.link-row,
+.rules > div,
+.safety,
+.mode-row > div,
+.faq-grid article,
+.value-matrix > div {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow);
+}
+
+.strip {
+  border-color: var(--line);
+  background: var(--line);
+  box-shadow: var(--shadow);
+}
+
+.strip div,
+.step,
+.rules > div {
+  background: #ffffff;
+}
+
+.primary {
+  border-color: var(--cyan);
+  background: var(--cyan);
+  color: #ffffff;
+}
+
+.secondary,
+.copy-button,
+.tool-list span,
+.link-row a,
+.site-footer a {
+  background: #ffffff;
+  color: var(--cyan);
+}
+
+.install-line code,
+.step pre,
+.command-stack pre,
+.compare-grid pre,
+.reference-grid pre,
+pre {
+  border-color: rgba(37, 99, 235, 0.15);
+  background: #eef6ff;
+  color: #14315f;
+}
+
+.connection-map,
+.trust-row {
+  display: grid;
+}
+
+.reference-grid.compact {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.compare-grid {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.18fr) minmax(0, 0.98fr);
+}
+
+.reference-grid {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+}
+
+.faq-grid {
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+}
+
+@media (max-width: 900px) {
+  .compare-grid,
+  .reference-grid,
+  .reference-grid.compact,
+  .faq-grid,
+  .trust-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* EOF guard: visual fixes that must win over every earlier docs rule. */
+.hero-proof span {
+  border-color: rgba(37, 99, 235, 0.16);
+  background: rgba(37, 99, 235, 0.065);
+  color: var(--cyan);
+}
+
+.hero-visual {
+  min-height: auto;
+  padding-bottom: 0;
+}
+
+.workspace-demo {
+  background:
+    linear-gradient(180deg, rgba(37, 99, 235, 0.055), transparent 54%),
+    #ffffff;
+}
+
+.demo-status {
+  border-bottom-color: var(--line);
+  background: #ffffff;
+}
+
+.demo-status small {
+  color: var(--muted);
+}
+
+.floating-note {
+  position: static;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  width: auto;
+  margin-top: 14px;
 }

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -61,7 +61,7 @@ Options:
   --codex-dir <dir>          Codex config/session directory. Default: ~/.codex.
   --write <off|handoff|workspace>
                              Write mode. Default: workspace in agent mode, handoff otherwise.
-                             handoff = ChatGPT can write .ai-bridge only; Codex edits source.
+                             handoff = no generic write/edit tools; handoff tools write bounded .ai-bridge files.
   --tool-mode <minimal|standard|full>
                              Tool surface exposed to ChatGPT. Default: standard.
                              minimal = open/read/write/edit/bash/show_changes only.
@@ -77,7 +77,7 @@ Options:
   --hostname <host>          Stable public hostname for cloudflare-named or ngrok.
   --url <url>                Alias for --hostname in ngrok/stable URL modes.
   --tunnel-name <name>       Existing Cloudflare named tunnel to run.
-  --cloudflare-token <token> Cloudflare Tunnel token for a remotely managed tunnel.
+  --cloudflare-token <token> Cloudflare Tunnel token for this launch only; not saved by settings set.
   --cloudflare-token-file <path>
                              File containing a Cloudflare Tunnel token.
   --cloudflare-config <path> cloudflared YAML config for a named tunnel.
@@ -321,6 +321,30 @@ function resolveCodexDir(root, input) {
   if (!input) return '';
   const expanded = expandHome(input);
   return path.isAbsolute(expanded) ? path.resolve(expanded) : path.resolve(root, expanded);
+}
+
+function resolveConfigPath(root, input) {
+  if (!input) return '';
+  const expanded = expandHome(String(input));
+  return path.isAbsolute(expanded) || path.win32.isAbsolute(expanded) ? path.resolve(expanded) : path.resolve(root, expanded);
+}
+
+function effectiveWriteMode(mode, requested) {
+  const value = requested || (mode === 'agent' ? 'workspace' : 'handoff');
+  if (!['off', 'handoff', 'workspace'].includes(value)) {
+    throw new Error('--write must be off, handoff, or workspace');
+  }
+  if (mode === 'agent') return value;
+  return value === 'off' ? 'off' : 'handoff';
+}
+
+function writeOption(args, profile, mode) {
+  return effectiveWriteMode(mode, optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff'));
+}
+
+function optionalWriteOption(args, profile, mode) {
+  const requested = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
+  return requested ? effectiveWriteMode(mode, requested) : '';
 }
 
 function commandExists(command) {
@@ -726,9 +750,9 @@ function resolveNgrok(args) {
   throw new Error('ngrok was not found on PATH. Install it with Homebrew, winget, apt, or from https://ngrok.com/download, then run ngrok config add-authtoken <token>.');
 }
 
-function ngrokConfigPath(args) {
+function ngrokConfigPath(root, args) {
   const configPath = args.ngrokConfig ?? process.env.NGROK_CONFIG ?? process.env.CODEXPRO_NGROK_CONFIG ?? '';
-  return configPath ? path.resolve(expandHome(configPath)) : '';
+  return resolveConfigPath(root, configPath);
 }
 
 function runHelperScript(scriptName, args) {
@@ -1679,7 +1703,7 @@ async function runDoctor(argv) {
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], 'agent');
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
-  const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
+  const write = writeOption(args, profile, mode);
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const stableHostname = args.hostname
     ?? args.url
@@ -1857,7 +1881,7 @@ function profileFromPreference(root, args, profile, preference) {
   const codexSessions = codexSessionsOption(args, profile);
   const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
-  const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
+  const write = optionalWriteOption(args, profile, mode);
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
   const existingToken = optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], '');
@@ -2000,7 +2024,7 @@ async function runSetupWizard(argv) {
     const bashTranscript = bashTranscriptOption(defaults, profile);
     const codexSessions = codexSessionsOption(defaults, profile);
     const codexDir = optionValue(defaults, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
-    const write = optionValue(defaults, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
+    const write = optionalWriteOption(defaults, profile, mode);
     const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
     const widgetDomain = optionValue(defaults, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
     if (bash) args.push('--bash', bash);
@@ -2128,13 +2152,23 @@ function printProfile(root, profile) {
     labelValue('Profile', profile.profilePath),
     labelValue('Tunnel', safe.tunnel ?? 'cloudflare'),
     ...(safe.hostname ? [labelValue('Hostname', safe.hostname)] : []),
+    ...(safe.tunnelName ? [labelValue('Tunnel name', safe.tunnelName)] : []),
+    ...(safe.ngrokConfig ? [labelValue('Ngrok config', safe.ngrokConfig)] : []),
+    ...(safe.cloudflareConfig ? [labelValue('Cloudflare cfg', safe.cloudflareConfig)] : []),
+    ...(safe.cloudflareTokenFile ? [labelValue('CF token file', safe.cloudflareTokenFile)] : []),
     ...(safe.port ? [labelValue('Port', safe.port)] : []),
     ...(safe.mode ? [labelValue('Mode', safe.mode)] : []),
+    ...(safe.bash ? [labelValue('Bash', safe.bash)] : []),
+    ...(safe.write ? [labelValue('Write', safe.write)] : []),
+    ...(safe.toolMode ? [labelValue('Tool mode', safe.toolMode)] : []),
     labelValue('Bash transcript', safe.bashTranscript ?? 'compact'),
     labelValue('Codex sessions', safe.codexSessions ?? 'off'),
     ...(safe.codexDir ? [labelValue('Codex dir', safe.codexDir)] : []),
     ...(safe.bashSession ? [labelValue('Bash session', `${safe.bashSession}${safe.requireBashSession ? ' required' : ''}`)] : []),
-    ...(safe.token ? [labelValue('Token', safe.token)] : [])
+    ...(safe.widgetDomain ? [labelValue('Widget origin', safe.widgetDomain)] : []),
+    ...(safe.noInstallCloudflared ? [labelValue('cloudflared', 'manual install only')] : []),
+    ...(safe.token ? [labelValue('Token', safe.token)] : []),
+    ...(safe.cloudflareToken ? [labelValue('Cloudflare token', safe.cloudflareToken)] : [])
   ]);
 }
 
@@ -2150,6 +2184,9 @@ function printProfileList(profiles = listWorkspaceProfiles()) {
 }
 
 function saveSettingsFromArgs(root, args, profile) {
+  if (args.cloudflareToken !== undefined) {
+    throw new Error('codexpro settings set does not save raw --cloudflare-token. Save it to a local file and use --cloudflare-token-file <path>; start still accepts --cloudflare-token for a single launch.');
+  }
   const tunnel = optionValue(args, profile, 'tunnel', ['CODEXPRO_TUNNEL'], profile.tunnel ?? 'cloudflare');
   if (!['none', 'cloudflare', 'cloudflare-named', 'ngrok'].includes(tunnel)) {
     throw new Error('--tunnel must be none, cloudflare, cloudflare-named, or ngrok');
@@ -2159,6 +2196,9 @@ function saveSettingsFromArgs(root, args, profile) {
     throw new Error('--hostname is required for ngrok and cloudflare-named settings.');
   }
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], profile.mode ?? 'agent');
+  if (!['agent', 'handoff', 'pro'].includes(mode)) {
+    throw new Error('--mode must be agent, handoff, or pro');
+  }
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? '');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], profile.widgetDomain ?? '');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
@@ -2166,6 +2206,11 @@ function saveSettingsFromArgs(root, args, profile) {
   const codexSessions = codexSessionsOption(args, profile);
   const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], profile.codexDir ?? '');
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
+  const write = writeOption(args, profile, mode);
+  const tunnelName = args.tunnelName ?? profile.tunnelName ?? '';
+  const ngrokConfig = resolveConfigPath(root, args.ngrokConfig ?? profile.ngrokConfig ?? '');
+  const cloudflareConfig = resolveConfigPath(root, args.cloudflareConfig ?? profile.cloudflareConfig ?? '');
+  const cloudflareTokenFile = resolveConfigPath(root, args.cloudflareTokenFile ?? profile.cloudflareTokenFile ?? '');
   const token = tunnel === 'none'
     ? optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], profile.token ?? '')
     : stableToken(optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], profile.token ?? ''));
@@ -2174,10 +2219,10 @@ function saveSettingsFromArgs(root, args, profile) {
     mode,
     tunnel,
     ...(hostname ? { hostname } : {}),
-    ...(args.tunnelName ?? profile.tunnelName ? { tunnelName: args.tunnelName ?? profile.tunnelName } : {}),
-    ...(args.ngrokConfig ?? profile.ngrokConfig ? { ngrokConfig: args.ngrokConfig ?? profile.ngrokConfig } : {}),
-    ...(args.cloudflareConfig ?? profile.cloudflareConfig ? { cloudflareConfig: args.cloudflareConfig ?? profile.cloudflareConfig } : {}),
-    ...(args.cloudflareTokenFile ?? profile.cloudflareTokenFile ? { cloudflareTokenFile: args.cloudflareTokenFile ?? profile.cloudflareTokenFile } : {}),
+    ...(tunnelName ? { tunnelName } : {}),
+    ...(ngrokConfig ? { ngrokConfig } : {}),
+    ...(cloudflareConfig ? { cloudflareConfig } : {}),
+    ...(cloudflareTokenFile ? { cloudflareTokenFile } : {}),
     ...(token ? { token } : {}),
     ...(args.bash ?? profile.bash ? { bash: args.bash ?? profile.bash } : {}),
     ...(bashTranscript !== 'compact' ? { bashTranscript } : {}),
@@ -2185,7 +2230,7 @@ function saveSettingsFromArgs(root, args, profile) {
     ...(codexDir ? { codexDir } : {}),
     ...(bashSession ? { bashSession } : {}),
     ...(requireBashSession ? { requireBashSession: true } : {}),
-    ...(args.write ?? profile.write ? { write: args.write ?? profile.write } : {}),
+    ...(mode !== 'agent' || args.write !== undefined || profile.write ? { write } : {}),
     ...(toolMode ? { toolMode } : {}),
     ...(widgetDomain ? { widgetDomain } : {}),
     ...(args.noInstallCloudflared ?? profile.noInstallCloudflared ? { noInstallCloudflared: true } : {})
@@ -2509,7 +2554,7 @@ async function main() {
   const codexSessions = codexSessionsOption(args, profile);
   const codexDir = resolveCodexDir(root, optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], ''));
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
-  const write = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
+  const write = writeOption(args, profile, mode);
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], 'https://rebel0789.github.io');
   if (!['off', 'safe', 'full'].includes(bash)) throw new Error('--bash must be off, safe, or full');
@@ -2624,7 +2669,7 @@ async function main() {
     const ngrokPath = resolveNgrok(effectiveArgs);
     const publicBase = publicBaseFromHostname(stableHostname);
     const ngrokArgs = ['http', localBase, '--url', publicBase];
-    const configPath = ngrokConfigPath(effectiveArgs);
+    const configPath = ngrokConfigPath(root, effectiveArgs);
     if (configPath) ngrokArgs.push('--config', configPath);
     statusLine('wait', `Opening ngrok endpoint for ${publicBase}`);
     cloudflared = spawnLogged('ngrok', ngrokPath, ngrokArgs, { cwd: root, env: process.env, verbose: verboseLogs });
@@ -2712,18 +2757,18 @@ async function main() {
 
   const publicBase = publicBaseFromHostname(stableHostname);
   const tunnelName = optionValue(args, profile, 'tunnelName', ['CLOUDFLARE_TUNNEL_NAME', 'CODEXPRO_TUNNEL_NAME'], '');
-  const cloudflareConfig = optionValue(args, profile, 'cloudflareConfig', ['CLOUDFLARE_TUNNEL_CONFIG', 'CODEXPRO_CLOUDFLARE_CONFIG'], '');
-  const cloudflareTokenFile = optionValue(args, profile, 'cloudflareTokenFile', ['CLOUDFLARE_TUNNEL_TOKEN_FILE', 'CODEXPRO_CLOUDFLARE_TUNNEL_TOKEN_FILE'], '');
+  const cloudflareConfig = resolveConfigPath(root, optionValue(args, profile, 'cloudflareConfig', ['CLOUDFLARE_TUNNEL_CONFIG', 'CODEXPRO_CLOUDFLARE_CONFIG'], ''));
+  const cloudflareTokenFile = resolveConfigPath(root, optionValue(args, profile, 'cloudflareTokenFile', ['CLOUDFLARE_TUNNEL_TOKEN_FILE', 'CODEXPRO_CLOUDFLARE_TUNNEL_TOKEN_FILE'], ''));
   const cloudflareToken = optionValue(args, profile, 'cloudflareToken', ['CLOUDFLARE_TUNNEL_TOKEN', 'CODEXPRO_CLOUDFLARE_TUNNEL_TOKEN'], '');
 
   const cloudflaredArgs = ['tunnel'];
   if (cloudflareConfig) {
-    cloudflaredArgs.push('--config', path.resolve(expandHome(cloudflareConfig)), 'run');
+    cloudflaredArgs.push('--config', cloudflareConfig, 'run');
     if (tunnelName) cloudflaredArgs.push(tunnelName);
   } else {
     cloudflaredArgs.push('run', '--url', localBase);
     if (cloudflareTokenFile) {
-      cloudflaredArgs.push('--token-file', path.resolve(expandHome(cloudflareTokenFile)));
+      cloudflaredArgs.push('--token-file', cloudflareTokenFile);
     } else if (cloudflareToken) {
       // Passed to cloudflared through the child environment below.
     } else {

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -123,7 +123,7 @@ function toolNames(tools) {
 function hasWidgetMeta(tools, name, uri) {
   const tool = tools.find((item) => item.name === name);
   const meta = tool?._meta ?? {};
-  return meta.ui?.resourceUri === uri || meta['openai/outputTemplate'] === uri;
+  return meta.ui?.resourceUri === uri && meta['openai/outputTemplate'] === uri;
 }
 
 await expectHttpTokenRequired('non-loopback', { CODEXPRO_HOST: '0.0.0.0' });
@@ -150,6 +150,7 @@ async function callTool(client, name, args = {}) {
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-smoke-'));
+const realRoot = await fs.realpath(root);
 const profileHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-profile-home-'));
 await fs.mkdir(path.join(root, '.codex', 'skills', 'http-smoke-skill'), { recursive: true });
 await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKILL.md'), [
@@ -211,11 +212,16 @@ try {
   if (home.status !== 200 || !home.headers.get('content-type')?.includes('text/html')) {
     throw new Error(`expected authenticated onboarding page to return HTML 200, got ${home.status}`);
   }
-  if (!homeText.includes('CodexPro Admin') || !homeText.includes('CLI controls') || !homeText.includes('Connect ChatGPT')) {
+  if (!homeText.includes('CodexPro Local Control') || !homeText.includes('CLI controls') || !homeText.includes('Connect ChatGPT') || !homeText.includes('Runtime guardrails')) {
     throw new Error('onboarding page did not include expected admin setup copy');
   }
   if (!homeText.includes('Connection profile') || !homeText.includes('data-profile-form')) {
     throw new Error('onboarding page did not include the saved profile editor');
+  }
+  for (const fieldName of ['tunnelName', 'ngrokConfig', 'cloudflareConfig', 'cloudflareTokenFile', 'noInstallCloudflared']) {
+    if (!homeText.includes(`name="${fieldName}"`)) {
+      throw new Error(`onboarding page did not include profile field ${fieldName}`);
+    }
   }
   if (homeText.includes(token)) {
     throw new Error('onboarding page leaked the raw auth token');
@@ -262,7 +268,8 @@ try {
       toolMode: 'full',
       widgetDomain: 'https://widgets.codexpro.test',
       ngrokConfig: path.join(root, 'ngrok.yml'),
-      cloudflareTokenFile: '~/.codexpro/cloudflare-tunnel-token'
+      cloudflareTokenFile: 'cloudflare-token',
+      noInstallCloudflared: true
     })
   });
   const profileSaveJson = await profileSave.json();
@@ -280,6 +287,9 @@ try {
     savedProfile.codexSessions !== 'metadata' ||
     savedProfile.bashSession !== 'http-main' ||
     savedProfile.requireBashSession !== true ||
+    savedProfile.ngrokConfig !== path.join(root, 'ngrok.yml') ||
+    savedProfile.cloudflareTokenFile !== path.join(realRoot, 'cloudflare-token') ||
+    savedProfile.noInstallCloudflared !== true ||
     savedProfile.token !== token
   ) {
     throw new Error(`admin profile save wrote unexpected profile: ${JSON.stringify(savedProfile)}`);
@@ -290,6 +300,11 @@ try {
   for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'load_skill', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
     if (!queryToolNames.includes(expected)) {
       throw new Error(`URL-token MCP tools/list missing ${expected}; got ${queryToolNames.join(', ')}`);
+    }
+  }
+  for (const hidden of ['write', 'edit']) {
+    if (queryToolNames.includes(hidden)) {
+      throw new Error(`HTTP handoff mode should not advertise ${hidden}; got ${queryToolNames.join(', ')}`);
     }
   }
   const toolCardUri = 'ui://widget/codexpro-tool-card-v9.html';
@@ -313,6 +328,9 @@ try {
     if (toolCard.mimeType !== 'text/html;profile=mcp-app') {
       throw new Error(`unexpected HTTP tool-card mime type: ${toolCard.mimeType}`);
     }
+    const legacyToolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
+    const legacyToolCard = resources.resources.find((resource) => resource.uri === legacyToolCardUri);
+    if (!legacyToolCard) throw new Error(`HTTP MCP resources/list missing legacy ${legacyToolCardUri}`);
     const widget = await client.readResource({ uri: toolCardUri });
     const widgetText = widget.contents?.[0]?.text ?? '';
     const widgetMeta = widget.contents?.[0]?._meta ?? {};
@@ -324,6 +342,13 @@ try {
     }
     if (widgetMeta.ui?.domain !== 'https://widgets.codexpro.test' || widgetMeta['openai/widgetDomain'] !== 'https://widgets.codexpro.test') {
       throw new Error('HTTP tool-card widget resource did not expose standard and ChatGPT widget domain metadata');
+    }
+    const legacyWidget = await client.readResource({ uri: legacyToolCardUri });
+    if (legacyWidget.contents?.[0]?.uri !== legacyToolCardUri) {
+      throw new Error('HTTP legacy tool-card widget resource did not preserve requested URI');
+    }
+    if (!(legacyWidget.contents?.[0]?.text ?? '').includes('Waiting for tool result')) {
+      throw new Error('HTTP legacy tool-card widget resource did not serve widget HTML');
     }
   });
 
@@ -409,6 +434,45 @@ try {
   await fs.stat(path.join(root, '.ai-bridge', 'pro-context.md'));
 } finally {
   child.kill('SIGTERM');
+  await waitForExit(child).catch(() => {});
+}
+
+const disabledRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-disabled-tools-'));
+const disabledPort = await getFreePort();
+const disabledToken = 'codexpro-http-disabled-token';
+const disabledChild = spawn('node', ['dist/http.js'], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_ROOT: disabledRoot,
+    CODEXPRO_ALLOWED_ROOTS: disabledRoot,
+    CODEXPRO_PORT: String(disabledPort),
+    CODEXPRO_HTTP_TOKEN: disabledToken,
+    CODEXPRO_BASH_MODE: 'off',
+    CODEXPRO_WRITE_MODE: 'off',
+    CODEXPRO_TOOL_MODE: 'full'
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+try {
+  await waitForListening(disabledChild);
+  const disabledBase = `http://127.0.0.1:${disabledPort}`;
+  const disabledTools = await listTools(`${disabledBase}/mcp?codexpro_token=${encodeURIComponent(disabledToken)}`);
+  const disabledToolNames = toolNames(disabledTools);
+  for (const hiddenTool of ['bash', 'write', 'edit']) {
+    if (disabledToolNames.includes(hiddenTool)) {
+      throw new Error(`HTTP disabled mode should not advertise ${hiddenTool}; got ${disabledToolNames.join(', ')}`);
+    }
+  }
+  await withClient(`${disabledBase}/mcp?codexpro_token=${encodeURIComponent(disabledToken)}`, async (client) => {
+    const config = await callTool(client, 'server_config');
+    if (config.structuredContent.bashMode !== 'off' || config.structuredContent.writeMode !== 'off') {
+      throw new Error(`HTTP disabled mode server_config mismatch: ${JSON.stringify(config.structuredContent)}`);
+    }
+  });
+} finally {
+  disabledChild.kill('SIGTERM');
+  await waitForExit(disabledChild).catch(() => {});
 }
 
 const cliRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-cli-http-smoke-'));

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -40,6 +40,7 @@ async function readProfile(root, home) {
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-root-'));
 const reuseRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-reuse-'));
+const policyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-policy-'));
 const home = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-home-'));
 const env = { ...process.env, CODEXPRO_HOME: home };
 
@@ -86,6 +87,41 @@ if (shown.includes('codexpro-settings-token')) {
 const profile = await readProfile(root, home);
 if (profile.toolMode !== 'full' || profile.bashTranscript !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
   throw new Error(`settings profile did not persist tool/widget options: ${JSON.stringify(profile)}`);
+}
+
+runFail([
+  'settings',
+  'set',
+  '--root',
+  policyRoot,
+  '--tunnel',
+  'cloudflare-named',
+  '--hostname',
+  'codexpro.example.com',
+  '--cloudflare-token',
+  'raw-cloudflare-token'
+], env, /does not save raw --cloudflare-token/i);
+
+run([
+  'settings',
+  'set',
+  '--root',
+  policyRoot,
+  '--tunnel',
+  'ngrok',
+  '--hostname',
+  'policy.ngrok-free.app',
+  '--mode',
+  'handoff',
+  '--write',
+  'workspace',
+  '--ngrok-config',
+  'ngrok.yml'
+], env);
+const policyProfile = await readProfile(policyRoot, home);
+const realPolicyRoot = await fs.realpath(policyRoot);
+if (policyProfile.write !== 'handoff' || policyProfile.ngrokConfig !== path.join(realPolicyRoot, 'ngrok.yml')) {
+  throw new Error(`settings policy profile did not normalize write/path values: ${JSON.stringify(policyProfile)}`);
 }
 
 runFail([

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -152,7 +152,7 @@ const toolCardUri = 'ui://widget/codexpro-tool-card-v9.html';
 const toolsByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
 function hasWidgetMeta(name) {
   const meta = toolsByName.get(name)?._meta ?? {};
-  return meta.ui?.resourceUri === toolCardUri || meta['openai/outputTemplate'] === toolCardUri;
+  return meta.ui?.resourceUri === toolCardUri && meta['openai/outputTemplate'] === toolCardUri;
 }
 async function expectToolError(name, args, pattern, targetClient = client) {
   const result = await targetClient.request('tools/call', { name, arguments: args });
@@ -171,6 +171,9 @@ const resources = await client.request('resources/list', {});
 const toolCard = resources.resources.find((resource) => resource.uri === toolCardUri);
 if (!toolCard) throw new Error(`missing tool-card resource: ${toolCardUri}`);
 if (toolCard.mimeType !== 'text/html;profile=mcp-app') throw new Error(`unexpected tool-card mime type: ${toolCard.mimeType}`);
+const legacyToolCardUri = 'ui://widget/codexpro-tool-card-v8.html';
+const legacyToolCard = resources.resources.find((resource) => resource.uri === legacyToolCardUri);
+if (!legacyToolCard) throw new Error(`missing legacy tool-card resource: ${legacyToolCardUri}`);
 const widget = await client.request('resources/read', { uri: toolCardUri });
 const widgetText = widget.contents?.[0]?.text ?? '';
 const widgetMeta = widget.contents?.[0]?._meta ?? {};
@@ -182,6 +185,13 @@ if (!widgetMeta.ui?.csp || !widgetMeta['openai/widgetCSP']) {
 }
 if (widgetMeta.ui?.domain !== 'https://widgets.codexpro.test' || widgetMeta['openai/widgetDomain'] !== 'https://widgets.codexpro.test') {
   throw new Error('tool-card widget resource did not expose standard and ChatGPT widget domain metadata');
+}
+const legacyWidget = await client.request('resources/read', { uri: legacyToolCardUri });
+if (legacyWidget.contents?.[0]?.uri !== legacyToolCardUri) {
+  throw new Error('legacy tool-card widget resource did not preserve requested URI');
+}
+if (!(legacyWidget.contents?.[0]?.text ?? '').includes('Waiting for tool result')) {
+  throw new Error('legacy tool-card widget resource did not serve widget HTML');
 }
 const current = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
 const realTmp = await fs.realpath(tmp);
@@ -200,6 +210,9 @@ const selfTest = await client.request('tools/call', {
 });
 if (selfTest.structuredContent.status === 'fail' || !selfTest.structuredContent.expected_tools?.includes?.('codexpro_self_test')) {
   throw new Error(`codexpro_self_test failed: ${JSON.stringify(selfTest.structuredContent)}`);
+}
+if (JSON.stringify([...(selfTest.structuredContent.expected_tools ?? [])].sort()) !== JSON.stringify([...(selfTest.structuredContent.registered_tools ?? [])].sort())) {
+  throw new Error(`codexpro_self_test expected/registered tools mismatch: ${JSON.stringify(selfTest.structuredContent)}`);
 }
 if (!selfTest.structuredContent.files_touched?.includes?.('.ai-bridge/codexpro-self-test.md')) {
   throw new Error('codexpro_self_test did not run the .ai-bridge write/edit probe');
@@ -405,6 +418,73 @@ async function assertToolMode(mode, expected, hidden) {
 await assertToolMode('', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'tree', 'search', 'load_skill', 'read', 'write', 'edit', 'bash', 'show_changes', 'read_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
 await assertToolMode('minimal', ['server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'bash', 'show_changes'], ['tree', 'search', 'load_skill', 'read_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
 
+const handoffWriteClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--write', 'handoff'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_TOOL_MODE: '' }
+});
+await handoffWriteClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-write-handoff-smoke', version: '0.1.0' }
+});
+handoffWriteClient.notify('notifications/initialized');
+const handoffWriteTools = await handoffWriteClient.request('tools/list', {});
+const handoffWriteToolNames = handoffWriteTools.tools.map((tool) => tool.name);
+for (const hiddenWriteTool of ['write', 'edit']) {
+  if (handoffWriteToolNames.includes(hiddenWriteTool)) {
+    throw new Error(`--write handoff should not advertise ${hiddenWriteTool} tool; got ${handoffWriteToolNames.join(', ')}`);
+  }
+}
+const handoffWriteConfig = await handoffWriteClient.request('tools/call', { name: 'server_config', arguments: {} });
+if (handoffWriteConfig.structuredContent.writeMode !== 'handoff' || handoffWriteConfig.structuredContent.registeredTools?.includes?.('write') || handoffWriteConfig.structuredContent.registeredTools?.includes?.('edit')) {
+  throw new Error(`server_config did not report write handoff with hidden edit tools: ${JSON.stringify(handoffWriteConfig.structuredContent)}`);
+}
+handoffWriteClient.close();
+
+const noBashClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'off'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_TOOL_MODE: '' }
+});
+await noBashClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-no-bash-smoke', version: '0.1.0' }
+});
+noBashClient.notify('notifications/initialized');
+const noBashTools = await noBashClient.request('tools/list', {});
+const noBashToolNames = noBashTools.tools.map((tool) => tool.name);
+if (noBashToolNames.includes('bash')) {
+  throw new Error(`--bash off should not advertise bash tool; got ${noBashToolNames.join(', ')}`);
+}
+const noBashConfig = await noBashClient.request('tools/call', { name: 'server_config', arguments: {} });
+if (noBashConfig.structuredContent.bashMode !== 'off') {
+  throw new Error(`server_config did not report bash off: ${JSON.stringify(noBashConfig.structuredContent)}`);
+}
+noBashClient.close();
+
+const disabledWriteClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--write', 'off'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_TOOL_MODE: '' }
+});
+await disabledWriteClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-write-off-smoke', version: '0.1.0' }
+});
+disabledWriteClient.notify('notifications/initialized');
+const disabledWriteTools = await disabledWriteClient.request('tools/list', {});
+const disabledWriteToolNames = disabledWriteTools.tools.map((tool) => tool.name);
+for (const hiddenWriteTool of ['write', 'edit']) {
+  if (disabledWriteToolNames.includes(hiddenWriteTool)) {
+    throw new Error(`--write off should not advertise ${hiddenWriteTool} tool; got ${disabledWriteToolNames.join(', ')}`);
+  }
+}
+const disabledWriteConfig = await disabledWriteClient.request('tools/call', { name: 'server_config', arguments: {} });
+if (disabledWriteConfig.structuredContent.writeMode !== 'off') {
+  throw new Error(`server_config did not report write off: ${JSON.stringify(disabledWriteConfig.structuredContent)}`);
+}
+disabledWriteClient.close();
+
 const standardCodexSessionsClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp], {
   cwd: path.resolve('.'),
   env: {
@@ -469,6 +549,16 @@ if (emptyCodexDirConfig.structuredContent.codexDir !== expectedDefaultCodexDir) 
   throw new Error(`empty CODEXPRO_CODEX_DIR resolved to ${emptyCodexDirConfig.structuredContent.codexDir}, expected ${expectedDefaultCodexDir}`);
 }
 emptyCodexDirClient.close();
+
+const invalidContextDir = spawnSync('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_CONTEXT_DIR: 'src' },
+  encoding: 'utf8',
+  timeout: 5000
+});
+if (invalidContextDir.status === 0 || !String(invalidContextDir.stderr || invalidContextDir.stdout).includes('CODEXPRO_CONTEXT_DIR')) {
+  throw new Error(`invalid CODEXPRO_CONTEXT_DIR=src was not rejected: status=${invalidContextDir.status} stdout=${invalidContextDir.stdout} stderr=${invalidContextDir.stderr}`);
+}
 
 const codexSessionsClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--tool-mode', 'full'], {
   cwd: path.resolve('.'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,6 +194,32 @@ function widgetDomainFrom(value: string | undefined): string {
   return parsed.origin;
 }
 
+function contextDirFrom(value: string | undefined): string {
+  const raw = (value?.trim() || ".ai-bridge").replaceAll("\\", "/");
+  if (path.isAbsolute(raw) || path.win32.isAbsolute(raw)) {
+    throw new Error("CODEXPRO_CONTEXT_DIR must be a workspace-relative hidden directory, for example .ai-bridge.");
+  }
+
+  const normalized = path.posix.normalize(raw);
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error("CODEXPRO_CONTEXT_DIR must stay inside the workspace.");
+  }
+
+  const parts = normalized.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error("CODEXPRO_CONTEXT_DIR must be a simple relative directory path.");
+  }
+  if (!parts[0].startsWith(".")) {
+    throw new Error("CODEXPRO_CONTEXT_DIR must start with a hidden directory such as .ai-bridge.");
+  }
+
+  const blocked = new Set([".git", ".ssh", ".gnupg", ".cache", "node_modules", "src", "dist", "build", ".next", "coverage"]);
+  if (parts.some((part) => blocked.has(part))) {
+    throw new Error("CODEXPRO_CONTEXT_DIR cannot point at source, dependency, build, cache, or credential directories.");
+  }
+  return normalized;
+}
+
 function boolFrom(value: string | undefined, fallback = false): boolean {
   if (value === undefined) return fallback;
   return ["1", "true", "yes", "y", "on"].includes(value.toLowerCase());
@@ -278,6 +304,6 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     maxHttpSessions: numberFrom(process.env.CODEXPRO_MAX_HTTP_SESSIONS, 64, 1, 512),
     httpSessionTtlMs: numberFrom(process.env.CODEXPRO_HTTP_SESSION_TTL_MS, 30 * 60_000, 60_000, 24 * 60 * 60_000),
     blockedGlobs: [...DEFAULT_BLOCKED_GLOBS, ...extraBlockedGlobs],
-    contextDir: process.env.CODEXPRO_CONTEXT_DIR ?? ".ai-bridge"
+    contextDir: contextDirFrom(process.env.CODEXPRO_CONTEXT_DIR)
   };
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import { timingSafeEqual } from "node:crypto";
+import path from "node:path";
 import express, { type NextFunction, type Request, type Response } from "express";
 import cors from "cors";
 import { z } from "zod";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import { loadConfig, type CodexProConfig } from "./config.js";
+import { expandHome, loadConfig, type CodexProConfig } from "./config.js";
 import {
   profilePathForRoot,
   readRuntimeConnection,
@@ -135,6 +136,20 @@ function normalizeWidgetDomain(value: string | undefined): string {
   return url.origin;
 }
 
+function effectiveWriteMode(mode: ConnectorMode, write: ProfileFormValues["write"]): ProfileFormValues["write"] {
+  if (mode === "agent") return write;
+  return write === "off" ? "off" : "handoff";
+}
+
+function normalizeProfilePath(root: string, value: string | undefined): string {
+  const raw = value?.trim() ?? "";
+  if (!raw) return "";
+  const expanded = expandHome(raw);
+  return path.isAbsolute(expanded) || path.win32.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(root, expanded);
+}
+
 function profileValues(config: CodexProConfig, profile = readWorkspaceProfile(config.defaultRoot)): ProfileFormValues {
   const hostname =
     profile.hostname ??
@@ -142,9 +157,11 @@ function profileValues(config: CodexProConfig, profile = readWorkspaceProfile(co
     process.env.CODEXPRO_HOSTNAME ??
     process.env.NGROK_DOMAIN ??
     "";
+  const mode = oneOf(profile.mode ?? process.env.CODEXPRO_MODE, MODES, "agent");
+  const write = effectiveWriteMode(mode, oneOf(profile.write ?? config.writeMode, WRITE_MODES, config.writeMode));
   return {
     port: String(profile.port ?? config.port),
-    mode: oneOf(profile.mode ?? process.env.CODEXPRO_MODE, MODES, "agent"),
+    mode,
     tunnel: oneOf(profile.tunnel, TUNNELS, runtimeTunnelFallback()),
     hostname: String(hostname),
     tunnelName: String(profile.tunnelName ?? ""),
@@ -157,7 +174,7 @@ function profileValues(config: CodexProConfig, profile = readWorkspaceProfile(co
     codexDir: String(profile.codexDir ?? config.codexDir),
     bashSession: String(profile.bashSession ?? config.bashSessionId ?? ""),
     requireBashSession: Boolean(profile.requireBashSession ?? config.requireBashSession),
-    write: oneOf(profile.write ?? config.writeMode, WRITE_MODES, config.writeMode),
+    write,
     toolMode: oneOf(profile.toolMode ?? config.toolMode, TOOL_MODES, config.toolMode),
     widgetDomain: String(profile.widgetDomain ?? config.widgetDomain),
     noInstallCloudflared: Boolean(profile.noInstallCloudflared)
@@ -264,8 +281,13 @@ function profileForm(config: CodexProConfig): string {
             <label><span>Public hostname</span><input name="hostname" value="${escapeHtml(values.hostname)}" data-hostname-input data-autofilled="0"></label>
             <label><span>Port</span><input name="port" type="number" min="1" max="65535" value="${escapeHtml(values.port)}"></label>
             <label><span>Mode</span><select name="mode">${selectOptions(MODES, values.mode)}</select></label>
+            <label><span>Cloudflare tunnel name</span><input name="tunnelName" value="${escapeHtml(values.tunnelName)}"></label>
+            <label><span>ngrok config file</span><input name="ngrokConfig" value="${escapeHtml(values.ngrokConfig)}"></label>
+            <label><span>Cloudflare config file</span><input name="cloudflareConfig" value="${escapeHtml(values.cloudflareConfig)}"></label>
+            <label><span>Cloudflare token file</span><input name="cloudflareTokenFile" value="${escapeHtml(values.cloudflareTokenFile)}"></label>
           </div>
           <p class="field-help" data-hostname-help>${escapeHtml(currentTunnelMessage(values.tunnel, runtimeEndpoint))}</p>
+          <label class="check-row"><input name="noInstallCloudflared" type="checkbox" value="true"${values.noInstallCloudflared ? " checked" : ""}><span>Do not auto-install cloudflared</span></label>
         </fieldset>
         <fieldset class="profile-group">
           <legend>Runtime policy</legend>
@@ -316,15 +338,19 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
 
   const token = typeof existing.token === "string" && existing.token ? existing.token : config.authToken ?? "";
   const cloudflareToken = typeof existing.cloudflareToken === "string" && existing.cloudflareToken ? existing.cloudflareToken : "";
+  const write = effectiveWriteMode(next.mode, next.write);
+  const ngrokConfig = normalizeProfilePath(config.defaultRoot, next.ngrokConfig);
+  const cloudflareConfig = normalizeProfilePath(config.defaultRoot, next.cloudflareConfig);
+  const cloudflareTokenFile = normalizeProfilePath(config.defaultRoot, next.cloudflareTokenFile);
   return {
     port: next.port,
     mode: next.mode,
     tunnel: next.tunnel,
     ...(next.hostname ? { hostname: next.hostname } : {}),
     ...(next.tunnelName ? { tunnelName: next.tunnelName } : {}),
-    ...(next.ngrokConfig ? { ngrokConfig: next.ngrokConfig } : {}),
-    ...(next.cloudflareConfig ? { cloudflareConfig: next.cloudflareConfig } : {}),
-    ...(next.cloudflareTokenFile ? { cloudflareTokenFile: next.cloudflareTokenFile } : {}),
+    ...(ngrokConfig ? { ngrokConfig } : {}),
+    ...(cloudflareConfig ? { cloudflareConfig } : {}),
+    ...(cloudflareTokenFile ? { cloudflareTokenFile } : {}),
     ...(token ? { token } : {}),
     ...(cloudflareToken ? { cloudflareToken } : {}),
     bash: next.bash,
@@ -333,7 +359,7 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
     ...(next.codexDir ? { codexDir: next.codexDir } : {}),
     ...(next.bashSession ? { bashSession: next.bashSession } : {}),
     ...(next.requireBashSession ? { requireBashSession: true } : {}),
-    write: next.write,
+    write,
     toolMode: next.toolMode,
     ...(next.widgetDomain ? { widgetDomain: next.widgetDomain } : {}),
     ...(next.noInstallCloudflared ? { noInstallCloudflared: true } : {})
@@ -404,14 +430,14 @@ function onboardingPage(config: CodexProConfig): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="/favicon.ico">
-  <title>CodexPro Admin</title>
+  <title>CodexPro Local Control - ChatGPT Workspace Agent</title>
   <style>
     /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
     /* Hallmark · macrostructure: Workbench · genre: modern-minimal · theme: CC Switch-inspired light manager · tone: technical admin · nav: section switcher · footer: Ft2 · contrast: pass (40-41) · mobile: pass (34, 49, 50-57) */
     :root {
       color-scheme: light;
-      --font-display: "Inter", "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      --font-body: "Inter", "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-display: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-body: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --font-mono: "Fira Code", "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
       --color-paper: oklch(98.5% 0.004 250);
       --color-surface: oklch(100% 0 0);
@@ -714,6 +740,7 @@ function onboardingPage(config: CodexProConfig): string {
       font-size: 12px;
       font-weight: 800;
       line-height: 1;
+      white-space: nowrap;
     }
     .warn {
       border-color: var(--color-warn);
@@ -1115,6 +1142,10 @@ function onboardingPage(config: CodexProConfig): string {
       .panel {
         padding: var(--space-4);
       }
+      .section-head {
+        align-items: start;
+        flex-direction: column;
+      }
       h1 {
         font-size: 1.85rem;
       }
@@ -1159,12 +1190,12 @@ function onboardingPage(config: CodexProConfig): string {
       <div class="brand">
         <span class="logo" aria-hidden="true"><img src="/favicon.ico" alt=""></span>
         <span>
-          <span class="brand-kicker">Local admin</span>
+          <span class="brand-kicker">Workspace control</span>
           <span class="brand-title">CodexPro</span>
         </span>
       </div>
       <nav class="quick-links" aria-label="CodexPro resources">
-        <a class="action-link primary-link" href="${chatgptUrl}" target="_blank" rel="noreferrer">Open ChatGPT</a>
+        <a class="action-link primary-link" href="${chatgptUrl}" target="_blank" rel="noreferrer">Open ChatGPT settings</a>
         <a class="resource-link" href="${githubUrl}" target="_blank" rel="noreferrer">Open GitHub</a>
         <a class="resource-link" href="${npmUrl}" target="_blank" rel="noreferrer">NPM</a>
         <a class="resource-link" href="${docsUrl}" target="_blank" rel="noreferrer">Docs</a>
@@ -1184,18 +1215,18 @@ function onboardingPage(config: CodexProConfig): string {
           <div class="section-head">
             <div>
               <h2>Quick path</h2>
-              <p>For a new local admin session, do these in order.</p>
+              <p>Use ChatGPT like a coding agent for this workspace without widening the local trust boundary.</p>
             </div>
           </div>
           <div class="guide-list">
-            <div class="guide-item"><span class="num">1</span><span><strong>Check the profile</strong><p>Save the tunnel, port, mode, bash, write, tool, Codex sessions, and working directory defaults for the next launch.</p></span></div>
+            <div class="guide-item"><span class="num">1</span><span><strong>Review the profile</strong><p>Choose the tunnel, port, mode, bash, write, tool, Codex session, and workspace defaults for the next launch.</p></span></div>
             <div class="guide-item"><span class="num">2</span><span><strong>Copy the Server URL</strong><p>Use the current public URL shown in the profile when available, or the one printed by the terminal after launch.</p></span></div>
-            <div class="guide-item"><span class="num">3</span><span><strong>Open ChatGPT settings</strong><p>Create an app connection, choose Server URL, paste the public URL, and use no extra authentication.</p></span></div>
-            <div class="guide-item"><span class="num">4</span><span><strong>Restart for policy changes</strong><p>Saved profile changes apply when CodexPro starts again. This keeps the live server predictable.</p></span></div>
+            <div class="guide-item"><span class="num">3</span><span><strong>Create the ChatGPT app</strong><p>Choose Server URL, paste the copied URL, and use no extra authentication. The private token is already in the URL.</p></span></div>
+            <div class="guide-item"><span class="num">4</span><span><strong>Restart for policy changes</strong><p>Saved profile changes apply when CodexPro starts again. The live server does not mutate under an active ChatGPT session.</p></span></div>
           </div>
         </section>
         <article class="run-card" id="status" aria-label="Current runtime">
-          <h2>Current session</h2>
+          <h2>Runtime guardrails</h2>
           <div class="status">
             <div class="row"><span class="label">Workspace</span><span class="mono">${escapeHtml(config.defaultRoot)}</span></div>
             <div class="row"><span class="label">Local MCP</span><span class="mono">${escapeHtml(localMcp)}</span></div>
@@ -1215,7 +1246,7 @@ function onboardingPage(config: CodexProConfig): string {
       <section class="panel" id="connect">
         <div class="section-head">
           <div>
-            <h2>Connect ChatGPT</h2>
+          <h2>Connect ChatGPT</h2>
             <p>Create an app connection that points at the public Server URL copied by the terminal.</p>
           </div>
         </div>
@@ -1253,7 +1284,7 @@ function onboardingPage(config: CodexProConfig): string {
       <ul class="roots">${allowedRoots}</ul>
       <p class="note">CodexPro rejects workspace access outside these roots.</p>
     </details>
-    <footer class="foot">Local admin surface for status, saved profile settings, CLI restart commands, and MCP access. Public sharing still happens through your chosen tunnel.</footer>
+    <footer class="foot">Token-protected local control surface for this workspace. Public sharing still happens only through your chosen tunnel.</footer>
   </main>
   <script>
     document.querySelectorAll("[data-copy], [data-copy-kind]").forEach((button) => {
@@ -1332,6 +1363,10 @@ function onboardingPage(config: CodexProConfig): string {
         const payload = {
           tunnel: data.tunnel,
           hostname: data.hostname,
+          tunnelName: data.tunnelName,
+          ngrokConfig: data.ngrokConfig,
+          cloudflareConfig: data.cloudflareConfig,
+          cloudflareTokenFile: data.cloudflareTokenFile,
           port: Number(data.port),
           mode: data.mode,
           bash: data.bash,
@@ -1340,7 +1375,8 @@ function onboardingPage(config: CodexProConfig): string {
           codexSessions: data.codexSessions,
           codexDir: data.codexDir,
           bashSession: data.bashSession,
-          requireBashSession: Boolean(form.elements.requireBashSession?.checked)
+          requireBashSession: Boolean(form.elements.requireBashSession?.checked),
+          noInstallCloudflared: Boolean(form.elements.noInstallCloudflared?.checked)
         };
         if (status) status.textContent = "Saving...";
         try {
@@ -1584,11 +1620,11 @@ async function main(): Promise<void> {
 
       await transport.handleRequest(req, res, req.body);
     } catch (error) {
-      console.error(error);
+      console.error(error instanceof Error ? error.stack ?? error.message : String(error));
       if (!res.headersSent) {
         res.status(500).json({
           jsonrpc: "2.0",
-          error: { code: -32603, message: error instanceof Error ? error.message : String(error) },
+          error: { code: -32603, message: "Internal CodexPro MCP error. Check the local terminal for details." },
           id: null
         });
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./works
 import { buildProContext, exportProContext } from "./proContext.js";
 import { codexproInventory, loadSkill } from "./capabilitiesOps.js";
 import { listCodexSessions, readCodexSession } from "./codexSessions.js";
-import { TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
+import { TOOL_CARD_LEGACY_URIS, TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
 
 function errorText(error: unknown): string {
@@ -95,42 +95,52 @@ function logToolCall(name: string, status: "ok" | "error", started: number): voi
 
 function registerToolCardResource(server: McpServer, config: CodexProConfig): void {
   const s = server as any;
-  if (typeof s.registerResource !== "function") return;
-  s.registerResource(
-    "codexpro-tool-card",
-    TOOL_CARD_URI,
-    {
-      title: "CodexPro Tool Card",
-      description: "Compact visual renderer for CodexPro workspace orientation, source changes, and handoffs.",
-      mimeType: TOOL_CARD_MIME_TYPE
-    },
-    async () => ({
-      contents: [
-        {
-          uri: TOOL_CARD_URI,
-          mimeType: TOOL_CARD_MIME_TYPE,
-          text: toolCardWidgetHtml,
-          _meta: {
-            ui: {
-              prefersBorder: true,
-              domain: config.widgetDomain,
-              csp: {
-                connectDomains: [],
-                resourceDomains: []
+  if (typeof s.registerResource !== "function") {
+    throw new Error("Unsupported MCP SDK: CodexPro widgets require registerResource.");
+  }
+
+  const registerUri = (uri: string, name: string): void => {
+    s.registerResource(
+      name,
+      uri,
+      {
+        title: "CodexPro Tool Card",
+        description: "Compact visual renderer for CodexPro workspace orientation, source changes, and handoffs.",
+        mimeType: TOOL_CARD_MIME_TYPE
+      },
+      async () => ({
+        contents: [
+          {
+            uri,
+            mimeType: TOOL_CARD_MIME_TYPE,
+            text: toolCardWidgetHtml,
+            _meta: {
+              ui: {
+                prefersBorder: true,
+                domain: config.widgetDomain,
+                csp: {
+                  connectDomains: [],
+                  resourceDomains: []
+                }
+              },
+              "openai/widgetDescription": "Renders CodexPro workspace orientation, diagnostics, file diffs, change reviews, terminal checks, Pro context exports, and handoff plans as compact developer cards with bounded previews.",
+              "openai/widgetPrefersBorder": true,
+              "openai/widgetDomain": config.widgetDomain,
+              "openai/widgetCSP": {
+                connect_domains: [],
+                resource_domains: []
               }
-            },
-            "openai/widgetDescription": "Renders CodexPro workspace orientation, diagnostics, file diffs, change reviews, terminal checks, Pro context exports, and handoff plans as compact developer cards with bounded previews.",
-            "openai/widgetPrefersBorder": true,
-            "openai/widgetDomain": config.widgetDomain,
-            "openai/widgetCSP": {
-              connect_domains: [],
-              resource_domains: []
             }
           }
-        }
-      ]
-    })
-  );
+        ]
+      })
+    );
+  };
+
+  registerUri(TOOL_CARD_URI, "codexpro-tool-card");
+  for (const legacyUri of TOOL_CARD_LEGACY_URIS) {
+    registerUri(legacyUri, `codexpro-tool-card-${legacyUri.match(/v\d+/)?.[0] ?? "legacy"}`);
+  }
 }
 
 
@@ -256,6 +266,16 @@ function toolNamesForMode(config: CodexProConfig): string[] {
       : config.toolMode === "minimal"
         ? [...MINIMAL_TOOL_NAMES]
         : [...STANDARD_TOOL_NAMES];
+  if (config.bashMode === "off") {
+    const bashIndex = names.indexOf("bash");
+    if (bashIndex !== -1) names.splice(bashIndex, 1);
+  }
+  if (config.writeMode !== "workspace") {
+    for (const writeTool of ["write", "edit"]) {
+      const toolIndex = names.indexOf(writeTool);
+      if (toolIndex !== -1) names.splice(toolIndex, 1);
+    }
+  }
   for (const name of codexSessionToolNames(config)) {
     if (!names.includes(name)) names.push(name);
   }
@@ -264,8 +284,22 @@ function toolNamesForMode(config: CodexProConfig): string[] {
 
 const MINIMAL_TOOLS = new Set<string>(MINIMAL_TOOL_NAMES);
 const STANDARD_TOOLS = new Set<string>(STANDARD_TOOL_NAMES);
+const registeredToolNamesByServer = new WeakMap<object, string[]>();
+
+function rememberRegisteredTool(server: McpServer, name: string): void {
+  const key = server as object;
+  const names = registeredToolNamesByServer.get(key) ?? [];
+  if (!registeredToolNamesByServer.has(key)) registeredToolNamesByServer.set(key, names);
+  if (!names.includes(name)) names.push(name);
+}
+
+function registeredToolNames(server: McpServer): string[] {
+  return [...(registeredToolNamesByServer.get(server as object) ?? [])];
+}
 
 function shouldRegisterTool(config: CodexProConfig, name: string): boolean {
+  if (name === "bash" && config.bashMode === "off") return false;
+  if ((name === "write" || name === "edit") && config.writeMode !== "workspace") return false;
   if (name === "codex_sessions") return config.codexSessions !== "off";
   if (name === "read_codex_session") return config.codexSessions === "read";
   if (config.toolMode === "full") return true;
@@ -282,9 +316,21 @@ function registerCodexTool(
 ): void {
   if (!shouldRegisterTool(config, name)) return;
   registerToolCompat(server, name, options, handler);
+  rememberRegisteredTool(server, name);
 }
 
 function serverInstructions(config: CodexProConfig): string {
+  const editInstruction =
+    config.writeMode === "workspace"
+      ? "4. Edit source files with write/edit. After edits, call show_changes once for git status, diff stats, and review diff."
+      : config.writeMode === "handoff"
+        ? "4. Source writes are disabled and generic write/edit tools are unavailable. Use handoff_to_agent/handoff_to_codex for plans."
+        : "4. Write/edit tools are disabled. Do not attempt direct file writes; use handoff or context export workflows instead.";
+  const bashInstruction =
+    config.bashMode === "off"
+      ? "5. Bash is disabled and the bash tool is unavailable. Do not attempt shell commands."
+      : "5. Use bash only for meaningful verification commands such as npm test, npm run build, lint, typecheck, or an existing project script.";
+
   return [
     "CodexPro connects ChatGPT to one local development workspace.",
     "",
@@ -292,9 +338,9 @@ function serverInstructions(config: CodexProConfig): string {
     "1. Start with open_current_workspace. Use open_workspace only when the user gives a different root or asks to switch folders.",
     "2. Follow any AGENTS.md-style instructions returned by the workspace open call before editing files.",
     "3. Inspect with tree, search, and read. Do not use bash for git status, git diff, cat, sed, grep, rg, find, ls, or file reading.",
-    "4. Edit with write/edit. After edits, call show_changes once for git status, diff stats, and review diff.",
-    "5. Use bash only for meaningful verification commands such as npm test, npm run build, lint, typecheck, or an existing project script.",
-    "6. Keep tool calls minimal. Prefer one targeted search plus show_changes instead of repeated broad bash/git calls.",
+    editInstruction,
+    bashInstruction,
+    "6. Keep tool calls minimal. Prefer one targeted search plus show_changes instead of repeated broad inspection calls.",
     config.codexSessions !== "off"
       ? `7. Codex session history access is enabled in ${config.codexSessions} mode. Use it only when the user asks for local Codex session history.`
       : "",
@@ -567,6 +613,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = getSharedWorkspaceManager(config);
   const guard = new PathGuard(config);
   const server = new McpServer({ name: "CodexPro", version: "0.28.5" }, { instructions: serverInstructions(config) });
+  registeredToolNamesByServer.set(server as object, []);
   registerToolCardResource(server, config);
 
   registerCodexTool(
@@ -606,7 +653,9 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         maxWriteBytes: config.maxWriteBytes,
         maxOutputBytes: config.maxOutputBytes,
         maxSearchResults: config.maxSearchResults,
-        blockedGlobs: config.blockedGlobs
+        blockedGlobs: config.blockedGlobs,
+        registeredTools: registeredToolNames(server),
+        registeredToolCount: registeredToolNames(server).length
       };
       return textResult(`# CodexPro Server Config\n\n${JSON.stringify(safeConfig, null, 2)}`, safeConfig);
     }
@@ -655,7 +704,17 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         config.requireHttpToken && !config.authToken ? "fail" : "pass",
         config.requireHttpToken ? "token required for public/non-loopback access" : "loopback token not required"
       );
-      check("registered tool set", "pass", `${toolNamesForMode(config).length} tools for ${config.toolMode} mode`);
+      const expectedTools = toolNamesForMode(config).sort();
+      const actualTools = registeredToolNames(server).sort();
+      const missingTools = expectedTools.filter((name) => !actualTools.includes(name));
+      const extraTools = actualTools.filter((name) => !expectedTools.includes(name));
+      check(
+        "registered tool set",
+        missingTools.length || extraTools.length ? "fail" : "pass",
+        missingTools.length || extraTools.length
+          ? `missing: ${missingTools.join(", ") || "none"}; extra: ${extraTools.join(", ") || "none"}`
+          : `${actualTools.length} tools registered for ${config.toolMode} mode`
+      );
 
       try {
         const inventory = await codexproInventory(config, workspace, {
@@ -781,7 +840,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         `Status: ${status}`,
         `Workspace: ${workspace.root}`,
         `Mode: tools=${config.toolMode}, write=${config.writeMode}, bash=${config.bashMode}${config.bashSessionId ? `, bash_session=${config.bashSessionId}${config.requireBashSession ? " required" : ""}` : ""}`,
-        `Expected tools: ${toolNamesForMode(config).length}`,
+        `Expected tools: ${expectedTools.length}`,
+        `Registered tools: ${actualTools.length}`,
         `Duration: ${Date.now() - started} ms`,
         "",
         "## Checks",
@@ -801,8 +861,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         warned,
         failed,
         duration_ms: Date.now() - started,
-        expected_tools: toolNamesForMode(config),
-        expected_tool_count: toolNamesForMode(config).length,
+        expected_tools: expectedTools,
+        expected_tool_count: expectedTools.length,
+        registered_tools: actualTools,
+        registered_tool_count: actualTools.length,
         bash_mode: config.bashMode,
         bash_session_id: config.bashSessionId ?? null,
         require_bash_session: config.requireBashSession,

--- a/src/toolCardWidget.ts
+++ b/src/toolCardWidget.ts
@@ -1,4 +1,5 @@
 export const TOOL_CARD_URI = "ui://widget/codexpro-tool-card-v9.html";
+export const TOOL_CARD_LEGACY_URIS = ["ui://widget/codexpro-tool-card-v8.html"];
 export const TOOL_CARD_MIME_TYPE = "text/html;profile=mcp-app";
 
 export const toolCardWidgetHtml = String.raw`
@@ -933,10 +934,35 @@ export const toolCardWidgetHtml = String.raw`
     }
   }
 
-  render(window.openai?.toolOutput || window.openai?.toolResponseMetadata || {});
+  function extractStructuredContent(value) {
+    if (!value || typeof value !== "object") return {};
+    if (value.codexpro_tool || value.codexpro_title) return value;
+    const candidates = [
+      value.structuredContent,
+      value.toolOutput?.structuredContent,
+      value.toolOutput,
+      value.toolResponseMetadata?.structuredContent,
+      value.mcp_tool_result?.structuredContent,
+      value.call_tool_result?.structuredContent,
+      value.result?.structuredContent
+    ];
+    for (const candidate of candidates) {
+      if (candidate && typeof candidate === "object") return candidate;
+    }
+    return {};
+  }
+
+  render(extractStructuredContent(window.openai?.toolOutput || window.openai?.toolResponseMetadata || {}));
 
   window.addEventListener("openai:set_globals", (event) => {
-    render(event.detail?.globals?.toolOutput || window.openai?.toolOutput || {});
+    render(extractStructuredContent(
+      event.detail?.globals?.toolOutput ||
+      event.detail?.globals?.toolResponseMetadata ||
+      event.detail ||
+      window.openai?.toolOutput ||
+      window.openai?.toolResponseMetadata ||
+      {}
+    ));
   }, { passive: true });
 
   window.addEventListener("message", (event) => {
@@ -944,7 +970,7 @@ export const toolCardWidgetHtml = String.raw`
     const message = event.data;
     if (!message || message.jsonrpc !== "2.0") return;
     if (message.method === "ui/notifications/tool-result") {
-      render(message.params?.structuredContent || {});
+      render(extractStructuredContent(message.params || {}));
     }
   }, { passive: true });
 </script>


### PR DESCRIPTION
## Summary
- Reposition CodexPro around the clearer promise: use ChatGPT like your local coding agent for one token-protected workspace.
- Redesign the docs/admin copy and visual system toward a minimal white/blue setup-first experience.
- Tighten safety boundaries around bash/write/tool modes, Codex session access, tunnel token handling, and MCP error responses.
- Add a durable design note and expand smoke coverage for the new admin/settings/tool registration behavior.

## Why
Users were getting too much raw connector detail before understanding the simple path: install, setup in one repo, paste the Server URL into ChatGPT, then work inside a bounded local workspace. This PR makes that flow clearer while keeping the ToS/security boundary explicit.

## Validation
- npm run build
- npm run smoke
- npm pack --dry-run
- npm audit --audit-level=high
- git diff --check
- Playwright screenshots for docs desktop and mobile
- Focused secret-pattern scan; matches were placeholders or deliberate smoke-test fixtures only

## Notes
- Draft PR only; do not merge until Codex/GitHub review comments are checked.
- Package version remains 0.28.5 in this PR.