### PR TITLE
[codex] harden autonomous handoff loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- Added `codexpro loop-handoff` for bounded local execute/review loops over `.ai-bridge/current-plan.md`, with a required local `--review-command`, `--max-iters`, dry-run preview, optional test command capture, and stop conditions for no diff, repeated diff, missing follow-up plans, reviewer errors, and human cancellation.
+- Hardened `loop-handoff` external-command boundaries: commands are preflighted before execution, reviewer verdicts require explicit `CODEXPRO_REVIEW=...` assignment lines by default, and reviewer `PASS` no longer masks failed executor/test/reviewer commands unless the user opts into the supported override behavior.
+- Fixed loop change detection so `--stop-if-no-files-changed` and `--stop-if-same-diff` compare each iteration against a pre-execution baseline and count unstaged diffs, staged diffs, and untracked file fingerprints outside `.ai-bridge`.
+- Switched loop guard decisions to an uncapped git-state fingerprint instead of hashing or vetoing on the trimmed reviewer diff artifact.
+- Kept handoff plan hashing on the handoff read-size budget instead of `--max-output-bytes`, so valid plans larger than captured output excerpts do not abort the loop after execution.
+- Made loop change fingerprints content/status based instead of timestamp based, so repeated identical tracked-file writes stop as no new changes instead of looking different because of volatile mtimes.
+- Bounded untracked file fingerprinting so symlinks are reported via `readlink` and regular files hash only a capped prefix instead of following arbitrary paths or reading entire generated artifacts.
+- Tightened `--require-clean-git-start` so staged renames are treated as handoff-only only when both rename endpoints are inside `.ai-bridge`.
+- Stopped reviewer `FAIL` and implicit review verdicts from continuing when the reviewer deletes, empties, or restores `.ai-bridge/current-plan.md` to the scaffold instead of writing a usable follow-up plan.
+- Kept the autonomous handoff loop CLI-only and local-terminal-owned; it does not expose agent execution as a remote MCP tool, automate ChatGPT Web, approve product prompts, proxy models, or bypass limits.
+- Extended handoff smoke coverage with a fake reviewer that fails once by writing a follow-up plan, then passes on the second local executor iteration, plus failed executor, failed reviewer, bare `PASS`, staged-only, untracked-file, bounded-untracked, dirty-baseline, repeated-identical-write, large-dirty-baseline, unavailable-diff-artifact, large-plan-over-output-cap, staged-rename, deleted-follow-up-plan, and implicit-deleted-plan cases.
+
 ## 0.28.5
 
 - Added a compatibility alias for stale ChatGPT descriptors that still request `ui://widget/codexpro-tool-card-v8.html`, while keeping `ui://widget/codexpro-tool-card-v9.html` as the current advertised widget.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Local-only companion command:
 
 - `codexpro execute-handoff` — run a previously written `.ai-bridge/current-plan.md` through a local agent, then collect status, logs, and git diff. This is intentionally a CLI command, not a remote MCP tool.
 - `codexpro watch-handoff` — watch `.ai-bridge/current-plan.md` locally and run a new plan through a configured agent when its content hash changes. This is also CLI-only and is not exposed as a remote MCP tool.
+- `codexpro loop-handoff` — run a bounded local execute/review loop where a user-provided reviewer command can pass or rewrite `.ai-bridge/current-plan.md` for another local executor iteration.
 
 The watcher is the safer way to automate handoff execution from ChatGPT Web. ChatGPT writes the plan through `handoff_to_agent`; the user-started local watcher notices the new plan and runs Pi, OpenCode, Codex, or a restricted custom command from the terminal:
 
@@ -248,6 +249,47 @@ The watcher writes the same review files as `execute-handoff`:
 .ai-bridge/implementation-diff.patch
 .ai-bridge/execution-log.jsonl
 ```
+
+For autonomous local handoff loops, use `loop-handoff` with an explicit reviewer command:
+
+```bash
+codexpro loop-handoff \
+  --agent opencode \
+  --model provider/model \
+  --review-command "node ./reviewer.js --status {{status_file}} --diff {{diff_file}} --log {{log_file}} --plan-file {{plan_file}}" \
+  --max-iters 3 \
+  --stop-if-no-files-changed \
+  --stop-if-same-diff \
+  --yes
+```
+
+The reviewer command runs locally after each executor iteration. It must inspect the generated files, then either print `CODEXPRO_REVIEW=PASS` or print `CODEXPRO_REVIEW=FAIL` and update `.ai-bridge/current-plan.md` with the next fix plan. CodexPro stops on pass, max iterations, missing verdict, no usable follow-up plan, repeated diff, no new executor changes, reviewer error, executor/test failure, or human cancellation. Loop change detection compares each iteration against a pre-execution baseline and counts unstaged diffs, staged diffs, and bounded untracked file fingerprints outside `.ai-bridge`.
+
+Useful loop placeholders:
+
+```text
+{{plan_file}}    .ai-bridge/current-plan.md
+{{status_file}}  .ai-bridge/agent-status.md
+{{diff_file}}    .ai-bridge/implementation-diff.patch
+{{log_file}}     .ai-bridge/execution-log.jsonl
+{{tests_file}}   .ai-bridge/loop-tests.txt
+{{review_file}}  .ai-bridge/loop-review.md
+{{root}}         workspace root
+{{iteration}}    current loop iteration
+```
+
+Optional safety flags:
+
+```text
+--dry-run                         preview executor, test, and reviewer commands
+--run-tests "npm test"            run a local verification command before review
+--require-clean-git-start         require no non-.ai-bridge git changes before starting
+--require-human-confirmation      ask before running each reviewer-generated follow-up plan
+--allow-implicit-review-verdict   infer verdicts from reviewer exit code and plan changes
+--allow-review-pass-on-failure    let reviewer PASS override failed executor/tests
+```
+
+`loop-handoff` does not resume ChatGPT Web, drive a browser, approve terminal prompts, proxy models, or bypass product limits. It is a local terminal-owned loop over explicit repo files and local commands.
 
 ## Visual ChatGPT cards
 
@@ -616,6 +658,19 @@ By default, `execute-handoff` asks for local confirmation before running. Use `-
 ```
 
 Then let ChatGPT review those files through `read_handoff` or `codex_context`.
+
+To keep the review cycle local after the first handoff, provide a reviewer command to `loop-handoff`:
+
+```bash
+codexpro loop-handoff \
+  --agent opencode \
+  --model provider/cheap-model \
+  --review-command "node ./reviewer.js --status {{status_file}} --diff {{diff_file}} --plan-file {{plan_file}}" \
+  --max-iters 3 \
+  --yes
+```
+
+The reviewer command is responsible for deciding the next step. Print `CODEXPRO_REVIEW=PASS` to stop successfully, or print `CODEXPRO_REVIEW=FAIL` and update `.ai-bridge/current-plan.md` with the next local fix plan. Add `--run-tests "npm test"` to capture test output in `.ai-bridge/loop-tests.txt` before the reviewer runs. By default, CodexPro requires an explicit verdict and rejects a reviewer `PASS` if the executor or test command failed.
 
 Manual fallback:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,7 @@ CodexPro can expose:
 - optional shell command execution through the `bash` tool, hidden when bash mode is off
 - optional write/edit capability depending on `CODEXPRO_WRITE_MODE`, advertised only in workspace write mode
 - optional local handoff execution through `codexpro execute-handoff`, run from the user's terminal only
+- optional local execute/review looping through `codexpro loop-handoff`, run from the user's terminal only with a user-provided reviewer command and iteration limit
 
 ## Failure Model
 
@@ -43,6 +44,8 @@ Review changes against these failure modes before release:
 | Local Codex history is treated as ChatGPT memory | Codex session access is opt-in metadata/read mode and never attaches to a live Codex app session. |
 | Browser admin mutates live runtime unexpectedly | Admin profile changes apply on restart; active runtime policy stays stable for the current session. |
 | Remote MCP tool runs Codex/OpenCode/Pi directly | Agent execution remains a user-started CLI/watch process on the local machine. |
+| Autonomous loop drives ChatGPT Web or bypasses approvals | `loop-handoff` only runs local terminal commands over `.ai-bridge` files; it does not resume browser sessions, approve prompts, or expose a remote MCP executor. |
+| Reviewer masks a failed external command | `loop-handoff` requires explicit reviewer verdict assignments and rejects reviewer `PASS` after failed executor, test, or reviewer commands unless the user opts into the supported executor/test override behavior. |
 
 The main risks are:
 
@@ -51,6 +54,7 @@ The main risks are:
 - running with `CODEXPRO_BASH_MODE=full`
 - running with `CODEXPRO_WRITE_MODE=workspace` on an important repo
 - executing an untrusted `.ai-bridge/current-plan.md` or custom `execute-handoff --command`
+- running `loop-handoff` with an untrusted reviewer command or without a small `--max-iters`
 - adding overly broad allowed roots
 - leaking a `codexpro_token` or Cloudflare tunnel token
 - trusting a downloaded `cloudflared` binary without understanding where it came from
@@ -97,7 +101,9 @@ codexpro start \
 - Do not paste raw Cloudflare tunnel tokens into browser pages or screenshots. Use `--cloudflare-token-file` or the local page's Cloudflare token file field instead.
 - Use `--mode handoff` for planning workflows where ChatGPT should not edit source files. Handoff mode does not advertise generic `write`/`edit` tools.
 - Preview local handoff execution with `codexpro execute-handoff --dry-run` before running an unfamiliar adapter or custom command.
+- Preview autonomous local loops with `codexpro loop-handoff --dry-run`, keep `--max-iters` small, and prefer `--require-human-confirmation` until you trust the reviewer command.
 - Keep `execute-handoff` local. Do not wrap it in a remote MCP tool unless you add a stronger approval and sandbox story.
+- Keep `loop-handoff` local. Do not use it to automate ChatGPT Web, Codex approvals, account access, third-party Pro sites, quota limits, or product safety prompts.
 - Use default agent mode only with trusted ChatGPT sessions and repo-specific roots.
 - Use `--no-bash` when ChatGPT should never trigger shell commands in the workspace.
 - Use `--bash-session <id> --require-bash-session` when bash should be enabled only for calls that explicitly target this local CodexPro terminal label.

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -10,6 +10,8 @@ import { createInterface } from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const UNTRACKED_FILE_HASH_BYTES = 64 * 1024;
+const UNTRACKED_SYMLINK_TARGET_BYTES = 512;
 
 function usage() {
   console.log(`CodexPro easy launcher
