### PR TITLE
[codex] fix loop fingerprints in nested workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@
 - Switched loop guard decisions to an uncapped git-state fingerprint instead of hashing or vetoing on the trimmed reviewer diff artifact.
 - Kept handoff plan hashing on the handoff read-size budget instead of `--max-output-bytes`, so valid plans larger than captured output excerpts do not abort the loop after execution.
 - Made loop change fingerprints content/status based instead of timestamp based, so repeated identical tracked-file writes stop as no new changes instead of looking different because of volatile mtimes.
+- Normalized Git porcelain paths back to workspace-relative paths before loop clean-start filtering and change fingerprinting, with path-scoped status and untracked-file scans so nested workspaces inside larger Git repos are handled correctly.
 - Bounded untracked file fingerprinting so symlinks are reported via `readlink` and regular files hash only a capped prefix instead of following arbitrary paths or reading entire generated artifacts.
 - Tightened `--require-clean-git-start` so staged renames are treated as handoff-only only when both rename endpoints are inside `.ai-bridge`.
 - Stopped reviewer `FAIL` and implicit review verdicts from continuing when the reviewer deletes, empties, or restores `.ai-bridge/current-plan.md` to the scaffold instead of writing a usable follow-up plan.
 - Kept the autonomous handoff loop CLI-only and local-terminal-owned; it does not expose agent execution as a remote MCP tool, automate ChatGPT Web, approve product prompts, proxy models, or bypass limits.
-- Extended handoff smoke coverage with a fake reviewer that fails once by writing a follow-up plan, then passes on the second local executor iteration, plus failed executor, failed reviewer, bare `PASS`, staged-only, untracked-file, bounded-untracked, dirty-baseline, repeated-identical-write, large-dirty-baseline, unavailable-diff-artifact, large-plan-over-output-cap, staged-rename, deleted-follow-up-plan, and implicit-deleted-plan cases.
+- Extended handoff smoke coverage with a fake reviewer that fails once by writing a follow-up plan, then passes on the second local executor iteration, plus failed executor, failed reviewer, bare `PASS`, staged-only, untracked-file, bounded-untracked, dirty-baseline, repeated-identical-write, nested-workspace, nested-untracked-workspace, outside-untracked-nested-workspace, large-dirty-baseline, unavailable-diff-artifact, large-plan-over-output-cap, staged-rename, deleted-follow-up-plan, and implicit-deleted-plan cases.
 
 ## 0.28.5
 

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1637,18 +1637,8 @@ function commandDisplay(commandInfo) {
   return shellCommandPreview([commandInfo.command, ...(commandInfo.displayArgs ?? commandInfo.args)]);
 }
 
