### PR TITLE
[codex] Make ChatGPT tool cards opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Made ChatGPT tool-card descriptor metadata opt-in with `CODEXPRO_TOOL_CARDS=1`, so default `tools/list` responses stay plain MCP and avoid fragile widget metadata during tool discovery.
 - Added `codexpro loop-handoff` for bounded local execute/review loops over `.ai-bridge/current-plan.md`, with a required local `--review-command`, `--max-iters`, dry-run preview, optional test command capture, and stop conditions for no diff, repeated diff, missing follow-up plans, reviewer errors, and human cancellation.
 - Hardened `loop-handoff` external-command boundaries: commands are preflighted before execution, reviewer verdicts require explicit `CODEXPRO_REVIEW=...` assignment lines by default, and reviewer `PASS` no longer masks failed executor/test/reviewer commands unless the user opts into the supported override behavior.
 - Fixed loop change detection so `--stop-if-no-files-changed` and `--stop-if-same-diff` compare each iteration against a pre-execution baseline and count unstaged diffs, staged diffs, and untracked file fingerprints outside `.ai-bridge`.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Account tier and model tool support are separate things. Plus/Pro can expose App
 
 ## Status
 
-CodexPro is a public open-source MCP bridge with conservative defaults: workspace-only writes, safe bash by default, blocked secret paths, token-protected public URLs, and compact visual cards for every tool result.
+CodexPro is a public open-source MCP bridge with conservative defaults: workspace-only writes, safe bash by default, blocked secret paths, token-protected public URLs, and optional compact visual cards.
 
 CodexPro does not bypass, avoid, increase, pool, resell, or modify ChatGPT, Codex, OpenAI, or third-party model limits. It does not provide models or account access. It only exposes local repo tools to the ChatGPT session the user already controls through official MCP and Developer Mode.
 
@@ -293,13 +293,19 @@ Optional safety flags:
 
 ## Visual ChatGPT cards
 
-v0.28.5+ registers a reusable Apps SDK widget resource:
+CodexPro can register a reusable Apps SDK widget resource:
 
 ```text
 ui://widget/codexpro-tool-card-v9.html
 ```
 
-Every CodexPro tool descriptor attaches that resource through `_meta.ui.resourceUri` and the ChatGPT compatibility key `_meta["openai/outputTemplate"]`. In ChatGPT Developer Mode this renders compact cards for:
+Tool-card descriptors are opt-in. By default, ChatGPT receives plain MCP tool descriptors with no widget/status metadata. To enable CodexPro cards, start with:
+
+```bash
+CODEXPRO_TOOL_CARDS=1 codexpro start
+```
+
+When enabled, CodexPro attaches `_meta.ui.resourceUri` and the ChatGPT compatibility key `_meta["openai/outputTemplate"]`. In ChatGPT Developer Mode this renders compact cards for:
 
 ```text
 server_config and codexpro_self_test
@@ -313,9 +319,9 @@ read_handoff, codex_context
 handoff/pro-context exports
 ```
 
-Cards stay compact by default. Git details, discovered skills, file trees, terminal output, context bundles, and raw diffs are folded or bounded so the chat does not fill with project inventory unless you open it.
+Cards stay compact when enabled. Git details, discovered skills, file trees, terminal output, context bundles, and raw diffs are folded or bounded so the chat does not fill with project inventory unless you open it.
 
-ChatGPT may still show some raw tool transcript around a card depending on the host UI and model behavior. CodexPro minimizes that by returning structured data, bounded previews, and a v9 card for every tool, but the ChatGPT client controls final transcript rendering.
+ChatGPT may still show some raw tool transcript around a card depending on the host UI and model behavior. CodexPro minimizes that by returning structured data and bounded previews, but the ChatGPT client controls final transcript rendering.
 
 The visual cards are not unlocked by "normal coding mode" alone; the MCP server has to register an HTML resource with `text/html;profile=mcp-app` and point tool descriptors at it.
 
@@ -330,7 +336,7 @@ _meta["openai/widgetCSP"]
 
 `CODEXPRO_WIDGET_DOMAIN` defaults to `https://rebel0789.github.io` for this package. For app submission, set it to a dedicated HTTPS origin you control, for example `https://widgets.yourdomain.com`. The CSP lists are intentionally strict because the widget has no external fetches, fonts, scripts, images, or iframes.
 
