### PR TITLE
[codex] avoid competitor naming in docs

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -10,7 +10,7 @@ CodexPro does not unlock Developer Mode, unlock models, bypass account limits, o
 
 Account access and model tool support are separate. A Plus or Pro account can have Apps / Developer Mode, while a specific model surface may still be unable to call connectors or MCP tools directly. Use the Pro context fallback for those sessions.
 
-## How is CodexPro different from DevSpace?
+## How is CodexPro different from generic workspace bridges?
 
 They can look similar at the transport layer because both use a local MCP-style bridge and a workspace root.
 
@@ -28,7 +28,7 @@ The main differences are:
 - The normal workflow emphasizes compact cards, diffs, `show_changes`, smoke tests, and handoff status files.
 - CodexPro keeps a strict boundary: no model proxying, account pooling, third-party Pro site scraping, quota bypassing, or OS sandbox claims.
 
-Short version: DevSpace-style tools may share the bridge idea; CodexPro is the cleaner ChatGPT-to-local-repo coding agent workflow with stricter defaults and clearer review surfaces.
+Short version: other tools may share the bridge idea; CodexPro is the cleaner ChatGPT-to-local-repo coding agent workflow with stricter defaults and clearer review surfaces.
 
 ## What is the recommended install path?
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If one workflow is unavailable and another product surface you already have acce
 
 If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some ChatGPT model surfaces may not be able to call connectors or MCP tools directly. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
 
-## CodexPro vs DevSpace-style bridges
+## CodexPro vs generic workspace bridges
 
 The high-level shape can look similar because both use a local MCP bridge, a tunnel, and a workspace root. CodexPro is narrower and more opinionated: it is built to make ChatGPT Developer Mode work like a practical local coding agent for one repo.
 
@@ -110,7 +110,7 @@ The high-level shape can look similar because both use a local MCP bridge, a tun
 | Reviewable outputs | Tool cards, diffs, `show_changes`, smoke tests, and handoff status files are designed so users can see what changed before trusting it. |
 | TOS-safe product boundary | CodexPro does not proxy models, pool accounts, scrape third-party Pro sites, bypass quotas, or pretend to be an OS sandbox. |
 
-So the short answer is: DevSpace-style bridges may share the transport idea, but CodexPro is positioned as the cleaner ChatGPT-to-local-repo coding product with stricter defaults, clearer admin controls, and a repo-first agent workflow.
+So the short answer is: generic workspace bridges may share the transport idea, but CodexPro is positioned as the cleaner ChatGPT-to-local-repo coding product with stricter defaults, clearer admin controls, and a repo-first agent workflow.
 
 ## Preview
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -189,7 +189,7 @@ codexpro setup</code>
 
       <section class="section two-col">
         <div>
-          <p class="eyebrow">Compared with DevSpace-style bridges</p>
+          <p class="eyebrow">Compared with generic workspace bridges</p>
           <h2>CodexPro is the ChatGPT-first local coding loop.</h2>
           <p>
             The transport can look similar: local MCP server, workspace root, and a tunnel. CodexPro is more opinionated. It is built for one job: make ChatGPT Developer Mode useful against one local repo without widening the trust boundary.


### PR DESCRIPTION
## Summary
- Replace direct competitor naming in public docs with generic workspace bridge language.
- Keep direct product comparisons for issue discussions where users ask for them.

## Validation
- npm run build
- npm run smoke
- git diff --check
- rg DevSpace/devspace across public docs returned no matches