@@ -23,6 +25,7 @@ Usage:
   codexpro doctor
   codexpro execute-handoff --agent opencode --model provider/model
   codexpro watch-handoff --agent opencode --model provider/model
+  codexpro loop-handoff --agent opencode --model provider/model --review-command "node ./reviewer.js --status {{status_file}} --diff {{diff_file}} --plan-file {{plan_file}}"
   codexpro --root /path/to/repo
   codexpro ngrok --hostname your-domain.ngrok-free.dev
   codexpro stable --hostname codexpro.example.com --tunnel-name codexpro
@@ -123,6 +126,26 @@ Watch handoff options:
   --state-file <path>       Watch state file. Default: .ai-bridge/watch-handoff-state.json.
   --yes                     Start automatic local execution without startup confirmation.
 
+Loop handoff options:
+  codexpro loop-handoff --agent opencode --model provider/model --review-command "reviewer --status {{status_file}} --diff {{diff_file}} --plan-file {{plan_file}}"
+  --review-command <template>
+                             Local reviewer/orchestrator command. It should print CODEXPRO_REVIEW=PASS or CODEXPRO_REVIEW=FAIL.
+                             On FAIL it must update .ai-bridge/current-plan.md before the next iteration.
+  --max-iters <n>           Maximum execute/review iterations. Default: 3.
+  --run-tests <template>    Optional local verification command before review.
+  --allow-implicit-review-verdict
+                             Infer PASS/FAIL from reviewer exit code and plan changes when no CODEXPRO_REVIEW line is printed.
+  --allow-review-pass-on-failure
+                             Let explicit reviewer PASS override a failed executor or failed test command.
+  --require-clean-git-start Refuse to start unless git status is clean.
+  --stop-if-no-files-changed
+                             Stop if an executor iteration produces no git diff.
+  --stop-if-same-diff       Stop if an executor iteration repeats the previous diff.
+  --require-human-confirmation
+                             Ask before running a reviewer-generated follow-up plan.
+  --dry-run                 Print executor/reviewer/test commands without executing them.
+  --yes                     Start the local loop without startup confirmation.
+
 Default agent mode:
   codexpro start --root /path/to/repo
 
@@ -154,6 +177,9 @@ Execute a local handoff after ChatGPT writes .ai-bridge/current-plan.md:
 Watch for new handoff plans and execute them locally:
   codexpro watch-handoff --agent opencode --model provider/model --yes
   codexpro watch-handoff --agent custom --command "node ./agent.js --task-file {{plan_file}}" --yes
+
+Run a bounded local execute/review loop:
+  codexpro loop-handoff --agent opencode --model provider/model --review-command "node ./reviewer.js --status {{status_file}} --diff {{diff_file}} --plan-file {{plan_file}}" --max-iters 3 --yes
 
 Stable URL mode after one-time Cloudflare tunnel setup:
   codexpro stable --root /path/to/repo --hostname codexpro.example.com --tunnel-name codexpro
