### PR TITLE
[codex] Make workspace skill discovery opt-in

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ Current testing shows free and Go accounts do not expose the app flow needed for
 
 CodexPro does not unlock Developer Mode, unlock models, bypass account limits, or provide account access. It connects to the ChatGPT app surface your account already has.
 
-Account access and model tool support are separate. A Plus or Pro account can have Apps / Developer Mode, while a specific model surface may still be unable to call connectors or MCP tools directly. Use the Pro context fallback for those sessions.
+Account access and model tool support are separate. A Plus or Pro account can have Apps / Developer Mode, while a specific model surface may still be unable to call connectors or MCP tools directly. OpenAI currently documents GPT-5.5 Pro as not supporting Apps, so use another tool-capable ChatGPT surface or the Pro context fallback for those sessions.
 
 ## How is CodexPro different from generic workspace bridges?
 
@@ -95,7 +95,7 @@ The useful part is that Codex and ChatGPT are different product surfaces. If one
 
 Only if your ChatGPT account already exposes that exact model, or a similar stronger model, in the ChatGPT web product surface you are using, and that model surface can call Developer Mode apps.
 
-Some stronger planning-model surfaces may not be able to call the CodexPro connector directly. CodexPro does not provide, proxy, resell, or unlock models. It gives compatible ChatGPT sessions local repo tools.
+OpenAI's current GPT-5.5 help page says Apps are not available with GPT-5.5 Pro. If that is the selected surface, CodexPro cannot make it call MCP tools. CodexPro does not provide, proxy, resell, or unlock models. It gives compatible ChatGPT sessions local repo tools.
 
 For models that cannot call tools, generate a repo context bundle instead:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ CodexPro is not a rate-limit bypass, model proxy, hosted SaaS, or OS sandbox. It
 
 If one workflow is unavailable and another product surface you already have access to is still available, CodexPro lets you keep working against the same local repo without modifying or evading either product's limits.
 
-If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some ChatGPT model surfaces may not be able to call connectors or MCP tools directly. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
+If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some ChatGPT model surfaces may not be able to call connectors or MCP tools directly. OpenAI's current GPT-5.5 help page says Apps are not available with GPT-5.5 Pro, so that model surface cannot use CodexPro tools. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
 
 ## CodexPro vs generic workspace bridges
 
@@ -143,7 +143,7 @@ One public tunnel option: Cloudflare quick tunnel, ngrok free dev domain, or Clo
 
 Current testing shows free / Go ChatGPT accounts do not expose the app flow needed for CodexPro. Use Plus or Pro for the best experience.
 
-Account tier and model tool support are separate things. Plus/Pro can expose Apps / Developer Mode, but a specific model surface may still be unable to call the connector. Use Pro context fallback for those sessions.
+Account tier and model tool support are separate things. Plus/Pro can expose Apps / Developer Mode, but a specific model surface may still be unable to call the connector. OpenAI currently documents GPT-5.5 Pro as not supporting Apps, so use another tool-capable ChatGPT surface or the Pro context fallback for those sessions.
 
 ## Status
 