-function gitStatusPorcelain(root) {
-  const result = spawnSync('git', ['status', '--porcelain=v1'], {
-    cwd: root,
-    encoding: 'utf8',
-    maxBuffer: 1_000_000,
-    shell: false
-  });
-  if (result.status !== 0) {
-    const reason = result.stderr || result.stdout || `git status exited ${result.status}`;
-    throw new Error(`git status failed: ${redactForLog(reason).trim()}`);
-  }
-  return result.stdout || '';
+function gitStatusPorcelain(root, maxBytes = 1_000_000) {
+  return runGitText(root, ['status', '--porcelain=v1', '--untracked-files=all', '--', '.'], maxBytes);
 }
 
 function normalizedContextDir(contextDir) {
@@ -1657,6 +1647,10 @@ function normalizedContextDir(contextDir) {
 
 function normalizeStatusPath(value) {
   return String(value || '').replace(/^"|"$/g, '').replace(/\\"/g, '"');
+}
+
+function toPosixPath(value) {
+  return String(value || '').replace(/\\/g, '/');
 }
 
 function statusLinePaths(line) {
@@ -1669,15 +1663,45 @@ function statusLinePaths(line) {
   ];
 }
 
-function isContextStatusLine(line, contextDir) {
+function gitWorkspacePrefix(root) {
+  const topLevel = runGitText(root, ['rev-parse', '--show-toplevel'], 100_000).trim();
+  return toPosixPath(path.relative(topLevel, root)).replace(/\/+$/, '');
+}
+
+function workspacePathFromGitPath(filePath, workspacePrefix) {
+  const normalized = toPosixPath(filePath).replace(/^\.?\//, '');
+  const prefix = toPosixPath(workspacePrefix).replace(/\/+$/, '');
+  if (!prefix) return normalized;
+  if (normalized === prefix) return '';
+  if (normalized.startsWith(`${prefix}/`)) return normalized.slice(prefix.length + 1);
+  return null;
+}
+
+function statusLineWorkspacePaths(line, workspacePrefix) {
+  return statusLinePaths(line)
+    .map((filePath) => workspacePathFromGitPath(filePath, workspacePrefix))
+    .filter((filePath) => filePath !== null && filePath !== '');
+}
+
+function workspaceStatusLine(line, workspacePaths) {
+  return `${String(line || '').slice(0, 3)}${workspacePaths.join(' -> ')}`;
+}
+
+function isContextStatusLine(line, contextDir, workspacePrefix = '') {
   const context = normalizedContextDir(contextDir);
-  const paths = statusLinePaths(line);
+  const paths = statusLineWorkspacePaths(line, workspacePrefix);
   return paths.length > 0 && paths.every((filePath) => filePath === context || filePath.startsWith(`${context}/`));
 }
 
 function assertCleanGitStart(root, contextDir) {
   const status = gitStatusPorcelain(root);
-  const nonContextStatus = status.split(/\r?\n/).filter((line) => line.trim() && !isContextStatusLine(line, contextDir)).join('\n');
+  const workspacePrefix = gitWorkspacePrefix(root);
+  const nonContextStatus = status.split(/\r?\n/).map((line) => {
+    if (!line.trim()) return '';
+    const paths = statusLineWorkspacePaths(line, workspacePrefix);
+    if (!paths.length || paths.every(contextPathPredicate(contextDir))) return '';
+    return workspaceStatusLine(line, paths);
+  }).filter(Boolean).join('\n');
   if (nonContextStatus.trim()) {
     throw new Error(`--require-clean-git-start refused to start because the workspace has non-handoff changes:\n${nonContextStatus}`);
   }
@@ -1754,7 +1778,7 @@ function untrackedEntrySummary(root, relPath) {
 
 function untrackedFilesSummary(root, contextDir, maxBytes) {
   const context = normalizedContextDir(contextDir);
-  const output = runGitText(root, ['ls-files', '--others', '--exclude-standard', '-z'], 1_000_000);
+  const output = runGitText(root, ['ls-files', '--others', '--exclude-standard', '-z', '--', '.'], 1_000_000);
   const entries = output.split('\0').filter(Boolean).filter((relPath) => relPath !== context && !relPath.startsWith(`${context}/`));
   if (!entries.length) return '';
   const lines = [];
@@ -1809,14 +1833,16 @@ function pathStateForFingerprint(root, relPath, options = {}) {
 function changeFingerprintExcludingContext(root, contextDir) {
   const context = normalizedContextDir(contextDir);
   const isContextPath = contextPathPredicate(contextDir);
-  const status = runGitText(root, ['status', '--porcelain=v1', '--untracked-files=all'], 25_000_000);
+  const workspacePrefix = gitWorkspacePrefix(root);
+  const status = gitStatusPorcelain(root, 25_000_000);
   const stagedRaw = runGitText(root, ['diff', '--cached', '--raw', '-z', '--no-ext-diff', '--', '.', `:(exclude)${context}`], 25_000_000);
   const hash = createHash('sha256');
   hash.update(`staged-raw\0${stagedRaw}\0`);
   for (const line of status.split(/\r?\n/).filter(Boolean).sort()) {
-    const paths = statusLinePaths(line);
+    const paths = statusLineWorkspacePaths(line, workspacePrefix);
+    if (!paths.length) continue;
     if (paths.length && paths.every(isContextPath)) continue;
-    hash.update(`status\0${line}\0`);
+    hash.update(`status\0${workspaceStatusLine(line, paths)}\0`);
     const fullFileHash = !line.startsWith('?? ');
     for (const filePath of paths) {
       hash.update(`path\0${filePath}\0${pathStateForFingerprint(root, filePath, { fullFileHash })}\0`);

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -535,6 +535,115 @@ if (!repeatedSameLog.includes('"stop_reason":"no_files_changed"')) {
   throw new Error(`loop did not stop on repeated identical content write\nlog:\n${repeatedSameLog}`);
 }
 
+const subdirRepoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-subdir-repo-'));
+const subdirRoot = path.join(subdirRepoRoot, 'packages', 'demo');
+await fs.mkdir(path.join(subdirRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(subdirRoot, '.ai-bridge', 'current-plan.md'), '# Subdir plan\n\nAppend the first marker.\n', 'utf8');
+await fs.writeFile(path.join(subdirRoot, 'app.txt'), 'base\n', 'utf8');
+await fs.writeFile(path.join(subdirRoot, 'agent.mjs'), `
+import fs from 'node:fs';
+const planPath = process.argv[process.argv.indexOf('--task-file') + 1];
+const plan = fs.readFileSync(planPath, 'utf8');
+fs.appendFileSync('app.txt', plan.includes('second marker') ? 'second subdir change\\n' : 'first subdir change\\n');
+`, 'utf8');
+await fs.writeFile(path.join(subdirRoot, 'reviewer.mjs'), `
+import fs from 'node:fs';
+const planPath = process.argv[process.argv.indexOf('--plan-file') + 1];
+const app = fs.readFileSync('app.txt', 'utf8');
+if (app.includes('second subdir change')) {
+  console.log('CODEXPRO_REVIEW=PASS');
+} else if (app.includes('first subdir change')) {
+  fs.writeFileSync(planPath, '# Subdir follow-up\\n\\nAppend the second marker.\\n');
+  console.log('CODEXPRO_REVIEW=FAIL');
+} else {
+  process.exit(9);
+}
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: subdirRepoRoot, encoding: 'utf8' }), 'subdir repo git init');
+requireSuccess(spawnSync('git', ['add', 'packages/demo/app.txt', 'packages/demo/agent.mjs', 'packages/demo/reviewer.mjs'], { cwd: subdirRepoRoot, encoding: 'utf8' }), 'subdir repo git add');
+requireSuccess(spawnSync('git', ['-c', 'user.email=codexpro@example.invalid', '-c', 'user.name=CodexPro Smoke', 'commit', '-m', 'init'], { cwd: subdirRepoRoot, encoding: 'utf8' }), 'subdir repo git commit');
+
+const subdirRun = run([
+  'loop-handoff',
+  '--root',
+  subdirRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} agent.mjs --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} reviewer.mjs --plan-file {{plan_file}}`,
+  '--max-iters',
+  '2',
+  '--require-clean-git-start',
+  '--stop-if-no-files-changed',
+  '--yes'
+]);
+requireSuccess(subdirRun, 'loop-handoff workspace nested below git top-level');
+
+const subdirUntrackedRepoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-subdir-untracked-'));
+const subdirUntrackedRoot = path.join(subdirUntrackedRepoRoot, 'packages', 'demo');
+await fs.mkdir(path.join(subdirUntrackedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(subdirUntrackedRoot, '.ai-bridge', 'current-plan.md'), '# Untracked subdir plan\n\nShould not start.\n', 'utf8');
+await fs.writeFile(path.join(subdirUntrackedRoot, 'app.txt'), 'untracked workspace file\n', 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: subdirUntrackedRepoRoot, encoding: 'utf8' }), 'subdir untracked repo git init');
+
+const subdirUntrackedRun = run([
+  'loop-handoff',
+  '--root',
+  subdirUntrackedRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} -e "process.exit(0)" --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} -e "console.log('CODEXPRO_REVIEW=PASS')" --plan-file {{plan_file}}`,
+  '--require-clean-git-start',
+  '--yes'
+]);
+if (subdirUntrackedRun.status === 0) {
+  throw new Error(`loop accepted untracked files under a nested workspace as clean\nstdout:\n${subdirUntrackedRun.stdout}\nstderr:\n${subdirUntrackedRun.stderr}`);
+}
+if (!subdirUntrackedRun.stderr.includes('--require-clean-git-start refused') || !subdirUntrackedRun.stderr.includes('app.txt')) {
+  throw new Error(`loop did not report nested untracked workspace file\nstdout:\n${subdirUntrackedRun.stdout}\nstderr:\n${subdirUntrackedRun.stderr}`);
+}
+
+const subdirOutsideUntrackedRepoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-subdir-outside-untracked-'));
+const subdirOutsideUntrackedRoot = path.join(subdirOutsideUntrackedRepoRoot, 'packages', 'demo');
+await fs.mkdir(path.join(subdirOutsideUntrackedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(subdirOutsideUntrackedRoot, '.ai-bridge', 'current-plan.md'), '# Outside untracked plan\n\nAppend a marker.\n', 'utf8');
+await fs.writeFile(path.join(subdirOutsideUntrackedRoot, 'app.txt'), 'base\n', 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: subdirOutsideUntrackedRepoRoot, encoding: 'utf8' }), 'subdir outside untracked repo git init');
+requireSuccess(spawnSync('git', ['add', 'packages/demo/app.txt'], { cwd: subdirOutsideUntrackedRepoRoot, encoding: 'utf8' }), 'subdir outside untracked repo git add');
+requireSuccess(spawnSync('git', ['-c', 'user.email=codexpro@example.invalid', '-c', 'user.name=CodexPro Smoke', 'commit', '-m', 'init'], { cwd: subdirOutsideUntrackedRepoRoot, encoding: 'utf8' }), 'subdir outside untracked repo git commit');
+const outsideGeneratedDir = path.join(
+  subdirOutsideUntrackedRepoRoot,
+  'packages',
+  'generated',
+  'x'.repeat(170),
+  'y'.repeat(170),
+  'z'.repeat(170)
+);
+await fs.mkdir(outsideGeneratedDir, { recursive: true });
+const outsideFileSuffix = 'a'.repeat(110);
+for (let index = 0; index < 1800; index += 1) {
+  await fs.writeFile(path.join(outsideGeneratedDir, `${String(index).padStart(4, '0')}-${outsideFileSuffix}.txt`), 'outside workspace\n', 'utf8');
+}
+const subdirOutsideUntrackedRun = run([
+  'loop-handoff',
+  '--root',
+  subdirOutsideUntrackedRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} -e "require('node:fs').appendFileSync('app.txt', 'workspace change\\n')" -- --task-file {{plan_file}}`,
+  '--review-command',
+  `${quoteArg(process.execPath)} -e "console.log('CODEXPRO_REVIEW=PASS')" -- --plan-file {{plan_file}}`,
+  '--require-clean-git-start',
+  '--yes'
+]);
+requireSuccess(subdirOutsideUntrackedRun, 'loop-handoff ignores large untracked tree outside nested workspace');
+
 const largeDirtyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-large-dirty-'));
 await fs.mkdir(path.join(largeDirtyRoot, '.ai-bridge'), { recursive: true });
 await fs.writeFile(path.join(largeDirtyRoot, '.ai-bridge', 'current-plan.md'), '# Large dirty plan\n\nAppend to later file.\n', 'utf8');


### PR DESCRIPTION
## Summary
- normalize Git porcelain status paths to workspace-relative paths before loop clean-start filtering and change fingerprinting
- keep .ai-bridge context filtering correct when CodexPro is run from a subdirectory of a larger Git repo
- add smoke coverage for a nested workspace that requires a second tracked-file edit to be detected

## Validation
- node --check scripts/codexpro.mjs
- node --check scripts/execute-handoff-smoke.mjs
- node scripts/execute-handoff-smoke.mjs
- npm run build
- npm run smoke
- git diff --check
- npm audit --audit-level=high
- npm pack --dry-run