@@ -271,6 +297,12 @@ function parseArgs(argv) {
     else if (key === 'once') out.once = true;
     else if (key === 'confirm') out.confirm = true;
     else if (key === 'no-confirm') out.noConfirm = true;
+    else if (key === 'require-clean-git-start') out.requireCleanGitStart = true;
+    else if (key === 'stop-if-no-files-changed') out.stopIfNoFilesChanged = true;
+    else if (key === 'stop-if-same-diff') out.stopIfSameDiff = true;
+    else if (key === 'require-human-confirmation') out.requireHumanConfirmation = true;
+    else if (key === 'allow-implicit-review-verdict') out.allowImplicitReviewVerdict = true;
+    else if (key === 'allow-review-pass-on-failure') out.allowReviewPassOnFailure = true;
     else if (key === 'open-chatgpt') out.openChatgpt = true;
     else if (key === 'no-profile') out.noProfile = true;
     else if (key === 'save-config') out.saveConfig = true;
@@ -1001,6 +1033,10 @@ function numberOption(value, fallback, min, max) {
   return Math.max(min, Math.min(max, Math.floor(parsed)));
 }
 
+function handoffMaxReadBytes() {
+  return numberOption(process.env.CODEXPRO_MAX_READ_BYTES, 180_000, 4_000, 2_000_000);
+}
+
 function shellCommandPreview(parts) {
   return parts.map((part) => {
     const text = String(part);
@@ -1069,7 +1105,7 @@ function splitCommandTemplate(input) {
 }
 
 function applyCommandTemplate(value, replacements) {
-  return String(value).replace(/\{\{\s*(model|plan_file|plan_text|root)\s*\}\}/g, (_, key) => replacements[key] ?? '');
+  return String(value).replace(/\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g, (_, key) => replacements[key] ?? '');
 }
 
 function buildExecutorCommand(args, root, planPath, planText) {
@@ -1285,7 +1321,7 @@ function loadHandoffExecution(args) {
   const contextDir = contextDirFromArgs(args);
   const bridgeDir = resolveWorkspaceFile(root, contextDir);
   const planPath = path.join(bridgeDir, 'current-plan.md');
-  const maxReadBytes = numberOption(process.env.CODEXPRO_MAX_READ_BYTES, 180_000, 4_000, 2_000_000);
+  const maxReadBytes = handoffMaxReadBytes();
   const maxOutputBytes = numberOption(args.maxOutputBytes ?? process.env.CODEXPRO_MAX_OUTPUT_BYTES, 120_000, 4_000, 2_000_000);
   const timeoutMs = numberOption(args.timeoutMs ?? args.timeout, 600_000, 1_000, 24 * 60 * 60_000);
   if (!fs.existsSync(planPath)) {
@@ -1540,6 +1576,632 @@ async function runWatchHandoff(argv) {
 
     await sleep(pollIntervalMs);
   }
+}
+
+function loopArtifactPaths(root, contextDir) {
+  const bridgeDir = resolveWorkspaceFile(root, contextDir);
+  return {
+    bridgeDir,
+    planPath: path.join(bridgeDir, 'current-plan.md'),
+    statusPath: path.join(bridgeDir, 'agent-status.md'),
+    diffPath: path.join(bridgeDir, 'implementation-diff.patch'),
+    logPath: path.join(bridgeDir, 'execution-log.jsonl'),
+    testsPath: path.join(bridgeDir, 'loop-tests.txt'),
+    reviewPath: path.join(bridgeDir, 'loop-review.md'),
+    statePath: path.join(bridgeDir, 'loop-handoff-state.json')
+  };
+}
+
+function buildTemplateCommand(template, replacements, displayReplacements, label) {
+  const parts = splitCommandTemplate(template).map((part) => applyCommandTemplate(part, replacements));
+  const displayParts = splitCommandTemplate(template).map((part) => applyCommandTemplate(part, displayReplacements ?? replacements));
+  if (!parts.length) throw new Error(`${label} command is empty.`);
+  return {
+    command: parts[0],
+    args: parts.slice(1),
+    displayArgs: displayParts.slice(1),
+    displayCommand: shellCommandPreview([displayParts[0], ...displayParts.slice(1)])
+  };
+}
+
+function loopTemplateReplacements(root, contextDir, iteration, paths) {
+  return {
+    root,
+    context_dir: resolveWorkspaceFile(root, contextDir),
+    iteration: String(iteration),
+    plan_file: paths.planPath,
+    status_file: paths.statusPath,
+    diff_file: paths.diffPath,
+    log_file: paths.logPath,
+    tests_file: paths.testsPath,
+    review_file: paths.reviewPath,
+    state_file: paths.statePath
+  };
+}
+
+function buildReviewerCommand(args, root, contextDir, iteration, paths) {
+  const template = String(args.reviewCommand ?? '').trim();
+  if (!template) throw new Error('loop-handoff requires --review-command <template>.');
+  const replacements = loopTemplateReplacements(root, contextDir, iteration, paths);
+  return buildTemplateCommand(template, replacements, replacements, 'Review');
+}
+
+function buildTestCommand(args, root, contextDir, iteration, paths) {
+  const template = String(args.runTests ?? '').trim();
+  if (!template) return null;
+  const replacements = loopTemplateReplacements(root, contextDir, iteration, paths);
+  return buildTemplateCommand(template, replacements, replacements, 'Test');
+}
+
+function commandDisplay(commandInfo) {
+  return shellCommandPreview([commandInfo.command, ...(commandInfo.displayArgs ?? commandInfo.args)]);
+}
+
+function gitStatusPorcelain(root) {
+  const result = spawnSync('git', ['status', '--porcelain=v1'], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 1_000_000,
+    shell: false
+  });
+  if (result.status !== 0) {
+    const reason = result.stderr || result.stdout || `git status exited ${result.status}`;
+    throw new Error(`git status failed: ${redactForLog(reason).trim()}`);
+  }
+  return result.stdout || '';
+}
+
+function normalizedContextDir(contextDir) {
+  return String(contextDir || '.ai-bridge').replace(/\\/g, '/').replace(/^\.?\//, '').replace(/\/+$/, '');
+}
+
+function normalizeStatusPath(value) {
+  return String(value || '').replace(/^"|"$/g, '').replace(/\\"/g, '"');
+}
+
+function statusLinePaths(line) {
+  const value = String(line || '').slice(3).trim();
+  const renameIndex = value.indexOf(' -> ');
+  if (renameIndex < 0) return [normalizeStatusPath(value)];
+  return [
+    normalizeStatusPath(value.slice(0, renameIndex)),
+    normalizeStatusPath(value.slice(renameIndex + 4))
+  ];
+}
+
+function isContextStatusLine(line, contextDir) {
+  const context = normalizedContextDir(contextDir);
+  const paths = statusLinePaths(line);
+  return paths.length > 0 && paths.every((filePath) => filePath === context || filePath.startsWith(`${context}/`));
+}
+
+function assertCleanGitStart(root, contextDir) {
+  const status = gitStatusPorcelain(root);
+  const nonContextStatus = status.split(/\r?\n/).filter((line) => line.trim() && !isContextStatusLine(line, contextDir)).join('\n');
+  if (nonContextStatus.trim()) {
+    throw new Error(`--require-clean-git-start refused to start because the workspace has non-handoff changes:\n${nonContextStatus}`);
+  }
+}
+
+function runGitText(root, args, maxBytes) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: Math.max(maxBytes * 2, 1_000_000),
+    shell: false
+  });
+  if (result.status !== 0) {
+    const reason = result.stderr || result.stdout || `git ${args.join(' ')} exited ${result.status}`;
+    throw new Error(redactForLog(reason).trim());
+  }
+  return result.stdout || '';
+}
+
+function singleLineSummary(value) {
+  return String(value).replace(/\r/g, '\\r').replace(/\n/g, '\\n');
+}
+
+function fileSha256(filePath) {
+  const hash = createHash('sha256');
+  const fd = fs.openSync(filePath, 'r');
+  const buffer = Buffer.alloc(64 * 1024);
+  try {
+    for (;;) {
+      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (!bytesRead) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  return hash.digest('hex');
+}
+
+function boundedFileFingerprint(filePath, stat) {
+  const hash = createHash('sha256');
+  const fd = fs.openSync(filePath, 'r');
+  const buffer = Buffer.alloc(64 * 1024);
+  let remaining = Math.min(stat.size, UNTRACKED_FILE_HASH_BYTES);
+  try {
+    while (remaining > 0) {
+      const bytesRead = fs.readSync(fd, buffer, 0, Math.min(buffer.length, remaining), null);
+      if (!bytesRead) break;
+      hash.update(buffer.subarray(0, bytesRead));
+      remaining -= bytesRead;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  const hashLabel = stat.size > UNTRACKED_FILE_HASH_BYTES ? `sha256_first_${UNTRACKED_FILE_HASH_BYTES}` : 'sha256';
+  const truncated = stat.size > UNTRACKED_FILE_HASH_BYTES ? ', fingerprint_truncated=true' : '';
+  return `${stat.size} bytes, ${hashLabel}=${hash.digest('hex')}${truncated}`;
+}
+
+function untrackedEntrySummary(root, relPath) {
+  const absPath = path.resolve(root, relPath);
+  try {
+    const stat = fs.lstatSync(absPath);
+    if (stat.isSymbolicLink()) {
+      const target = singleLineSummary(trimBytes(fs.readlinkSync(absPath), UNTRACKED_SYMLINK_TARGET_BYTES).text);
+      return `- ${relPath} (symlink, target=${target})`;
+    }
+    if (!stat.isFile()) return `- ${relPath} (${stat.isDirectory() ? 'directory' : 'non-file'})`;
+    return `- ${relPath} (${boundedFileFingerprint(absPath, stat)})`;
+  } catch (error) {
+    return `- ${relPath} (unavailable: ${singleLineSummary(redactForLog(error instanceof Error ? error.message : String(error)))})`;
+  }
+}
+
+function untrackedFilesSummary(root, contextDir, maxBytes) {
+  const context = normalizedContextDir(contextDir);
+  const output = runGitText(root, ['ls-files', '--others', '--exclude-standard', '-z'], 1_000_000);
+  const entries = output.split('\0').filter(Boolean).filter((relPath) => relPath !== context && !relPath.startsWith(`${context}/`));
+  if (!entries.length) return '';
+  const lines = [];
+  let usedBytes = 0;
+  let omitted = 0;
+  const budget = Math.max(1_024, maxBytes);
+  for (const relPath of entries.sort()) {
+    const line = untrackedEntrySummary(root, relPath);
+    const lineBytes = Buffer.byteLength(`${line}\n`, 'utf8');
+    if (usedBytes + lineBytes > budget) {
+      omitted += 1;
+      continue;
+    }
+    lines.push(line);
+    usedBytes += lineBytes;
+  }
+  if (omitted) lines.push(`- ... ${omitted} untracked entries omitted after ${budget} bytes`);
+  return `${lines.join('\n')}\n`;
+}
+
+function contextPathPredicate(contextDir) {
+  const context = normalizedContextDir(contextDir);
+  return (filePath) => filePath === context || filePath.startsWith(`${context}/`);
+}
+
+function pathStateForFingerprint(root, relPath, options = {}) {
+  const absPath = path.resolve(root, relPath);
+  try {
+    const stat = fs.lstatSync(absPath);
+    const type = stat.isSymbolicLink()
+      ? 'symlink'
+      : stat.isFile()
+        ? 'file'
+        : stat.isDirectory()
+          ? 'directory'
+          : 'non-file';
+    const parts = [
+      `type=${type}`,
+      `mode=${stat.mode}`,
+      `size=${stat.size}`
+    ];
+    if (stat.isSymbolicLink()) parts.push(`target=${singleLineSummary(fs.readlinkSync(absPath))}`);
+    if (stat.isFile()) {
+      parts.push(options.fullFileHash ? `sha256=${fileSha256(absPath)}` : boundedFileFingerprint(absPath, stat));
+    }
+    return parts.join(';');
+  } catch (error) {
+    return `unavailable:${singleLineSummary(redactForLog(error instanceof Error ? error.message : String(error)))}`;
+  }
+}
+
+function changeFingerprintExcludingContext(root, contextDir) {
+  const context = normalizedContextDir(contextDir);
+  const isContextPath = contextPathPredicate(contextDir);
+  const status = runGitText(root, ['status', '--porcelain=v1', '--untracked-files=all'], 25_000_000);
+  const stagedRaw = runGitText(root, ['diff', '--cached', '--raw', '-z', '--no-ext-diff', '--', '.', `:(exclude)${context}`], 25_000_000);
+  const hash = createHash('sha256');
+  hash.update(`staged-raw\0${stagedRaw}\0`);
+  for (const line of status.split(/\r?\n/).filter(Boolean).sort()) {
+    const paths = statusLinePaths(line);
+    if (paths.length && paths.every(isContextPath)) continue;
+    hash.update(`status\0${line}\0`);
+    const fullFileHash = !line.startsWith('?? ');
+    for (const filePath of paths) {
+      hash.update(`path\0${filePath}\0${pathStateForFingerprint(root, filePath, { fullFileHash })}\0`);
+    }
+  }
+  return hash.digest('hex');
+}
+
+function readGitDiffExcludingContext(root, contextDir, maxBytes) {
+  const context = normalizedContextDir(contextDir);
+  try {
+    const staged = runGitText(root, ['diff', '--cached', '--no-ext-diff', '--', '.', `:(exclude)${context}`], maxBytes);
+    const unstaged = runGitText(root, ['diff', '--no-ext-diff', '--', '.', `:(exclude)${context}`], maxBytes);
+    const untracked = untrackedFilesSummary(root, contextDir, maxBytes);
+    const sections = [];
+    if (staged.trim()) sections.push(`# Staged diff\n\n${staged}`);
+    if (unstaged.trim()) sections.push(`# Unstaged diff\n\n${unstaged}`);
+    if (untracked.trim()) sections.push(`# Untracked files\n\n${untracked}`);
+    if (!sections.length) return '';
+    return trimBytes(sections.join('\n\n'), maxBytes).text;
+  } catch (error) {
+    return `# git changes unavailable\n\n${error instanceof Error ? error.message : String(error)}\n`;
+  }
+}
+
+function writeLoopTestOutput(paths, result, commandText) {
+  fs.mkdirSync(paths.bridgeDir, { recursive: true, mode: 0o700 });
+  const content = [
+    '# Loop Test Output',
+    '',
+    `Updated: ${new Date().toISOString()}`,
+    `Command: ${commandText}`,
+    `Exit code: ${result.exitCode ?? 'null'}`,
+    result.signal ? `Signal: ${result.signal}` : '',
+    `Timed out: ${result.timedOut ? 'yes' : 'no'}`,
+    `Duration: ${result.durationMs} ms`,
+    '',
+    codeBlock('Stdout excerpt', result.stdout),
+    codeBlock('Stderr excerpt', result.stderr)
+  ].filter(Boolean).join('\n');
+  fs.writeFileSync(paths.testsPath, content, { mode: 0o600 });
+}
+
+function explicitReviewVerdict(text) {
+  for (const rawLine of String(text || '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const assignment = line.match(/^CODEXPRO_REVIEW\s*=\s*(PASS|FAIL)\b/i);
+    if (assignment) return assignment[1].toUpperCase();
+  }
+  return '';
+}
+
+function writeLoopReviewOutput(paths, result, commandText, verdict, nextPlanChanged) {
+  fs.mkdirSync(paths.bridgeDir, { recursive: true, mode: 0o700 });
+  const content = [
+    '# Loop Review',
+    '',
+    `Updated: ${new Date().toISOString()}`,
+    `Command: ${commandText}`,
+    `Verdict: ${verdict || 'unknown'}`,
+    `Next plan changed: ${nextPlanChanged ? 'yes' : 'no'}`,
+    `Exit code: ${result.exitCode ?? 'null'}`,
+    result.signal ? `Signal: ${result.signal}` : '',
+    `Timed out: ${result.timedOut ? 'yes' : 'no'}`,
+    `Duration: ${result.durationMs} ms`,
+    '',
+    codeBlock('Stdout excerpt', result.stdout),
+    codeBlock('Stderr excerpt', result.stderr)
+  ].filter(Boolean).join('\n');
+  fs.writeFileSync(paths.reviewPath, content, { mode: 0o600 });
+}
+
+async function runLoopCommand(commandInfo, root, timeoutMs, maxOutputBytes, label) {
+  if (!commandAvailableFromRoot(commandInfo.command, root)) {
+    throw new Error(`${label} command was not found: ${commandInfo.command}`);
+  }
+  statusLine('wait', `Running ${label.toLowerCase()}: ${commandDisplay(commandInfo)}`);
+  return runProcessCaptured(commandInfo.command, commandInfo.args, {
+    cwd: root,
+    timeoutMs,
+    maxOutputBytes
+  });
+}
+
+function assertLoopCommandAvailable(commandInfo, root, label) {
+  if (!commandAvailableFromRoot(commandInfo.command, root)) {
+    throw new Error(`${label} command was not found before starting loop-handoff: ${commandInfo.command}`);
+  }
+}
+
+function preflightLoopCommands(request, reviewCommand, testCommand) {
+  assertLoopCommandAvailable(request.commandInfo, request.root, 'Executor');
+  assertLoopCommandAvailable(reviewCommand, request.root, 'Review');
+  if (testCommand) assertLoopCommandAvailable(testCommand, request.root, 'Test');
+}
+
+async function confirmLoopHandoff(args, root) {
+  if (args.yes || args.noConfirm || args.dryRun) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error('Use --yes to start loop-handoff in non-interactive shells, or use --dry-run to preview.');
+  }
+  printBox('Confirm handoff loop', [
+    labelValue('Workspace', root),
+    labelValue('Agent', args.agent ?? 'opencode'),
+    ...(args.model ? [labelValue('Model', args.model)] : []),
+    labelValue('Max iters', args.maxIters ?? '3'),
+    labelValue('Reviewer', args.reviewCommand ?? ''),
+    'This runs local executor and reviewer commands in a bounded loop. It does not automate ChatGPT or any browser session.'
+  ]);
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await ask(rl, 'Start local execute/review loop?', 'no');
+    return ['y', 'yes'].includes(answer.trim().toLowerCase());
+  } finally {
+    rl.close();
+  }
+}
+
+async function confirmLoopContinuation(args, root, iteration, planPath) {
+  if (!args.requireHumanConfirmation) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error('--require-human-confirmation needs an interactive terminal before running follow-up plans.');
+  }
+  printBox('Confirm follow-up plan', [
+    labelValue('Workspace', root),
+    labelValue('Iteration', String(iteration)),
+    labelValue('Plan', path.relative(root, planPath)),
+    'The reviewer wrote or kept a follow-up plan. Review it before continuing.'
+  ]);
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await ask(rl, 'Run the next local executor iteration?', 'no');
+    return ['y', 'yes'].includes(answer.trim().toLowerCase());
+  } finally {
+    rl.close();
+  }
+}
+
+function printLoopDryRun(request, reviewCommand, testCommand, maxIters) {
+  printBox('CodexPro loop-handoff dry run', [
+    labelValue('Workspace', request.root),
+    labelValue('Plan', path.relative(request.root, request.planPath)),
+    labelValue('Agent', request.commandInfo.agent),
+    ...(request.commandInfo.model ? [labelValue('Model', request.commandInfo.model)] : []),
+    labelValue('Max iters', String(maxIters)),
+    labelValue('Executor', request.commandText),
+    ...(testCommand ? [labelValue('Tests', commandDisplay(testCommand))] : []),
+    labelValue('Reviewer', commandDisplay(reviewCommand)),
+    'No command was executed and no .ai-bridge result files were changed.'
+  ]);
+}
+
+function writeLoopState(paths, state) {
+  fs.mkdirSync(paths.bridgeDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(paths.statePath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+}
+
+async function runLoopHandoff(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    usage();
+    return;
+  }
+
+  const root = realDir(args.root ?? process.env.CODEXPRO_ROOT ?? process.cwd());
+  const contextDir = contextDirFromArgs(args);
+  const paths = loopArtifactPaths(root, contextDir);
+  const maxIters = numberOption(args.maxIters ?? args.maxIterations, 3, 1, 25);
+  const maxReadBytes = handoffMaxReadBytes();
+  const maxOutputBytes = numberOption(args.maxOutputBytes ?? process.env.CODEXPRO_MAX_OUTPUT_BYTES, 120_000, 4_000, 2_000_000);
+  const reviewTimeoutMs = numberOption(args.reviewTimeoutMs, 600_000, 1_000, 24 * 60 * 60_000);
+  const testTimeoutMs = numberOption(args.testTimeoutMs, 600_000, 1_000, 24 * 60 * 60_000);
+
+  if (args.requireCleanGitStart) assertCleanGitStart(root, contextDir);
+
+  let request = loadHandoffExecution({ ...args, root, contextDir });
+  const reviewCommand = buildReviewerCommand(args, root, contextDir, 1, paths);
+  const testCommand = buildTestCommand(args, root, contextDir, 1, paths);
+
+  if (args.dryRun) {
+    printLoopDryRun(request, reviewCommand, testCommand, maxIters);
+    return;
+  }
+
+  preflightLoopCommands(request, reviewCommand, testCommand);
+
+  const approved = await confirmLoopHandoff(args, root);
+  if (!approved) {
+    statusLine('warn', 'Loop cancelled.');
+    return;
+  }
+
+  printBox('CodexPro loop-handoff', [
+    labelValue('Workspace', root),
+    labelValue('Plan', path.relative(root, paths.planPath)),
+    labelValue('Agent', request.commandInfo.agent),
+    ...(request.commandInfo.model ? [labelValue('Model', request.commandInfo.model)] : []),
+    labelValue('Max iters', String(maxIters)),
+    labelValue('Reviewer', commandDisplay(reviewCommand)),
+    ...(testCommand ? [labelValue('Tests', commandDisplay(testCommand))] : []),
+    'Mode: local execute/review loop. No ChatGPT or browser session is automated.'
+  ]);
+
+  let previousChangeFingerprint = '';
+  let finalVerdict = 'FAIL';
+  let stopReason = 'max_iters';
+
+  for (let iteration = 1; iteration <= maxIters; iteration += 1) {
+    if (iteration > 1) {
+      const continueLoop = await confirmLoopContinuation(args, root, iteration, paths.planPath);
+      if (!continueLoop) {
+        stopReason = 'human_cancelled';
+        break;
+      }
+    }
+
+    request = loadHandoffExecution({ ...args, root, contextDir });
+    const currentPlanHash = planHash(request.planText);
+    if (isScaffoldedHandoffPlan(request.planText)) {
+      stopReason = 'scaffolded_plan';
+      statusLine('warn', 'Stopping because current-plan.md is still the empty scaffold.');
+      break;
+    }
+
+    appendBridgeLog(root, contextDir, {
+      event: 'loop_handoff_iteration_started',
+      iteration,
+      plan_hash: currentPlanHash,
+      agent: request.commandInfo.agent,
+      model: request.commandInfo.model || undefined
+    });
+
+    const beforeExecutionFingerprint = changeFingerprintExcludingContext(root, contextDir);
+    const execution = await executeHandoffRequest(request, { ...args, yes: true }, { skipConfirmation: true });
+    const diffText = readGitDiffExcludingContext(root, contextDir, maxOutputBytes);
+    fs.writeFileSync(paths.diffPath, diffText || '', { mode: 0o600 });
+    const currentChangeFingerprint = changeFingerprintExcludingContext(root, contextDir);
+    const changedThisIteration = currentChangeFingerprint !== beforeExecutionFingerprint;
+
+    if (args.stopIfNoFilesChanged && !changedThisIteration) {
+      finalVerdict = 'FAIL';
+      stopReason = 'no_files_changed';
+      statusLine('warn', 'Stopping because the executor produced no new git changes.');
+      break;
+    }
+    if (args.stopIfSameDiff && previousChangeFingerprint && currentChangeFingerprint === previousChangeFingerprint) {
+      finalVerdict = 'FAIL';
+      stopReason = 'same_diff';
+      statusLine('warn', 'Stopping because the executor repeated the previous diff.');
+      break;
+    }
+    previousChangeFingerprint = currentChangeFingerprint;
+
+    const iterationTestCommand = buildTestCommand(args, root, contextDir, iteration, paths);
+    let testResult = null;
+    if (iterationTestCommand) {
+      testResult = await runLoopCommand(iterationTestCommand, root, testTimeoutMs, maxOutputBytes, 'Test');
+      writeLoopTestOutput(paths, testResult, commandDisplay(iterationTestCommand));
+      statusLine(testResult.exitCode === 0 ? 'ok' : 'warn', `Tests exited with code ${testResult.exitCode ?? 'null'}${testResult.signal ? ` signal=${testResult.signal}` : ''}`);
+    }
+
+    const iterationReviewCommand = buildReviewerCommand(args, root, contextDir, iteration, paths);
+    const beforeReviewPlanExists = fs.existsSync(paths.planPath);
+    const beforeReviewPlan = beforeReviewPlanExists ? readTextFileBounded(paths.planPath, maxReadBytes) : '';
+    const reviewResult = await runLoopCommand(iterationReviewCommand, root, reviewTimeoutMs, maxOutputBytes, 'Review');
+    const afterReviewPlanExists = fs.existsSync(paths.planPath);
+    const afterReviewPlan = afterReviewPlanExists ? readTextFileBounded(paths.planPath, maxReadBytes) : '';
+    const planDeletedByReview = beforeReviewPlanExists && !afterReviewPlanExists;
+    const nextPlanChanged = planDeletedByReview || (afterReviewPlanExists && planHash(afterReviewPlan) !== planHash(beforeReviewPlan));
+    const hasUsableFollowupPlan = afterReviewPlanExists && afterReviewPlan.trim() && !isScaffoldedHandoffPlan(afterReviewPlan);
+    let verdict = explicitReviewVerdict(`${reviewResult.stdout}\n${reviewResult.stderr}`);
+    if (!verdict && args.allowImplicitReviewVerdict && nextPlanChanged && reviewResult.exitCode === 0) verdict = 'FAIL';
+    if (!verdict && args.allowImplicitReviewVerdict && afterReviewPlanExists && reviewResult.exitCode === 0 && execution.result?.exitCode === 0 && (!testResult || testResult.exitCode === 0)) verdict = 'PASS';
+    writeLoopReviewOutput(paths, reviewResult, commandDisplay(iterationReviewCommand), verdict, nextPlanChanged);
+    let acceptedVerdict = verdict;
+    let rejectedPassReason = '';
+    if (verdict === 'PASS' && reviewResult.exitCode !== 0) {
+      acceptedVerdict = 'FAIL';
+      rejectedPassReason = 'reviewer_failed';
+    } else if (verdict === 'PASS' && !args.allowReviewPassOnFailure && execution.result?.exitCode !== 0) {
+      acceptedVerdict = 'FAIL';
+      rejectedPassReason = 'executor_failed';
+    } else if (verdict === 'PASS' && !args.allowReviewPassOnFailure && testResult && testResult.exitCode !== 0) {
+      acceptedVerdict = 'FAIL';
+      rejectedPassReason = 'tests_failed';
+    }
+
+    appendBridgeLog(root, contextDir, {
+      event: 'loop_handoff_iteration_finished',
+      iteration,
+      plan_hash: currentPlanHash,
+      agent: request.commandInfo.agent,
+      model: request.commandInfo.model || undefined,
+      executor_exit_code: execution.result?.exitCode ?? null,
+      test_exit_code: testResult?.exitCode ?? null,
+      reviewer_exit_code: reviewResult.exitCode,
+      reviewer_verdict: verdict,
+      verdict: acceptedVerdict,
+      rejected_pass_reason: rejectedPassReason || undefined,
+      next_plan_changed: nextPlanChanged,
+      followup_plan_exists: afterReviewPlanExists,
+      has_usable_followup_plan: Boolean(hasUsableFollowupPlan),
+      changed_this_iteration: changedThisIteration,
+      status_path: path.posix.join(contextDir, 'agent-status.md'),
+      diff_path: path.posix.join(contextDir, 'implementation-diff.patch'),
+      tests_path: iterationTestCommand ? path.posix.join(contextDir, 'loop-tests.txt') : undefined,
+      review_path: path.posix.join(contextDir, 'loop-review.md')
+    });
+    writeLoopState(paths, {
+      updatedAt: new Date().toISOString(),
+      iteration,
+      maxIters,
+      reviewerVerdict: verdict,
+      verdict: acceptedVerdict,
+      rejectedPassReason: rejectedPassReason || undefined,
+      planHash: currentPlanHash,
+      nextPlanChanged,
+      followupPlanExists: afterReviewPlanExists,
+      hasUsableFollowupPlan: Boolean(hasUsableFollowupPlan),
+      changedThisIteration,
+      executorExitCode: execution.result?.exitCode ?? null,
+      reviewerExitCode: reviewResult.exitCode
+    });
+
+    if (acceptedVerdict === 'PASS') {
+      finalVerdict = 'PASS';
+      stopReason = 'pass';
+      statusLine('ok', `Reviewer passed on iteration ${iteration}.`);
+      break;
+    }
+
+    if (rejectedPassReason) {
+      if (rejectedPassReason === 'reviewer_failed') {
+        finalVerdict = 'FAIL';
+        stopReason = 'reviewer_error';
+        statusLine('warn', `Reviewer returned PASS, but reviewer process exited with code ${reviewResult.exitCode ?? 'null'}.`);
+        break;
+      }
+      if (rejectedPassReason === 'executor_failed') {
+        finalVerdict = 'FAIL';
+        stopReason = 'executor_failed';
+        statusLine('warn', `Reviewer returned PASS, but executor exited with code ${execution.result?.exitCode ?? 'null'}.`);
+        break;
+      }
+      finalVerdict = 'FAIL';
+      stopReason = 'tests_failed';
+      statusLine('warn', `Reviewer returned PASS, but tests exited with code ${testResult?.exitCode ?? 'null'}.`);
+      break;
+    }
+
+    if (acceptedVerdict !== 'FAIL') {
+      finalVerdict = 'FAIL';
+      stopReason = reviewResult.exitCode === 0 ? 'unknown_verdict' : 'reviewer_error';
+      statusLine('warn', `Stopping because reviewer did not return a usable verdict. Exit code: ${reviewResult.exitCode ?? 'null'}`);
+      break;
+    }
+
+    if (reviewResult.exitCode !== 0) {
+      finalVerdict = 'FAIL';
+      stopReason = 'reviewer_error';
+      statusLine('warn', `Stopping because reviewer exited with code ${reviewResult.exitCode ?? 'null'}.`);
+      break;
+    }
+
+    if (!nextPlanChanged || !hasUsableFollowupPlan) {
+      finalVerdict = 'FAIL';
+      stopReason = 'no_followup_plan';
+      statusLine('warn', 'Reviewer returned FAIL but did not update current-plan.md.');
+      break;
+    }
+
+    statusLine('wait', `Reviewer requested another iteration (${iteration}/${maxIters}).`);
+  }
+
+  appendBridgeLog(root, contextDir, {
+    event: 'loop_handoff_finished',
+    verdict: finalVerdict,
+    stop_reason: stopReason
+  });
+  statusLine(finalVerdict === 'PASS' ? 'ok' : 'warn', `Loop finished: ${finalVerdict} (${stopReason}).`);
+  console.log(`Status: ${path.relative(root, paths.statusPath)}`);
+  console.log(`Diff:   ${path.relative(root, paths.diffPath)}`);
+  console.log(`Review: ${path.relative(root, paths.reviewPath)}`);
+  console.log(`Log:    ${path.relative(root, paths.logPath)}`);
+  if (finalVerdict !== 'PASS') process.exitCode = 1;
 }
 
 function createConnectorDetails(endpoint, token, localBase = '') {
@@ -2472,6 +3134,10 @@ async function main() {
   }
   if (subcommand === 'watch-handoff' || subcommand === 'watch') {
     await runWatchHandoff(argv.slice(1));
+    return;
+  }
+  if (subcommand === 'loop-handoff' || subcommand === 'loop') {
+    await runLoopHandoff(argv.slice(1));
     return;
   }
   if (subcommand === 'pro-bundle' || subcommand === 'bundle') {

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -165,4 +165,586 @@ if (!watchState.includes('lastPlanHash') || !watchLog.includes('"event":"watch_h
   throw new Error(`watch did not write state/log\nstate:\n${watchState}\nlog:\n${watchLog}`);
 }
 
-console.log('✓ execute-handoff and watch-handoff smoke test passed');
+const loopRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-handoff-'));
+await fs.mkdir(path.join(loopRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(loopRoot, '.ai-bridge', 'current-plan.md'), '# Loop plan 1\n\nAppend loop first marker.\n', 'utf8');
+await fs.writeFile(path.join(loopRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(loopRoot, 'loop-agent.mjs'), `
+import fs from 'node:fs';
+
+const taskIndex = process.argv.indexOf('--task-file');
+if (taskIndex < 0) throw new Error('missing --task-file');
+const plan = fs.readFileSync(process.argv[taskIndex + 1], 'utf8');
+const marker = plan.includes('Loop fix plan') ? 'fix' : 'first';
+fs.appendFileSync('app.txt', \`loop \${marker}\\n\`);
+console.log(\`loop agent completed \${marker}\`);
+`, 'utf8');
+await fs.writeFile(path.join(loopRoot, 'loop-reviewer.mjs'), `
+import fs from 'node:fs';
+
+const planIndex = process.argv.indexOf('--plan-file');
+const statusIndex = process.argv.indexOf('--status');
+const diffIndex = process.argv.indexOf('--diff');
+if (planIndex < 0 || statusIndex < 0 || diffIndex < 0) throw new Error('missing review artifacts');
+const planPath = process.argv[planIndex + 1];
+const plan = fs.readFileSync(planPath, 'utf8');
+fs.readFileSync(process.argv[statusIndex + 1], 'utf8');
+fs.readFileSync(process.argv[diffIndex + 1], 'utf8');
+if (!plan.includes('Loop fix plan')) {
+  fs.writeFileSync(planPath, '# Loop fix plan\\n\\nAppend loop fix marker.\\n');
+  console.log('CODEXPRO_REVIEW=FAIL');
+} else {
+  console.log('CODEXPRO_REVIEW=PASS');
+}
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: loopRoot, encoding: 'utf8' }), 'loop git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: loopRoot, encoding: 'utf8' }), 'loop git add');
+
+const loopRun = run([
+  'loop-handoff',
+  '--root',
+  loopRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} loop-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} loop-reviewer.mjs --status {{status_file}} --diff {{diff_file}} --log {{log_file}} --plan-file {{plan_file}}`,
+  '--max-iters',
+  '3',
+  '--stop-if-no-files-changed',
+  '--stop-if-same-diff',
+  '--yes'
+]);
+requireSuccess(loopRun, 'loop-handoff custom');
+
+const loopApp = await fs.readFile(path.join(loopRoot, 'app.txt'), 'utf8');
+const loopReview = await fs.readFile(path.join(loopRoot, '.ai-bridge', 'loop-review.md'), 'utf8');
+const loopState = await fs.readFile(path.join(loopRoot, '.ai-bridge', 'loop-handoff-state.json'), 'utf8');
+const loopLog = await fs.readFile(path.join(loopRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+
+if (!loopApp.includes('loop first') || !loopApp.includes('loop fix')) {
+  throw new Error(`loop did not execute first and fix iterations\n${loopApp}`);
+}
+if (!loopReview.includes('Verdict: PASS')) {
+  throw new Error(`loop review did not record PASS\n${loopReview}`);
+}
+if (!loopState.includes('"iteration": 2') || !loopLog.includes('"event":"loop_handoff_iteration_started"') || !loopLog.includes('"event":"loop_handoff_finished"')) {
+  throw new Error(`loop did not write state/log\nstate:\n${loopState}\nlog:\n${loopLog}`);
+}
+
+const failedExecutorRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-failed-executor-'));
+await fs.mkdir(path.join(failedExecutorRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(failedExecutorRoot, '.ai-bridge', 'current-plan.md'), '# Failed executor plan\n\nAppend marker and fail.\n', 'utf8');
+await fs.writeFile(path.join(failedExecutorRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(failedExecutorRoot, 'fail-agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'changed before failure\\n');
+console.log('agent changed file then failed');
+process.exit(2);
+`, 'utf8');
+await fs.writeFile(path.join(failedExecutorRoot, 'pass-reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: failedExecutorRoot, encoding: 'utf8' }), 'failed executor git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: failedExecutorRoot, encoding: 'utf8' }), 'failed executor git add');
+
+const failedExecutorRun = run([
+  'loop-handoff',
+  '--root',
+  failedExecutorRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} fail-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} pass-reviewer.mjs --plan-file {{plan_file}}`,
+  '--yes'
+]);
+if (failedExecutorRun.status === 0) {
+  throw new Error(`loop accepted reviewer PASS after failed executor\nstdout:\n${failedExecutorRun.stdout}\nstderr:\n${failedExecutorRun.stderr}`);
+}
+
+const failedExecutorState = await fs.readFile(path.join(failedExecutorRoot, '.ai-bridge', 'loop-handoff-state.json'), 'utf8');
+const failedExecutorLog = await fs.readFile(path.join(failedExecutorRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!failedExecutorState.includes('"verdict": "FAIL"') || !failedExecutorState.includes('"rejectedPassReason": "executor_failed"') || !failedExecutorLog.includes('"stop_reason":"executor_failed"')) {
+  throw new Error(`loop did not reject reviewer PASS after failed executor\nstate:\n${failedExecutorState}\nlog:\n${failedExecutorLog}`);
+}
+
+const failedReviewerRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-failed-reviewer-'));
+await fs.mkdir(path.join(failedReviewerRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(failedReviewerRoot, '.ai-bridge', 'current-plan.md'), '# Failed reviewer plan\n\nAppend marker.\n', 'utf8');
+await fs.writeFile(path.join(failedReviewerRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(failedReviewerRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'changed before failed reviewer\\n');
+console.log('agent changed file');
+`, 'utf8');
+await fs.writeFile(path.join(failedReviewerRoot, 'failed-reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+process.exit(3);
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: failedReviewerRoot, encoding: 'utf8' }), 'failed reviewer git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: failedReviewerRoot, encoding: 'utf8' }), 'failed reviewer git add');
+
+const failedReviewerRun = run([
+  'loop-handoff',
+  '--root',
+  failedReviewerRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} failed-reviewer.mjs --plan-file {{plan_file}}`,
+  '--yes'
+]);
+if (failedReviewerRun.status === 0) {
+  throw new Error(`loop accepted reviewer PASS after failed reviewer process\nstdout:\n${failedReviewerRun.stdout}\nstderr:\n${failedReviewerRun.stderr}`);
+}
+const failedReviewerState = await fs.readFile(path.join(failedReviewerRoot, '.ai-bridge', 'loop-handoff-state.json'), 'utf8');
+const failedReviewerLog = await fs.readFile(path.join(failedReviewerRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!failedReviewerState.includes('"rejectedPassReason": "reviewer_failed"') || !failedReviewerLog.includes('"stop_reason":"reviewer_error"')) {
+  throw new Error(`loop did not reject reviewer PASS after failed reviewer process\nstate:\n${failedReviewerState}\nlog:\n${failedReviewerLog}`);
+}
+
+const barePassRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-bare-pass-'));
+await fs.mkdir(path.join(barePassRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(barePassRoot, '.ai-bridge', 'current-plan.md'), '# Bare pass plan\n\nAppend marker.\n', 'utf8');
+await fs.writeFile(path.join(barePassRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(barePassRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'changed before bare pass\\n');
+`, 'utf8');
+await fs.writeFile(path.join(barePassRoot, 'bare-reviewer.mjs'), `
+console.log('PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: barePassRoot, encoding: 'utf8' }), 'bare pass git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: barePassRoot, encoding: 'utf8' }), 'bare pass git add');
+
+const barePassRun = run([
+  'loop-handoff',
+  '--root',
+  barePassRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} bare-reviewer.mjs --plan-file {{plan_file}}`,
+  '--yes'
+]);
+if (barePassRun.status === 0) {
+  throw new Error(`loop accepted bare PASS reviewer output\nstdout:\n${barePassRun.stdout}\nstderr:\n${barePassRun.stderr}`);
+}
+const barePassLog = await fs.readFile(path.join(barePassRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!barePassLog.includes('"stop_reason":"unknown_verdict"')) {
+  throw new Error(`loop did not reject bare PASS as unknown verdict\nlog:\n${barePassLog}`);
+}
+
+const stagedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-staged-change-'));
+await fs.mkdir(path.join(stagedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(stagedRoot, '.ai-bridge', 'current-plan.md'), '# Staged plan\n\nStage a change.\n', 'utf8');
+await fs.writeFile(path.join(stagedRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(stagedRoot, 'stage-agent.mjs'), `
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+fs.appendFileSync('app.txt', 'staged change\\n');
+const result = spawnSync('git', ['add', 'app.txt'], { stdio: 'inherit' });
+process.exit(result.status ?? 1);
+`, 'utf8');
+await fs.writeFile(path.join(stagedRoot, 'reviewer.mjs'), `
+import fs from 'node:fs';
+const diffPath = process.argv[process.argv.indexOf('--diff') + 1];
+const diff = fs.readFileSync(diffPath, 'utf8');
+if (!diff.includes('# Staged diff') || !diff.includes('staged change')) process.exit(4);
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: stagedRoot, encoding: 'utf8' }), 'staged git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: stagedRoot, encoding: 'utf8' }), 'staged git add');
+
+const stagedRun = run([
+  'loop-handoff',
+  '--root',
+  stagedRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} stage-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --diff {{diff_file}} --plan-file {{plan_file}}`,
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+requireSuccess(stagedRun, 'loop-handoff staged-only change');
+
+const untrackedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-untracked-change-'));
+await fs.mkdir(path.join(untrackedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(untrackedRoot, '.ai-bridge', 'current-plan.md'), '# Untracked plan\n\nCreate a new file.\n', 'utf8');
+await fs.writeFile(path.join(untrackedRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(untrackedRoot, 'untracked-agent.mjs'), `
+import fs from 'node:fs';
+fs.writeFileSync('new-feature.txt', 'new feature\\n');
+`, 'utf8');
+await fs.writeFile(path.join(untrackedRoot, 'reviewer.mjs'), `
+import fs from 'node:fs';
+const diffPath = process.argv[process.argv.indexOf('--diff') + 1];
+const diff = fs.readFileSync(diffPath, 'utf8');
+if (!diff.includes('# Untracked files') || !diff.includes('new-feature.txt')) process.exit(5);
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: untrackedRoot, encoding: 'utf8' }), 'untracked git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: untrackedRoot, encoding: 'utf8' }), 'untracked git add');
+
+const untrackedRun = run([
+  'loop-handoff',
+  '--root',
+  untrackedRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} untracked-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --diff {{diff_file}} --plan-file {{plan_file}}`,
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+requireSuccess(untrackedRun, 'loop-handoff untracked file change');
+
+const boundedUntrackedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-bounded-untracked-'));
+await fs.mkdir(path.join(boundedUntrackedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(boundedUntrackedRoot, '.ai-bridge', 'current-plan.md'), '# Bounded untracked plan\n\nCreate symlink and large untracked files.\n', 'utf8');
+await fs.writeFile(path.join(boundedUntrackedRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(boundedUntrackedRoot, 'bounded-agent.mjs'), `
+import fs from 'node:fs';
+fs.writeFileSync('large-artifact.bin', Buffer.alloc(96 * 1024, 'a'));
+fs.symlinkSync('app.txt', 'app-link.txt');
+`, 'utf8');
+await fs.writeFile(path.join(boundedUntrackedRoot, 'reviewer.mjs'), `
+import fs from 'node:fs';
+const diffPath = process.argv[process.argv.indexOf('--diff') + 1];
+const diff = fs.readFileSync(diffPath, 'utf8');
+const linkLine = diff.split(/\\r?\\n/).find((line) => line.includes('app-link.txt'));
+if (!linkLine || !linkLine.includes('(symlink, target=app.txt') || linkLine.includes('sha256')) process.exit(6);
+if (!diff.includes('large-artifact.bin') || !diff.includes('sha256_first_65536=') || !diff.includes('fingerprint_truncated=true')) process.exit(7);
+if (Buffer.byteLength(diff, 'utf8') > 4500) process.exit(8);
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: boundedUntrackedRoot, encoding: 'utf8' }), 'bounded untracked git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: boundedUntrackedRoot, encoding: 'utf8' }), 'bounded untracked git add');
+
+const boundedUntrackedRun = run([
+  'loop-handoff',
+  '--root',
+  boundedUntrackedRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} bounded-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --diff {{diff_file}} --plan-file {{plan_file}}`,
+  '--max-output-bytes',
+  '4000',
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+requireSuccess(boundedUntrackedRun, 'loop-handoff bounded untracked fingerprints');
+
+const dirtyBaselineRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-dirty-baseline-'));
+await fs.mkdir(path.join(dirtyBaselineRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(dirtyBaselineRoot, '.ai-bridge', 'current-plan.md'), '# Dirty baseline plan\n\nDo nothing.\n', 'utf8');
+await fs.writeFile(path.join(dirtyBaselineRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(dirtyBaselineRoot, 'noop-agent.mjs'), `
+console.log('noop agent');
+`, 'utf8');
+await fs.writeFile(path.join(dirtyBaselineRoot, 'reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: dirtyBaselineRoot, encoding: 'utf8' }), 'dirty baseline git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: dirtyBaselineRoot, encoding: 'utf8' }), 'dirty baseline git add');
+await fs.appendFile(path.join(dirtyBaselineRoot, 'app.txt'), 'preexisting dirty change\\n', 'utf8');
+
+const dirtyBaselineRun = run([
+  'loop-handoff',
+  '--root',
+  dirtyBaselineRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} noop-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+if (dirtyBaselineRun.status === 0) {
+  throw new Error(`loop accepted preexisting dirty baseline as executor changes\nstdout:\n${dirtyBaselineRun.stdout}\nstderr:\n${dirtyBaselineRun.stderr}`);
+}
+const dirtyBaselineLog = await fs.readFile(path.join(dirtyBaselineRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!dirtyBaselineLog.includes('"stop_reason":"no_files_changed"')) {
+  throw new Error(`loop did not stop no-op executor against dirty baseline\nlog:\n${dirtyBaselineLog}`);
+}
+
+const repeatedSameRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-repeated-same-'));
+await fs.mkdir(path.join(repeatedSameRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(repeatedSameRoot, '.ai-bridge', 'current-plan.md'), '# Repeated same plan\n\nWrite final content.\n', 'utf8');
+await fs.writeFile(path.join(repeatedSameRoot, 'app.txt'), 'base\n', 'utf8');
+await fs.writeFile(path.join(repeatedSameRoot, 'same-agent.mjs'), `
+import fs from 'node:fs';
+const markerPath = '.ai-bridge/rewrite-count.txt';
+const count = fs.existsSync(markerPath) ? Number(fs.readFileSync(markerPath, 'utf8')) : 0;
+fs.writeFileSync('app.txt', 'same final content\\n');
+const stamp = new Date(1700000000000 + (count + 1) * 1000);
+fs.utimesSync('app.txt', stamp, stamp);
+fs.writeFileSync(markerPath, String(count + 1));
+`, 'utf8');
+await fs.writeFile(path.join(repeatedSameRoot, 'reviewer.mjs'), `
+import fs from 'node:fs';
+const planPath = process.argv[process.argv.indexOf('--plan-file') + 1];
+const plan = fs.readFileSync(planPath, 'utf8');
+if (plan.includes('Repeated same plan')) {
+  fs.writeFileSync(planPath, '# Repeated same follow-up\\n\\nRewrite identical content.\\n');
+  console.log('CODEXPRO_REVIEW=FAIL');
+} else {
+  console.log('CODEXPRO_REVIEW=PASS');
+}
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: repeatedSameRoot, encoding: 'utf8' }), 'repeated same git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: repeatedSameRoot, encoding: 'utf8' }), 'repeated same git add');
+
+const repeatedSameRun = run([
+  'loop-handoff',
+  '--root',
+  repeatedSameRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} same-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--max-iters',
+  '3',
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+if (repeatedSameRun.status === 0) {
+  throw new Error(`loop treated repeated identical content writes as new changes\nstdout:\n${repeatedSameRun.stdout}\nstderr:\n${repeatedSameRun.stderr}`);
+}
+const repeatedSameLog = await fs.readFile(path.join(repeatedSameRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!repeatedSameLog.includes('"stop_reason":"no_files_changed"')) {
+  throw new Error(`loop did not stop on repeated identical content write\nlog:\n${repeatedSameLog}`);
+}
+
+const largeDirtyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-large-dirty-'));
+await fs.mkdir(path.join(largeDirtyRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(largeDirtyRoot, '.ai-bridge', 'current-plan.md'), '# Large dirty plan\n\nAppend to later file.\n', 'utf8');
+await fs.writeFile(path.join(largeDirtyRoot, 'aaa-large.txt'), 'base large\n', 'utf8');
+await fs.writeFile(path.join(largeDirtyRoot, 'zzz-later.txt'), 'base later\n', 'utf8');
+await fs.writeFile(path.join(largeDirtyRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('zzz-later.txt', 'executor changed later file\\n');
+`, 'utf8');
+await fs.writeFile(path.join(largeDirtyRoot, 'reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: largeDirtyRoot, encoding: 'utf8' }), 'large dirty git init');
+requireSuccess(spawnSync('git', ['add', 'aaa-large.txt', 'zzz-later.txt'], { cwd: largeDirtyRoot, encoding: 'utf8' }), 'large dirty git add');
+requireSuccess(spawnSync('git', ['-c', 'user.email=codexpro@example.invalid', '-c', 'user.name=CodexPro Smoke', 'commit', '-m', 'init'], { cwd: largeDirtyRoot, encoding: 'utf8' }), 'large dirty git commit');
+await fs.writeFile(path.join(largeDirtyRoot, 'aaa-large.txt'), `${'preexisting dirty line\n'.repeat(9000)}`, 'utf8');
+
+const largeDirtyRun = run([
+  'loop-handoff',
+  '--root',
+  largeDirtyRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--max-output-bytes',
+  '4000',
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+requireSuccess(largeDirtyRun, 'loop-handoff large dirty baseline with later executor change');
+
+const unavailableDiffRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-unavailable-diff-'));
+await fs.mkdir(path.join(unavailableDiffRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(unavailableDiffRoot, '.ai-bridge', 'current-plan.md'), '# Unavailable diff plan\n\nWrite a very large tracked diff.\n', 'utf8');
+await fs.writeFile(path.join(unavailableDiffRoot, 'huge.txt'), 'base\n', 'utf8');
+await fs.writeFile(path.join(unavailableDiffRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.writeFileSync('huge.txt', \`changed\\n\${'x'.repeat(2_500_000)}\\n\`);
+`, 'utf8');
+await fs.writeFile(path.join(unavailableDiffRoot, 'reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: unavailableDiffRoot, encoding: 'utf8' }), 'unavailable diff git init');
+requireSuccess(spawnSync('git', ['add', 'huge.txt'], { cwd: unavailableDiffRoot, encoding: 'utf8' }), 'unavailable diff git add');
+
+const unavailableDiffRun = run([
+  'loop-handoff',
+  '--root',
+  unavailableDiffRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--max-output-bytes',
+  '4000',
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+requireSuccess(unavailableDiffRun, 'loop-handoff unavailable diff artifact with real executor change');
+const unavailableDiffArtifact = await fs.readFile(path.join(unavailableDiffRoot, '.ai-bridge', 'implementation-diff.patch'), 'utf8');
+if (!unavailableDiffArtifact.includes('# git changes unavailable')) {
+  throw new Error(`unavailable diff smoke did not exercise the bounded diff artifact path\n${unavailableDiffArtifact.slice(0, 1000)}`);
+}
+
+const largePlanRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-large-plan-'));
+const largePlanText = `# Large accepted plan\n\n${'Keep this valid plan above the output cap.\n'.repeat(160)}`;
+if (Buffer.byteLength(largePlanText, 'utf8') <= 4000) throw new Error('large plan smoke fixture is not larger than max-output cap');
+await fs.mkdir(path.join(largePlanRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(largePlanRoot, '.ai-bridge', 'current-plan.md'), largePlanText, 'utf8');
+await fs.writeFile(path.join(largePlanRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(largePlanRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'changed with large plan\\n');
+`, 'utf8');
+await fs.writeFile(path.join(largePlanRoot, 'reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: largePlanRoot, encoding: 'utf8' }), 'large plan git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: largePlanRoot, encoding: 'utf8' }), 'large plan git add');
+
+const largePlanRun = run([
+  'loop-handoff',
+  '--root',
+  largePlanRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--max-output-bytes',
+  '4000',
+  '--yes'
+]);
+requireSuccess(largePlanRun, 'loop-handoff valid plan larger than output cap');
+
+const stagedRenameRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-staged-rename-'));
+await fs.mkdir(path.join(stagedRenameRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(stagedRenameRoot, '.ai-bridge', 'current-plan.md'), '# Staged rename plan\n\nNo-op.\n', 'utf8');
+await fs.writeFile(path.join(stagedRenameRoot, 'src.txt'), 'tracked source\n', 'utf8');
+await fs.writeFile(path.join(stagedRenameRoot, 'noop-agent.mjs'), `
+console.log('noop agent');
+`, 'utf8');
+await fs.writeFile(path.join(stagedRenameRoot, 'reviewer.mjs'), `
+console.log('CODEXPRO_REVIEW=PASS');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: stagedRenameRoot, encoding: 'utf8' }), 'staged rename git init');
+requireSuccess(spawnSync('git', ['add', 'src.txt'], { cwd: stagedRenameRoot, encoding: 'utf8' }), 'staged rename git add');
+requireSuccess(spawnSync('git', ['-c', 'user.email=codexpro@example.invalid', '-c', 'user.name=CodexPro Smoke', 'commit', '-m', 'init'], { cwd: stagedRenameRoot, encoding: 'utf8' }), 'staged rename git commit');
+requireSuccess(spawnSync('git', ['mv', 'src.txt', '.ai-bridge/src.txt'], { cwd: stagedRenameRoot, encoding: 'utf8' }), 'staged rename git mv');
+
+const stagedRenameRun = run([
+  'loop-handoff',
+  '--root',
+  stagedRenameRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} noop-agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--require-clean-git-start',
+  '--yes'
+]);
+if (stagedRenameRun.status === 0) {
+  throw new Error(`loop accepted staged rename from outside into .ai-bridge as clean\nstdout:\n${stagedRenameRun.stdout}\nstderr:\n${stagedRenameRun.stderr}`);
+}
+if (!stagedRenameRun.stderr.includes('--require-clean-git-start refused') || !stagedRenameRun.stderr.includes('src.txt -> .ai-bridge/src.txt')) {
+  throw new Error(`loop did not report staged rename as non-handoff change\nstdout:\n${stagedRenameRun.stdout}\nstderr:\n${stagedRenameRun.stderr}`);
+}
+
+const deletedPlanRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-deleted-followup-'));
+await fs.mkdir(path.join(deletedPlanRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(deletedPlanRoot, '.ai-bridge', 'current-plan.md'), '# Delete follow-up plan\n\nAppend marker.\n', 'utf8');
+await fs.writeFile(path.join(deletedPlanRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(deletedPlanRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'changed before deleted follow-up\\n');
+`, 'utf8');
+await fs.writeFile(path.join(deletedPlanRoot, 'delete-plan-reviewer.mjs'), `
+import fs from 'node:fs';
+const planPath = process.argv[process.argv.indexOf('--plan-file') + 1];
+fs.rmSync(planPath);
+console.log('CODEXPRO_REVIEW=FAIL');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: deletedPlanRoot, encoding: 'utf8' }), 'deleted plan git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: deletedPlanRoot, encoding: 'utf8' }), 'deleted plan git add');
+
+const deletedPlanRun = run([
+  'loop-handoff',
+  '--root',
+  deletedPlanRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} delete-plan-reviewer.mjs --plan-file {{plan_file}}`,
+  '--yes'
+]);
+if (deletedPlanRun.status === 0) {
+  throw new Error(`loop accepted deleted follow-up plan after reviewer FAIL\nstdout:\n${deletedPlanRun.stdout}\nstderr:\n${deletedPlanRun.stderr}`);
+}
+const deletedPlanState = await fs.readFile(path.join(deletedPlanRoot, '.ai-bridge', 'loop-handoff-state.json'), 'utf8');
+const deletedPlanLog = await fs.readFile(path.join(deletedPlanRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!deletedPlanState.includes('"followupPlanExists": false') || !deletedPlanState.includes('"hasUsableFollowupPlan": false') || !deletedPlanLog.includes('"stop_reason":"no_followup_plan"')) {
+  throw new Error(`loop did not stop cleanly after deleted follow-up plan\nstate:\n${deletedPlanState}\nlog:\n${deletedPlanLog}`);
+}
+
+const implicitDeletedPlanRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-implicit-deleted-plan-'));
+await fs.mkdir(path.join(implicitDeletedPlanRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(implicitDeletedPlanRoot, '.ai-bridge', 'current-plan.md'), '# Implicit delete plan\n\nAppend marker.\n', 'utf8');
+await fs.writeFile(path.join(implicitDeletedPlanRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(implicitDeletedPlanRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'changed before implicit deleted plan\\n');
+`, 'utf8');
+await fs.writeFile(path.join(implicitDeletedPlanRoot, 'delete-plan-reviewer.mjs'), `
+import fs from 'node:fs';
+const planPath = process.argv[process.argv.indexOf('--plan-file') + 1];
+fs.rmSync(planPath);
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: implicitDeletedPlanRoot, encoding: 'utf8' }), 'implicit deleted plan git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: implicitDeletedPlanRoot, encoding: 'utf8' }), 'implicit deleted plan git add');
+
+const implicitDeletedPlanRun = run([
+  'loop-handoff',
+  '--root',
+  implicitDeletedPlanRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} delete-plan-reviewer.mjs --plan-file {{plan_file}}`,
+  '--allow-implicit-review-verdict',
+  '--yes'
+]);
+if (implicitDeletedPlanRun.status === 0) {
+  throw new Error(`loop inferred PASS after reviewer deleted the plan\nstdout:\n${implicitDeletedPlanRun.stdout}\nstderr:\n${implicitDeletedPlanRun.stderr}`);
+}
+const implicitDeletedPlanState = await fs.readFile(path.join(implicitDeletedPlanRoot, '.ai-bridge', 'loop-handoff-state.json'), 'utf8');
+const implicitDeletedPlanLog = await fs.readFile(path.join(implicitDeletedPlanRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
+if (!implicitDeletedPlanState.includes('"nextPlanChanged": true') || !implicitDeletedPlanState.includes('"followupPlanExists": false') || !implicitDeletedPlanLog.includes('"stop_reason":"no_followup_plan"')) {
+  throw new Error(`loop did not fail closed after implicit reviewer deleted the plan\nstate:\n${implicitDeletedPlanState}\nlog:\n${implicitDeletedPlanLog}`);
+}
+
+console.log('✓ execute-handoff, watch-handoff, and loop-handoff smoke test passed');


### PR DESCRIPTION
## What changed

- Added `codexpro loop-handoff`, a CLI-only local execute/review loop over `.ai-bridge/current-plan.md`.
- Added a required local `--review-command` contract using explicit `CODEXPRO_REVIEW=PASS` / `CODEXPRO_REVIEW=FAIL` verdicts.
- Added loop guardrails: max iterations, dry run, optional tests, clean-start check, stop on no diff, stop on same diff, and human confirmation for follow-up plans.
- Hardened the outside-command boundary: executor/reviewer/test commands are preflighted, missing verdicts fail closed by default, and reviewer `PASS` cannot mask failed executor/tests unless explicitly opted into.
- Documented the compliance boundary: this does not automate ChatGPT Web, Codex approvals, account access, third-party Pro sites, quota limits, or product safety prompts.

## Why

Issue #29 asks for an autonomous handoff loop with a callback/review cycle. The safe implementation is a terminal-owned local loop over explicit repo files and user-provided local commands, not browser automation or a remote MCP executor.

We cannot guarantee arbitrary future model or agent output. What this change can guarantee is that CodexPro's loop plumbing, command contract, and failure handling are tested and fail closed when external tools misbehave.

## Validation

- `node --check scripts/codexpro.mjs`
- `node scripts/execute-handoff-smoke.mjs`
- `npm run build`
- `npm run smoke`
- `git diff --check`
- `npm pack --dry-run`
- `npm audit --audit-level=high`

Adapter reality on this machine:

- `codex` installed: `codex-cli 0.135.0`
- `opencode` missing
- `pi` missing

The smoke suite covers the loop with fake local agents/reviewers, including:

- fail once by writing a follow-up plan, then pass on the second iteration
- no-diff stop behavior
- reviewer FAIL without a follow-up plan
- failed executor rejected even when reviewer prints PASS