@@ -169,7 +169,7 @@ Relevant OpenAI references: [ChatGPT Developer Mode](https://developers.openai.c
 
 CodexPro defaults to `CODEXPRO_TOOL_MODE=standard`, which keeps ChatGPT's tool picker focused on the normal coding loop plus handoff/export workflows. Use `--tool-mode minimal` for the tightest demo surface, or `--tool-mode full` when you want every compatibility and debugging tool exposed.
 
-The smaller default tool list is deliberate. ChatGPT behaves better when routine work goes through a few high-signal tools instead of a large action catalog. Installed user/plugin skills are still discovered during workspace open; they are surfaced as context in the workspace card and can be loaded on demand with `load_skill`, not exposed as dozens of separate ChatGPT actions.
+The smaller default tool list is deliberate. ChatGPT behaves better when routine work goes through a few high-signal tools instead of a large action catalog. Workspace open calls stay lean by default; use explicit skill discovery or `codexpro_inventory` when ChatGPT needs installed user/plugin skills, then load only the required skill with `load_skill`.
 
 Standard mode exposes:
 
@@ -710,13 +710,13 @@ For faster ChatGPT runs, keep the first call narrow:
 ```text
 Call open_current_workspace with include_tree=false unless you need the tree immediately.
 Use tree with max_depth=2 and max_entries=100 when you need file structure.
-Use load_skill only for the specific discovered skill needed for the task.
+Use open_current_workspace with include_skills=true only when skills are needed, then load_skill only for the specific discovered skill needed for the task.
 Use --tool-mode full and call codexpro_inventory only when you want ChatGPT to see full global skill and MCP server inventory.
 Do not call open_workspace after open_current_workspace unless you are switching to a different root.
 Use tree/search/read for inspection, one targeted search plus show_changes for review, and bash only for focused build/test/lint verification.
 ```
 
-`open_current_workspace` and `open_workspace` discover workspace, user, and plugin skills by default. Use `include_global_skills=false` when you only want repo-local instructions, or `include_skills=false` when you want the fastest possible open call. `load_skill` only accepts a discovered skill name plus optional source and exact displayed path, then reads that skill's `SKILL.md` with a bounded byte limit; it does not accept arbitrary file paths. If multiple discovered skills still match, CodexPro returns an ambiguity error instead of guessing. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
+`open_current_workspace` and `open_workspace` skip skill discovery by default for speed and ChatGPT web-client stability. Pass `include_skills=true` for repo-local skill discovery, and add `include_global_skills=true` only when user/plugin skill inventory is needed. `load_skill` only accepts a discovered skill name plus optional source and exact displayed path, then reads that skill's `SKILL.md` with a bounded byte limit; it does not accept arbitrary file paths. If multiple discovered skills still match, CodexPro returns an ambiguity error instead of guessing. `workspace_snapshot` stays narrower by default for speed. In `--tool-mode full`, use `codexpro_inventory` for global/user/plugin skills and MCP server names. `codexpro_inventory` reports names/descriptions and sanitized paths only; it does not expose MCP command arguments or environment values.
 
 ## Codex-style context
 

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -369,10 +369,35 @@ try {
     if (result.structuredContent.tool_mode !== 'full') {
       throw new Error(`open_current_workspace did not expose tool_mode: ${result.structuredContent.tool_mode}`);
     }
-    if (!result.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'http-smoke-skill')) {
-      throw new Error('HTTP open_current_workspace did not discover workspace skill inventory');
+    if (result.structuredContent.skill_inventory?.length) {
+      throw new Error('HTTP open_current_workspace discovered skills by default');
+    }
+    const withSkills = await callTool(client, 'open_current_workspace', {
+      include_tree: false,
+      include_skills: true
+    });
+    if (!withSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'http-smoke-skill')) {
+      throw new Error('HTTP open_current_workspace did not discover workspace skill inventory when requested');
     }
     return result.structuredContent.workspace_id;
+  });
+
+  await withClient(mcpUrl, async (client) => {
+    const result = await callTool(client, 'open_workspace', {
+      root,
+      include_tree: false
+    });
+    if (result.structuredContent.skill_inventory?.length) {
+      throw new Error('HTTP open_workspace discovered skills by default');
+    }
+    const withSkills = await callTool(client, 'open_workspace', {
+      root,
+      include_tree: false,
+      include_skills: true
+    });
+    if (!withSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'http-smoke-skill')) {
+      throw new Error('HTTP open_workspace did not discover workspace skill inventory when requested');
+    }
   });
 
   await withClient(mcpUrl, async (client) => {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -218,8 +218,12 @@ const realTmp = await fs.realpath(tmp);
 if (current.structuredContent.root !== realTmp) throw new Error(`open_current_workspace opened ${current.structuredContent.root}, expected ${realTmp}`);
 if (current.structuredContent.codexpro_tool !== 'open_current_workspace') throw new Error('tool result was not tagged for widget rendering');
 if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_current_workspace did not expose tool_mode: ${current.structuredContent.tool_mode}`);
-if (!current.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
-  throw new Error('open_current_workspace did not discover workspace skill inventory');
+if (current.structuredContent.skill_inventory?.length) {
+  throw new Error('open_current_workspace discovered skills by default');
+}
+const currentWithSkills = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false, include_skills: true } });
+if (!currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
+  throw new Error('open_current_workspace did not discover workspace skill inventory when requested');
 }
 const selfTest = await client.request('tools/call', {
   name: 'codexpro_self_test',

--- a/src/server.ts
+++ b/src/server.ts
@@ -1022,8 +1022,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         include_tree: z.boolean().optional().describe("Include a compact file tree. Default: false for speed."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth when include_tree=true. Default: 2."),
-        include_skills: z.boolean().optional().describe("Discover workspace, user, and plugin skills by name/description. Default: true."),
-        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: true.")
+        include_skills: z.boolean().optional().describe("Discover skills by name/description. Default: false for speed."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: false.")
       },
       annotations: SESSION_READ_ANNOTATIONS,
       _meta: {
@@ -1037,8 +1037,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const summary = await workspaceSummary(config, guard, workspace, {
         includeTree: parseBool(args.include_tree, false),
         maxDepth: limitInt(args.max_depth, 2, 1, 8),
-        includeSkills: parseBool(args.include_skills, true),
-        includeGlobalSkills: parseBool(args.include_global_skills, true),
+        includeSkills: parseBool(args.include_skills, false),
+        includeGlobalSkills: parseBool(args.include_global_skills, false),
         bootstrapContext: false
       });
       return textResult(summary.text, {
@@ -1065,15 +1065,15 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     {
       title: "Open Workspace",
       description:
-        "Open a local project directory as a CodexPro workspace. Returns a workspace_id plus git status, AGENTS.md, skills, and a compact file tree.",
+        "Open a local project directory as a CodexPro workspace. Returns a workspace_id plus git status, AGENTS.md, and a compact file tree.",
       inputSchema: {
         root: z.string().optional().describe("Project directory to open. Omit to use CODEXPRO_ROOT/current working directory. Supports ~/ paths."),
         path: z.string().optional().describe("Alias for root. Useful for clients that naturally send path instead of root."),
         include_tree: z.boolean().optional().describe("Include a compact file tree. Default: true."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth. Default: 3."),
         max_files: z.number().int().min(1).max(3000).optional().describe("Alias for maximum tree entries. Default: 500."),
-        include_skills: z.boolean().optional().describe("Discover workspace, user, and plugin skills by name/description. Default: true."),
-        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: true."),
+        include_skills: z.boolean().optional().describe("Discover skills by name/description. Default: false for speed."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills when include_skills=true. Default: false."),
         bootstrap_context: z.boolean().optional().describe("Deprecated and ignored. Use handoff_to_agent to create .ai-bridge files.")
       },
       annotations: SESSION_READ_ANNOTATIONS,
@@ -1092,8 +1092,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         includeTree: args.include_tree !== false,
         maxDepth: limitInt(args.max_depth, 3, 1, 8),
         maxEntries: limitInt(args.max_files, 500, 1, 3000),
-        includeSkills: parseBool(args.include_skills, true),
-        includeGlobalSkills: parseBool(args.include_global_skills, true),
+        includeSkills: parseBool(args.include_skills, false),
+        includeGlobalSkills: parseBool(args.include_global_skills, false),
         bootstrapContext: false
       });
       return textResult(summary.text, {


### PR DESCRIPTION
## Summary

- Make `open_current_workspace` and `open_workspace` skip skill discovery by default.
- Keep skill discovery available through explicit `include_skills=true` and `include_global_skills=true`.
- Update README/FAQ wording for the GPT-5.5 Pro Apps/MCP limitation.
- Add smoke coverage for default-no-skills and explicit skill discovery.

## Why

Issue #38 narrowed the broad "unusable" report into two separate layers:

1. CodexPro works when workspace opening avoids the large global skill inventory.
2. GPT-5.5 Pro / Pro-only model surfaces may not expose Apps/MCP tool calls at all, which CodexPro cannot fix from the local server.

The skill payload problem is fixable locally. Sending roughly 120 skill names/descriptions/paths during the first workspace-open call can destabilize ChatGPT Web before useful tool work starts. Workspace open should stay lean, and skill inventory should be requested only when needed.

The Pro model limitation is not fixed by this PR. OpenAI's current GPT-5.5 help page says Apps are not available with GPT-5.5 Pro. CodexPro can only serve MCP tools after ChatGPT exposes the app actions to that chat/model surface.

## Validation

- `npm run build`
- `npm run smoke`
- Direct MCP probe:
  - default `open_current_workspace({ include_tree: false })` returned `skill_inventory.length === 0`
  - explicit `open_current_workspace({ include_tree: false, include_skills: true, include_global_skills: true })` returned `skill_inventory.length === 120`

Refs #38.