-After upgrading or changing widget metadata, open the CodexPro app settings in ChatGPT Developer Mode and click `Refresh` / `Refresh actions` so ChatGPT reloads the tool descriptors and resource URI.
+After enabling cards, upgrading, or changing widget metadata, open the CodexPro app settings in ChatGPT Developer Mode and click `Refresh` / `Refresh actions` so ChatGPT reloads the tool descriptors and resource URI.
 
 ## Other Install Paths
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -102,7 +102,7 @@ ChatGPT Web 可以操作：
 
 默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，并可用 `load_skill` 按名称、source 和显示出的 path 加载需要的 `SKILL.md`；如果仍有重名匹配，CodexPro 会报歧义错误，不会随便选一个，也不会把几十个 skill 变成单独 action。
 
-ChatGPT 里每个 CodexPro 工具都可以显示紧凑 v9 卡片：server config、自测、workspace 摘要、读写 diff、bash 验证、git/tree/search/context 和 handoff/export 都有结构化视图。git、skills、tree、terminal 输出、context 和 raw diff 默认折叠或截断，避免在聊天里刷出大段原始数据。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
+CodexPro 默认给 ChatGPT 暴露纯 MCP 工具描述，不附带 widget/card metadata。需要紧凑 v9 卡片时用 `CODEXPRO_TOOL_CARDS=1` 启动；server config、自测、workspace 摘要、读写 diff、bash 验证、git/tree/search/context 和 handoff/export 都有结构化视图。git、skills、tree、terminal 输出、context 和 raw diff 会折叠或截断，避免在聊天里刷出大段原始数据。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 
 ## 其他启动方式
 

--- a/config.example.env
+++ b/config.example.env
@@ -11,6 +11,10 @@ CODEXPRO_WRITE_MODE=handoff
 CODEXPRO_TOOL_MODE=standard
 # Dedicated HTTPS origin for ChatGPT widget iframes. Required for app submission.
 CODEXPRO_WIDGET_DOMAIN=https://rebel0789.github.io
+
+# Disabled by default so ChatGPT receives plain MCP tool descriptors.
+# Set to 1 only if you want CodexPro's custom ChatGPT cards.
+CODEXPRO_TOOL_CARDS=0
 CODEXPRO_HTTP_TOKEN=replace-with-a-long-random-token
 # Require a token even for loopback binds. Non-loopback and tunnel mode require one unless explicitly overridden.
 # CODEXPRO_REQUIRE_HTTP_TOKEN=1

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -575,9 +575,18 @@ function optionBool(args, profile, field, envNames = [], fallback = false) {
   return fallback;
 }
 
+function hasToolCardsInput(args, profile = {}) {
+  return args.toolCards !== undefined || profile.toolCards !== undefined || (process.env.CODEXPRO_TOOL_CARDS !== undefined && process.env.CODEXPRO_TOOL_CARDS !== '');
+}
+
 function toolCardsProfileEntry(args, profile = {}) {
-  const hasInput = args.toolCards !== undefined || profile.toolCards !== undefined || process.env.CODEXPRO_TOOL_CARDS !== undefined;
+  const hasInput = hasToolCardsInput(args, profile);
   return hasInput ? { toolCards: optionBool(args, profile, 'toolCards', ['CODEXPRO_TOOL_CARDS'], false) } : {};
+}
+
+function toolCardsCliArgs(args, profile = {}) {
+  if (!hasToolCardsInput(args, profile)) return [];
+  return ['--tool-cards', optionBool(args, profile, 'toolCards', ['CODEXPRO_TOOL_CARDS'], false) ? 'on' : 'off'];
 }
 
 function validateBashSession(value) {
@@ -2734,7 +2743,7 @@ async function runSetupWizard(argv) {
     if (write) args.push('--write', write);
     if (toolMode) args.push('--tool-mode', toolMode);
     if (widgetDomain) args.push('--widget-domain', widgetDomain);
-    if (toolCardsEntry.toolCards) args.push('--tool-cards', 'on');
+    args.push(...toolCardsCliArgs(defaults, profile));
     if (defaults.noInstallCloudflared) args.push('--no-install-cloudflared');
     if (defaults.openChatgpt) args.push('--open-chatgpt');
     if (defaults.noCopyUrl) args.push('--no-copy-url');

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -3334,7 +3334,8 @@ async function main() {
     bashTranscript,
     codexSessions,
     bashSession,
-    requireBashSession
+    requireBashSession,
+    toolCards
   };
 
   if (tunnel === 'none') {

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -575,6 +575,11 @@ function optionBool(args, profile, field, envNames = [], fallback = false) {
   return fallback;
 }
 
+function toolCardsProfileEntry(args, profile = {}) {
+  const hasInput = args.toolCards !== undefined || profile.toolCards !== undefined || process.env.CODEXPRO_TOOL_CARDS !== undefined;
+  return hasInput ? { toolCards: optionBool(args, profile, 'toolCards', ['CODEXPRO_TOOL_CARDS'], false) } : {};
+}
+
 function validateBashSession(value) {
   if (!value) return '';
   const trimmed = String(value).trim();
@@ -2595,6 +2600,7 @@ function profileFromPreference(root, args, profile, preference) {
     ...(write ? { write } : {}),
     ...(toolMode ? { toolMode } : {}),
     ...(widgetDomain ? { widgetDomain } : {}),
+    ...toolCardsProfileEntry(args, profile),
     ...(args.noInstallCloudflared ? { noInstallCloudflared: true } : {}),
     root
   };
@@ -2717,6 +2723,7 @@ async function runSetupWizard(argv) {
     const write = optionalWriteOption(defaults, profile, mode);
     const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
     const widgetDomain = optionValue(defaults, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
+    const toolCardsEntry = toolCardsProfileEntry(defaults, profile);
     if (bash) args.push('--bash', bash);
     if (bashTranscript !== 'compact') args.push('--bash-transcript', bashTranscript);
     if (codexSessions !== 'off') args.push('--codex-sessions', codexSessions);
@@ -2727,6 +2734,7 @@ async function runSetupWizard(argv) {
     if (write) args.push('--write', write);
     if (toolMode) args.push('--tool-mode', toolMode);
     if (widgetDomain) args.push('--widget-domain', widgetDomain);
+    if (toolCardsEntry.toolCards) args.push('--tool-cards', 'on');
     if (defaults.noInstallCloudflared) args.push('--no-install-cloudflared');
     if (defaults.openChatgpt) args.push('--open-chatgpt');
     if (defaults.noCopyUrl) args.push('--no-copy-url');
@@ -2806,6 +2814,7 @@ async function runSetupWizard(argv) {
         ...(write ? { write } : {}),
         ...(toolMode ? { toolMode } : {}),
         ...(widgetDomain ? { widgetDomain } : {}),
+        ...toolCardsEntry,
         ...(defaults.noInstallCloudflared ? { noInstallCloudflared: true } : {})
       });
       statusLine('ok', `Saved workspace profile: ${savedPath}`);
@@ -2851,6 +2860,7 @@ function printProfile(root, profile) {
     ...(safe.bash ? [labelValue('Bash', safe.bash)] : []),
     ...(safe.write ? [labelValue('Write', safe.write)] : []),
     ...(safe.toolMode ? [labelValue('Tool mode', safe.toolMode)] : []),
+    ...(safe.toolCards !== undefined ? [labelValue('Tool cards', safe.toolCards ? 'on' : 'off')] : []),
     labelValue('Bash transcript', safe.bashTranscript ?? 'compact'),
     labelValue('Codex sessions', safe.codexSessions ?? 'off'),
     ...(safe.codexDir ? [labelValue('Codex dir', safe.codexDir)] : []),
@@ -2923,6 +2933,7 @@ function saveSettingsFromArgs(root, args, profile) {
     ...(mode !== 'agent' || args.write !== undefined || profile.write ? { write } : {}),
     ...(toolMode ? { toolMode } : {}),
     ...(widgetDomain ? { widgetDomain } : {}),
+    ...toolCardsProfileEntry(args, profile),
     ...(args.noInstallCloudflared ?? profile.noInstallCloudflared ? { noInstallCloudflared: true } : {})
   });
   statusLine('ok', `Saved workspace settings: ${savedPath}`);

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -71,6 +71,7 @@ Options:
                              full = expose every compatibility and advanced tool.
   --widget-domain <origin>   Dedicated HTTPS origin for ChatGPT widget iframes.
                              Required for app submission. Default: https://rebel0789.github.io.
+  --tool-cards <on|off>      Opt in to ChatGPT widget metadata on tool descriptors. Default: off.
   --tunnel <none|cloudflare|cloudflare-named|ngrok>
                              Expose local MCP. Default: cloudflare.
                              cloudflare = quick tunnel with a new URL each restart.
@@ -516,7 +517,8 @@ function saveRuntimeConnection(root, details, options = {}) {
     bashSession: options.bashSession ?? '',
     requireBashSession: Boolean(options.requireBashSession),
     write: options.write ?? '',
-    toolMode: options.toolMode ?? ''
+    toolMode: options.toolMode ?? '',
+    toolCards: Boolean(options.toolCards)
   };
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
   try {
@@ -3249,6 +3251,7 @@ async function main() {
   const write = writeOption(args, profile, mode);
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], 'https://rebel0789.github.io');
+  const toolCards = optionBool(args, profile, 'toolCards', ['CODEXPRO_TOOL_CARDS'], false);
   if (!['off', 'safe', 'full'].includes(bash)) throw new Error('--bash must be off, safe, or full');
   if (!['off', 'handoff', 'workspace'].includes(write)) throw new Error('--write must be off, handoff, or workspace');
   if (!['minimal', 'standard', 'full'].includes(toolMode)) throw new Error('--tool-mode must be minimal, standard, or full');
@@ -3270,6 +3273,7 @@ async function main() {
     CODEXPRO_WRITE_MODE: write,
     CODEXPRO_TOOL_MODE: toolMode,
     CODEXPRO_WIDGET_DOMAIN: widgetDomain,
+    CODEXPRO_TOOL_CARDS: toolCards ? '1' : '0',
     CODEXPRO_MODE: mode,
     CODEXPRO_TUNNEL_MODE: tunnel === 'none' ? '0' : '1'
   };

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -126,6 +126,12 @@ function hasWidgetMeta(tools, name, uri) {
   return meta.ui?.resourceUri === uri && meta['openai/outputTemplate'] === uri;
 }
 
+function hasToolCardStatusMeta(tools, name) {
+  const tool = tools.find((item) => item.name === name);
+  const meta = tool?._meta ?? {};
+  return Boolean(meta['openai/toolInvocation/invoking'] || meta['openai/toolInvocation/invoked']);
+}
+
 await expectHttpTokenRequired('non-loopback', { CODEXPRO_HOST: '0.0.0.0' });
 await expectHttpTokenRequired('tunnel-mode', { CODEXPRO_TUNNEL_MODE: '1' });
 
@@ -309,8 +315,8 @@ try {
   }
   const toolCardUri = 'ui://widget/codexpro-tool-card-v9.html';
   for (const visualTool of queryToolNames) {
-    if (!hasWidgetMeta(queryTools, visualTool, toolCardUri)) {
-      throw new Error(`${visualTool} should render the CodexPro widget`);
+    if (hasWidgetMeta(queryTools, visualTool, toolCardUri) || hasToolCardStatusMeta(queryTools, visualTool)) {
+      throw new Error(`${visualTool} exposed widget metadata while CODEXPRO_TOOL_CARDS is off`);
     }
   }
 

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -181,6 +181,7 @@ const child = spawn('node', ['dist/http.js'], {
     CODEXPRO_BASH_MODE: 'safe',
     CODEXPRO_WRITE_MODE: 'handoff',
     CODEXPRO_TOOL_MODE: 'full',
+    CODEXPRO_TOOL_CARDS: '0',
     CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test',
     CODEXPRO_HOME: profileHome
   },
@@ -224,7 +225,7 @@ try {
   if (!homeText.includes('Connection profile') || !homeText.includes('data-profile-form')) {
     throw new Error('onboarding page did not include the saved profile editor');
   }
-  for (const fieldName of ['tunnelName', 'ngrokConfig', 'cloudflareConfig', 'cloudflareTokenFile', 'noInstallCloudflared']) {
+  for (const fieldName of ['tunnelName', 'ngrokConfig', 'cloudflareConfig', 'cloudflareTokenFile', 'toolCards', 'noInstallCloudflared']) {
     if (!homeText.includes(`name="${fieldName}"`)) {
       throw new Error(`onboarding page did not include profile field ${fieldName}`);
     }
@@ -272,6 +273,7 @@ try {
       requireBashSession: true,
       write: 'workspace',
       toolMode: 'full',
+      toolCards: true,
       widgetDomain: 'https://widgets.codexpro.test',
       ngrokConfig: path.join(root, 'ngrok.yml'),
       cloudflareTokenFile: 'cloudflare-token',
@@ -293,6 +295,7 @@ try {
     savedProfile.codexSessions !== 'metadata' ||
     savedProfile.bashSession !== 'http-main' ||
     savedProfile.requireBashSession !== true ||
+    savedProfile.toolCards !== true ||
     savedProfile.ngrokConfig !== path.join(root, 'ngrok.yml') ||
     savedProfile.cloudflareTokenFile !== path.join(realRoot, 'cloudflare-token') ||
     savedProfile.noInstallCloudflared !== true ||

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -1,6 +1,7 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -38,9 +39,67 @@ async function readProfile(root, home) {
   return JSON.parse(await fs.readFile(path.join(home, 'profiles', `${id}.json`), 'utf8'));
 }
 
+async function runtimeStatusPath(root, home) {
+  const realRoot = await fs.realpath(root);
+  const id = createHash('sha256').update(realRoot).digest('hex').slice(0, 24);
+  return path.join(home, 'runtime', `${id}.json`);
+}
+
+async function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : undefined;
+      server.close(() => (port ? resolve(port) : reject(new Error('no free port'))));
+    });
+    server.on('error', reject);
+  });
+}
+
+async function waitForJson(filePath, predicate, label) {
+  const deadline = Date.now() + 10_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const data = JSON.parse(await fs.readFile(filePath, 'utf8'));
+      if (predicate(data)) return data;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for ${label}: ${lastError?.message ?? 'predicate not met'}`);
+}
+
+async function withStartedCodexPro(args, env, fn) {
+  const child = spawn(process.execPath, ['scripts/codexpro.mjs', 'start', ...args], {
+    cwd: path.resolve('.'),
+    env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  let output = '';
+  let closed = false;
+  const closedPromise = new Promise((resolve) => child.once('close', (code, signal) => {
+    closed = true;
+    resolve({ code, signal });
+  }));
+  child.stdout.on('data', (chunk) => { output += chunk; });
+  child.stderr.on('data', (chunk) => { output += chunk; });
+  try {
+    await fn();
+  } catch (error) {
+    throw new Error(`${error.message}\nstart output:\n${output}`);
+  } finally {
+    if (!closed) child.kill('SIGTERM');
+    await closedPromise;
+  }
+}
+
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-root-'));
 const reuseRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-reuse-'));
 const policyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-policy-'));
+const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-runtime-'));
 const home = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-home-'));
 const env = { ...process.env, CODEXPRO_HOME: home };
 
@@ -156,6 +215,24 @@ const guardedProfile = await readProfile(root, home);
 if (guardedProfile.bashSession !== 'guarded-main' || guardedProfile.requireBashSession !== true) {
   throw new Error(`settings profile did not persist bash session guard: ${JSON.stringify(guardedProfile)}`);
 }
+
+const runtimePort = await getFreePort();
+const runtimePath = await runtimeStatusPath(runtimeRoot, home);
+await withStartedCodexPro([
+  '--root',
+  runtimeRoot,
+  '--port',
+  String(runtimePort),
+  '--tunnel',
+  'none',
+  '--tool-cards',
+  'on'
+], env, async () => {
+  const runtime = await waitForJson(runtimePath, (data) => data.toolCards === true, 'tool-cards runtime status');
+  if (runtime.toolCards !== true) {
+    throw new Error(`runtime status did not persist toolCards: ${JSON.stringify(runtime)}`);
+  }
+});
 
 const listed = run(['settings', 'list'], env);
 if (!listed.includes(root) || !listed.includes('codexpro-test.ngrok-free.app')) {

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -127,6 +127,8 @@ const saved = run([
   'full',
   '--widget-domain',
   'https://widgets.codexpro.test',
+  '--tool-cards',
+  'on',
   '--token',
   'codexpro-settings-token'
 ], env);
@@ -135,7 +137,7 @@ if (!saved.includes('Saved workspace settings')) {
 }
 
 const shown = run(['settings', 'show', '--root', root], env);
-for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '19087', 'Bash transcript', 'full', '<saved>']) {
+for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '19087', 'Tool cards', 'on', 'Bash transcript', 'full', '<saved>']) {
   if (!shown.includes(expected)) {
     throw new Error(`settings show missing ${expected}\n${shown}`);
   }
@@ -144,7 +146,7 @@ if (shown.includes('codexpro-settings-token')) {
   throw new Error(`settings show leaked token\n${shown}`);
 }
 const profile = await readProfile(root, home);
-if (profile.toolMode !== 'full' || profile.bashTranscript !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
+if (profile.toolMode !== 'full' || profile.toolCards !== true || profile.bashTranscript !== 'full' || profile.widgetDomain !== 'https://widgets.codexpro.test') {
   throw new Error(`settings profile did not persist tool/widget options: ${JSON.stringify(profile)}`);
 }
 
@@ -218,15 +220,21 @@ if (guardedProfile.bashSession !== 'guarded-main' || guardedProfile.requireBashS
 
 const runtimePort = await getFreePort();
 const runtimePath = await runtimeStatusPath(runtimeRoot, home);
-await withStartedCodexPro([
+run([
+  'settings',
+  'set',
   '--root',
   runtimeRoot,
-  '--port',
-  String(runtimePort),
   '--tunnel',
   'none',
+  '--port',
+  String(runtimePort),
   '--tool-cards',
   'on'
+], env);
+await withStartedCodexPro([
+  '--root',
+  runtimeRoot
 ], env, async () => {
   const runtime = await waitForJson(runtimePath, (data) => data.toolCards === true, 'tool-cards runtime status');
   if (runtime.toolCards !== true) {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -134,7 +134,7 @@ if (commitResult.status !== 0) {
 
 const client = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe', '--tool-mode', 'full'], {
   cwd: path.resolve('.'),
-  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test' }
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_WIDGET_DOMAIN: 'https://widgets.codexpro.test', CODEXPRO_TOOL_CARDS: '0' }
 });
 
 await client.request('initialize', {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -154,6 +154,10 @@ function hasWidgetMeta(name) {
   const meta = toolsByName.get(name)?._meta ?? {};
   return meta.ui?.resourceUri === toolCardUri && meta['openai/outputTemplate'] === toolCardUri;
 }
+function hasToolCardStatusMeta(name) {
+  const meta = toolsByName.get(name)?._meta ?? {};
+  return Boolean(meta['openai/toolInvocation/invoking'] || meta['openai/toolInvocation/invoked']);
+}
 async function expectToolError(name, args, pattern, targetClient = client) {
   const result = await targetClient.request('tools/call', { name, arguments: args });
   if (!result.isError) {
@@ -165,8 +169,24 @@ async function expectToolError(name, args, pattern, targetClient = client) {
   }
 }
 for (const visualTool of toolNames) {
-  if (!hasWidgetMeta(visualTool)) throw new Error(`${visualTool} should render the CodexPro widget`);
+  if (hasWidgetMeta(visualTool) || hasToolCardStatusMeta(visualTool)) throw new Error(`${visualTool} exposed widget metadata while CODEXPRO_TOOL_CARDS is off`);
 }
+const cardClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe', '--tool-mode', 'full'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_TOOL_CARDS: '1' }
+});
+await cardClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-smoke-card-opt-in', version: '0.1.0' }
+});
+cardClient.notify('notifications/initialized');
+const cardTools = await cardClient.request('tools/list', {});
+const cardSearchMeta = cardTools.tools.find((tool) => tool.name === 'search')?._meta ?? {};
+if (cardSearchMeta.ui?.resourceUri !== toolCardUri || cardSearchMeta['openai/outputTemplate'] !== toolCardUri) {
+  throw new Error('CODEXPRO_TOOL_CARDS=1 did not opt search into widget metadata');
+}
+await cardClient.close();
 const resources = await client.request('resources/list', {});
 const toolCard = resources.resources.find((resource) => resource.uri === toolCardUri);
 if (!toolCard) throw new Error(`missing tool-card resource: ${toolCardUri}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export interface CodexProConfig {
   httpSessionTtlMs: number;
   blockedGlobs: string[];
   contextDir: string;
+  toolCards: boolean;
 }
 
 const DEFAULT_BLOCKED_GLOBS = [
@@ -266,6 +267,12 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
   const writeArg = typeof args.write === "string" ? args.write : undefined;
   const toolModeArg = typeof args["tool-mode"] === "string" ? args["tool-mode"] : undefined;
   const widgetDomainArg = typeof args["widget-domain"] === "string" ? args["widget-domain"] : undefined;
+  const toolCardsArg =
+    args["tool-cards"] === true
+      ? "true"
+      : typeof args["tool-cards"] === "string"
+        ? args["tool-cards"]
+        : undefined;
   const extraBlockedGlobs = splitList(process.env.CODEXPRO_BLOCKED_GLOBS, ",");
   const host = hostArg ?? process.env.HOST ?? process.env.CODEXPRO_HOST ?? "127.0.0.1";
   const authToken = process.env.CODEXPRO_HTTP_TOKEN ?? process.env.CODEBASE_BRIDGE_HTTP_TOKEN;
@@ -304,6 +311,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     maxHttpSessions: numberFrom(process.env.CODEXPRO_MAX_HTTP_SESSIONS, 64, 1, 512),
     httpSessionTtlMs: numberFrom(process.env.CODEXPRO_HTTP_SESSION_TTL_MS, 30 * 60_000, 60_000, 24 * 60 * 60_000),
     blockedGlobs: [...DEFAULT_BLOCKED_GLOBS, ...extraBlockedGlobs],
-    contextDir: contextDirFrom(process.env.CODEXPRO_CONTEXT_DIR)
+    contextDir: contextDirFrom(process.env.CODEXPRO_CONTEXT_DIR),
+    toolCards: boolFrom(toolCardsArg ?? process.env.CODEXPRO_TOOL_CARDS, false)
   };
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -73,6 +73,7 @@ const AdminProfilePatch = z.object({
   requireBashSession: z.boolean().optional(),
   write: z.enum(WRITE_MODES).optional(),
   toolMode: z.enum(TOOL_MODES).optional(),
+  toolCards: z.boolean().optional(),
   widgetDomain: textField(2048),
   tunnelName: textField(128),
   ngrokConfig: textField(4096),
@@ -100,6 +101,7 @@ interface ProfileFormValues {
   requireBashSession: boolean;
   write: "off" | "handoff" | "workspace";
   toolMode: "minimal" | "standard" | "full";
+  toolCards: boolean;
   widgetDomain: string;
   noInstallCloudflared: boolean;
 }
@@ -176,6 +178,7 @@ function profileValues(config: CodexProConfig, profile = readWorkspaceProfile(co
     requireBashSession: Boolean(profile.requireBashSession ?? config.requireBashSession),
     write,
     toolMode: oneOf(profile.toolMode ?? config.toolMode, TOOL_MODES, config.toolMode),
+    toolCards: Boolean(profile.toolCards ?? config.toolCards),
     widgetDomain: String(profile.widgetDomain ?? config.widgetDomain),
     noInstallCloudflared: Boolean(profile.noInstallCloudflared)
   };
@@ -300,6 +303,7 @@ function profileForm(config: CodexProConfig): string {
             <label><span>Codex directory</span><input name="codexDir" value="${escapeHtml(values.codexDir)}"></label>
             <label><span>Bash session</span><input name="bashSession" value="${escapeHtml(values.bashSession)}"></label>
           </div>
+          <label class="check-row"><input name="toolCards" type="checkbox" value="true"${values.toolCards ? " checked" : ""}><span>Enable ChatGPT tool cards</span></label>
           <label class="check-row"><input name="requireBashSession" type="checkbox" value="true"${values.requireBashSession ? " checked" : ""}><span>Require matching bash session id</span></label>
         </fieldset>
         <fieldset class="profile-group readonly-group">
@@ -361,6 +365,7 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
     ...(next.requireBashSession ? { requireBashSession: true } : {}),
     write,
     toolMode: next.toolMode,
+    toolCards: next.toolCards,
     ...(next.widgetDomain ? { widgetDomain: next.widgetDomain } : {}),
     ...(next.noInstallCloudflared ? { noInstallCloudflared: true } : {})
   };
@@ -384,6 +389,7 @@ function profileResponse(config: CodexProConfig): Record<string, unknown> {
       codexSessions: config.codexSessions,
       writeMode: config.writeMode,
       toolMode: config.toolMode,
+      toolCards: config.toolCards,
       widgetDomain: config.widgetDomain,
       authEnabled: Boolean(config.authToken)
     }
@@ -1372,6 +1378,7 @@ function onboardingPage(config: CodexProConfig): string {
           bash: data.bash,
           write: data.write,
           toolMode: data.toolMode,
+          toolCards: Boolean(form.elements.toolCards?.checked),
           codexSessions: data.codexSessions,
           codexDir: data.codexDir,
           bashSession: data.bashSession,

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -31,6 +31,7 @@ export interface WorkspaceProfile {
   requireBashSession?: boolean;
   write?: WriteMode | string;
   toolMode?: ToolMode | string;
+  toolCards?: boolean;
   widgetDomain?: string;
   noInstallCloudflared?: boolean;
 }
@@ -51,6 +52,7 @@ export interface RuntimeConnection {
   requireBashSession?: boolean;
   write?: WriteMode | string;
   toolMode?: ToolMode | string;
+  toolCards?: boolean;
 }
 
 export function codexProHome(): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -84,6 +84,20 @@ function toolCardMeta(): Record<string, unknown> {
   };
 }
 
+const OPTIONAL_TOOL_CARD_META = [
+  "ui",
+  "openai/outputTemplate",
+  "openai/toolInvocation/invoking",
+  "openai/toolInvocation/invoked"
+] as const;
+
+function descriptorOptionsForConfig(config: CodexProConfig, options: Record<string, unknown>): Record<string, unknown> {
+  if (config.toolCards) return options;
+  const meta = { ...((options._meta as Record<string, unknown> | undefined) ?? {}) };
+  for (const key of OPTIONAL_TOOL_CARD_META) delete meta[key];
+  return { ...options, _meta: meta };
+}
+
 function toolCallLoggingEnabled(): boolean {
   return process.env.CODEXPRO_LOG_TOOL_CALLS === "1" || process.env.CODEXPRO_LOG_REQUESTS === "1";
 }
@@ -315,7 +329,7 @@ function registerCodexTool(
   handler: (args: any) => Promise<any> | any
 ): void {
   if (!shouldRegisterTool(config, name)) return;
-  registerToolCompat(server, name, options, handler);
+  registerToolCompat(server, name, descriptorOptionsForConfig(config, options), handler);
   rememberRegisteredTool(server, name);
 }
 
@@ -647,6 +661,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         codexDir: config.codexDir,
         writeMode: config.writeMode,
         toolMode: config.toolMode,
+        toolCards: config.toolCards,
         inheritEnv: config.inheritEnv,
         contextDir: config.contextDir,
         maxReadBytes: config.maxReadBytes,


### PR DESCRIPTION
## Summary
- make CodexPro ChatGPT tool-card descriptor metadata opt-in with CODEXPRO_TOOL_CARDS=1
- strip widget/outputTemplate/toolInvocation metadata from default tools/list responses
- keep widget resources registered for stale ChatGPT card/resource requests
- add smoke coverage for default plain descriptors and explicit card opt-in

## Issue coverage
- Directly addresses #34 by making the stable no-widget/no-card descriptor mode the default.
- Also mitigates the widget fragility discussed in #13, but does not close #13 because its broader multi-account/session-selector discussion remains open.
- Does not address #33 or #35; those are separate feature requests.

## Verification
- node --check scripts/smoke.mjs
- node --check scripts/http-smoke.mjs
- git diff --check
- npm run build
- npm run smoke
- npm audit --audit-level=high
- npm pack --dry-run

I tested this locally. The remaining thing I want feedback on is real ChatGPT connector behavior after refreshing/reconnecting CodexPro, especially whether search discovery stops triggering stream errors and whether long sessions feel less laggy with cards off by default.

Refs #34