### PR TITLE
[codex] Harden CodexPro safety and stress coverage

### DIFF
--- a/CHATGPT_PROMPT.md
+++ b/CHATGPT_PROMPT.md
@@ -3,9 +3,10 @@ Use CodexPro.
 Call server_config first, then open_current_workspace with include_tree=false.
 Do not call open_workspace after open_current_workspace unless I ask you to switch roots.
 Call codexpro_inventory only when you need local skill or MCP server names.
+Use the codexpro supertool only when a stable action wrapper is needed; call it with action=list_actions first.
 
-Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and git_diff or git_status when useful.
+Act as a coding agent. Inspect the relevant files, make the requested source edits with write/edit, then verify with search/read/bash and show_changes when useful. Use git_status/git_diff only when CodexPro was started with --tool-mode full.
 
-Keep changes scoped to the request. Do not use handoff_to_codex unless I explicitly ask for planning-only handoff.
+Keep changes scoped to the request. Do not use handoff_to_agent or handoff_to_codex unless I explicitly ask for planning-only handoff.
 
 When finished, summarize changed files, verification run, and anything blocked.

--- a/CODEX_PROMPT.md
+++ b/CODEX_PROMPT.md
@@ -1,6 +1,6 @@
 Read .ai-bridge/current-plan.md and execute it in small, reviewable steps.
 
-After each meaningful change, update .ai-bridge/codex-status.md with:
+After each meaningful change, update .ai-bridge/agent-status.md with:
 
 - what changed
 - files touched

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ Current testing shows free and Go accounts do not expose the app flow needed for
 
 CodexPro does not unlock Developer Mode, unlock models, bypass account limits, or provide account access. It connects to the ChatGPT app surface your account already has.
 
-Account access and model tool support are separate. A Plus or Pro account can have Apps / Developer Mode, while a specific model surface may still be unable to call connectors or MCP tools directly. OpenAI currently documents GPT-5.5 Pro as not supporting Apps, so use another tool-capable ChatGPT surface or the Pro context fallback for those sessions.
+Account access and model tool support are separate. A Plus or Pro account can have Apps / Developer Mode, while a specific model surface may still be unable to call connectors or MCP tools directly. If CodexPro actions are unavailable in that chat, use another tool-capable ChatGPT surface or the Pro context fallback for that session.
 
 ## How is CodexPro different from generic workspace bridges?
 
@@ -29,6 +29,18 @@ The main differences are:
 - CodexPro keeps a strict boundary: no model proxying, account pooling, third-party Pro site scraping, quota bypassing, or OS sandbox claims.
 
 Short version: other tools may share the bridge idea; CodexPro is the cleaner ChatGPT-to-local-repo coding agent workflow with stricter defaults and clearer review surfaces.
+
+## What is the `codexpro` supertool?
+
+`codexpro` is a stable wrapper tool for advanced setups. It accepts:
+
+```json
+{ "action": "search", "args": { "query": "needle", "path": "src" } }
+```
+
+Call it with `action=list_actions` to see what the current server mode actually allows. It cannot call tools that are hidden by `--tool-mode`, `--no-bash`, or non-workspace write mode.
+
+Use explicit tools such as `read`, `search`, `edit`, `bash`, and `show_changes` for normal work. Use the supertool when ChatGPT connector caching, custom workflows, or stable wrapper-style integrations matter more than separate visible tool descriptors.
 
 ## What is the recommended install path?
 
@@ -95,7 +107,7 @@ The useful part is that Codex and ChatGPT are different product surfaces. If one
 
 Only if your ChatGPT account already exposes that exact model, or a similar stronger model, in the ChatGPT web product surface you are using, and that model surface can call Developer Mode apps.
 
-OpenAI's current GPT-5.5 help page says Apps are not available with GPT-5.5 Pro. If that is the selected surface, CodexPro cannot make it call MCP tools. CodexPro does not provide, proxy, resell, or unlock models. It gives compatible ChatGPT sessions local repo tools.
+Some GPT-5.5 Pro or other model surfaces may not expose app actions in a given chat. If CodexPro actions are unavailable there, CodexPro cannot make that request reach the local server. CodexPro does not provide, proxy, resell, or unlock models. It gives compatible ChatGPT sessions local repo tools.
 
 For models that cannot call tools, generate a repo context bundle instead:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ CodexPro is not a rate-limit bypass, model proxy, hosted SaaS, or OS sandbox. It
 | Fast first setup | `npm install -g codexpro`, then `codexpro setup` |
 | Daily start | `codexpro start` from the same repo |
 | Stable ChatGPT URL | ngrok free dev domain or Cloudflare named tunnel |
-| Smallest tool surface | default `CODEXPRO_TOOL_MODE=standard` |
+| Default tool surface | `CODEXPRO_TOOL_MODE=standard` |
 | Full diagnostics | `codexpro start --tool-mode full` |
 | No ChatGPT-triggered shell | `codexpro start --no-bash` |
 | Compact chat transcript | default bash cards; use `--bash-transcript full` only when needed |
@@ -96,7 +96,7 @@ CodexPro is not a rate-limit bypass, model proxy, hosted SaaS, or OS sandbox. It
 
 If one workflow is unavailable and another product surface you already have access to is still available, CodexPro lets you keep working against the same local repo without modifying or evading either product's limits.
 
-If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some ChatGPT model surfaces may not be able to call connectors or MCP tools directly. OpenAI's current GPT-5.5 help page says Apps are not available with GPT-5.5 Pro, so that model surface cannot use CodexPro tools. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
+If your ChatGPT account exposes a stronger model in the web app, and that model/surface can call Developer Mode apps, CodexPro lets it work against your local repo through MCP. Some GPT-5.5 Pro or other model surfaces may not expose app actions in a given chat. If CodexPro actions are unavailable there, CodexPro cannot make that request reach the local server. Use a tool-capable ChatGPT surface or the Pro context fallback instead. CodexPro does not provide, proxy, resell, or unlock models; it gives compatible ChatGPT sessions local coding tools and repo context.
 
 ## CodexPro vs generic workspace bridges
 
@@ -143,7 +143,7 @@ One public tunnel option: Cloudflare quick tunnel, ngrok free dev domain, or Clo
 
 Current testing shows free / Go ChatGPT accounts do not expose the app flow needed for CodexPro. Use Plus or Pro for the best experience.
 
-Account tier and model tool support are separate things. Plus/Pro can expose Apps / Developer Mode, but a specific model surface may still be unable to call the connector. OpenAI currently documents GPT-5.5 Pro as not supporting Apps, so use another tool-capable ChatGPT surface or the Pro context fallback for those sessions.
+Account tier and model tool support are separate things. Plus/Pro can expose Apps / Developer Mode, but a specific model surface may still be unable to call the connector. If CodexPro actions are unavailable in that chat, use another tool-capable ChatGPT surface or the Pro context fallback for that session.
 
 ## Status
 
@@ -171,8 +171,11 @@ CodexPro defaults to `CODEXPRO_TOOL_MODE=standard`, which keeps ChatGPT's tool p
 
 The smaller default tool list is deliberate. ChatGPT behaves better when routine work goes through a few high-signal tools instead of a large action catalog. Workspace open calls stay lean by default; use explicit skill discovery or `codexpro_inventory` when ChatGPT needs installed user/plugin skills, then load only the required skill with `load_skill`.
 
+CodexPro also exposes one stable wrapper tool named `codexpro`. It accepts `action` plus `args` and can call only tools already registered by the current tool/write/bash mode. Use it for advanced connector-cache or custom workflow cases where a stable visible schema matters. The explicit tools below remain the preferred default because they give ChatGPT clearer descriptions and validation.
+
 Standard mode exposes:
 
+- `codexpro` — stable supertool wrapper for already-registered actions; call with `action=list_actions` to see what the current mode allows.
 - `server_config` — show safety modes, limits, blocked globs, and allowed roots.
 - `codexpro_self_test` — run one local-only diagnostic for modes, expected tools, safe bash policy, `.ai-bridge` write/edit, and selected-only Pro context.
 - `open_current_workspace` — open the configured default workspace without accepting a path. Fastest/safest first call.
@@ -186,12 +189,14 @@ Standard mode exposes:
 - `bash` — run allowlisted shell commands in the workspace. Hidden when `CODEXPRO_BASH_MODE=off`.
 - `show_changes` — one review-oriented summary with git status, diff stats, and optional diff.
 - `read_handoff` — read `.ai-bridge` files.
+- `wait_for_handoff` — read-only polling of `.ai-bridge/handoff-run-state.json` after a local executor run.
 - `export_pro_context` — write `.ai-bridge/pro-context.md` for models that cannot call MCP tools directly.
 - `handoff_to_agent` — write `.ai-bridge/current-plan.md` for Codex, OpenCode, Pi, or a custom local implementation agent without executing local commands.
 
 Minimal mode exposes only:
 
 ```text
+codexpro
 server_config
 codexpro_self_test
 open_current_workspace / open_workspace
@@ -248,6 +253,7 @@ The watcher writes the same review files as `execute-handoff`:
 .ai-bridge/agent-status.md
 .ai-bridge/implementation-diff.patch
 .ai-bridge/execution-log.jsonl
+.ai-bridge/handoff-run-state.json
 ```
 
 For autonomous local handoff loops, use `loop-handoff` with an explicit reviewer command:
@@ -617,6 +623,7 @@ In handoff mode, ChatGPT can create a plan for a local implementation agent with
 .ai-bridge/agent-status.md
 .ai-bridge/implementation-diff.patch
 .ai-bridge/execution-log.jsonl
+.ai-bridge/handoff-run-state.json
 ```
 
 Then run the implementation locally with `codexpro execute-handoff`:
@@ -712,6 +719,7 @@ Call open_current_workspace with include_tree=false unless you need the tree imm
 Use tree with max_depth=2 and max_entries=100 when you need file structure.
 Use open_current_workspace with include_skills=true only when skills are needed, then load_skill only for the specific discovered skill needed for the task.
 Use --tool-mode full and call codexpro_inventory only when you want ChatGPT to see full global skill and MCP server inventory.
+Use the codexpro supertool only when a stable action wrapper helps with ChatGPT connector cache or custom workflow issues; call action=list_actions first.
 Do not call open_workspace after open_current_workspace unless you are switching to a different root.
 Use tree/search/read for inspection, one targeted search plus show_changes for review, and bash only for focused build/test/lint verification.
 ```
@@ -1115,7 +1123,7 @@ The launcher defaults to `workspace` in normal coding mode and `handoff` in hand
 `CODEXPRO_TOOL_MODE=standard` is the default. It exposes the normal coding loop plus `show_changes`, Pro context export, and generic agent handoff.
 
 ```text
-minimal   smallest surface for demos and simple coding: open/read/write/edit/bash/show_changes, with write/bash removed when their modes are disabled
+minimal   codexpro supertool plus config/self-test/open/read/write/edit/bash/show_changes, with write/bash removed when disabled
 standard  default surface for normal coding plus handoff/export, with write/edit only in workspace write mode
 full      all tools, including inventory, workspace snapshots, raw git tools, codex_context, and compatibility wrappers
 ```
@@ -1139,6 +1147,8 @@ pytest, go test, cargo test, cargo check, cargo clippy, tsc, eslint, biome check
 ```
 
 Use the MCP `read` and `search` tools for file contents. The safe shell blocks obvious destructive commands, redirects, pipes, `curl`, `wget`, `ssh`, `docker`, `git push/reset/clean/checkout/switch/restore`, `find -exec`, `find -delete`, and file-content shell readers such as `cat`, `grep`, `rg`, `head`, and `tail`.
+
+Package-manager scripts such as `npm run build` execute code from the repo. Use `--no-bash` for untrusted repos.
 
 `CODEXPRO_BASH_MODE=off` disables bash completely and removes the `bash` MCP tool from the advertised tool list. `codexpro start --no-bash` is the CLI shortcut for the same setting.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ Review changes against these failure modes before release:
 | Public tunnel reachable without a secret | Public/non-loopback HTTP fails closed unless a CodexPro token is configured. |
 | Raw CodexPro or Cloudflare token appears in UI, logs, docs, or package output | Tokens are redacted in profile/status output and tunnel tokens use local files for persistence. |
 | ChatGPT can edit outside the intended repo | Allowed roots are explicit; path resolution rejects escapes, blocked globs, and symlink traversal. |
-| ChatGPT can run arbitrary shell by default | Bash defaults to safe mode, can be disabled, and full mode is a trusted-local-only choice. |
+| ChatGPT can run arbitrary shell by default | Bash defaults to safe mode, can be disabled, and full mode is a trusted-local-only choice. Safe mode can still run repo package scripts, so use `--no-bash` for untrusted repos. |
 | Handoff mode still exposes generic writes | Handoff/pro modes do not advertise generic `write`/`edit`; bounded handoff tools write `.ai-bridge` files only. |
 | Local Codex history is treated as ChatGPT memory | Codex session access is opt-in metadata/read mode and never attaches to a live Codex app session. |
 | Browser admin mutates live runtime unexpectedly | Admin profile changes apply on restart; active runtime policy stays stable for the current session. |

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
     "smoke": "node scripts/smoke.mjs && node scripts/http-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs",
+    "stress": "npm run build && node scripts/stress.mjs",
     "doctor": "node scripts/codexpro.mjs doctor",
     "connect": "node scripts/codexpro.mjs",
     "connect:setup": "node scripts/codexpro.mjs setup",

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -13,6 +13,14 @@ const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '
 const UNTRACKED_FILE_HASH_BYTES = 64 * 1024;
 const UNTRACKED_SYMLINK_TARGET_BYTES = 512;
 
+function packageVersion() {
+  return JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')).version;
+}
+
+function isLoopbackHost(host) {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
 function usage() {
   console.log(`CodexPro easy launcher
 
@@ -67,7 +75,7 @@ Options:
                              handoff = no generic write/edit tools; handoff tools write bounded .ai-bridge files.
   --tool-mode <minimal|standard|full>
                              Tool surface exposed to ChatGPT. Default: standard.
-                             minimal = open/read/write/edit/bash/show_changes only.
+                             minimal = config/self-test plus open/read/write/edit/bash/show_changes.
                              full = expose every compatibility and advanced tool.
   --widget-domain <origin>   Dedicated HTTPS origin for ChatGPT widget iframes.
                              Required for app submission. Default: https://rebel0789.github.io.
@@ -101,6 +109,7 @@ Options:
   --no-auth                 Disable bearer-token auth. Only allowed with --tunnel none.
   --log-requests            Print redacted HTTP request and tool-call logs from the local MCP server.
   --print-env               Print the environment used to launch the server.
+  --version, -v             Print the CodexPro version.
   --help                    Show this message.
 
 Execute handoff options:
@@ -1064,10 +1073,24 @@ function shellCommandPreview(parts) {
 function redactForLog(value) {
   return String(value)
     .replace(/\bsk-[A-Za-z0-9_-]{10,}\b/g, '[REDACTED_SECRET]')
-    .replace(/\b[A-Za-z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]*\s*=\s*(?:"[^"\r\n]{12,}"|'[^'\r\n]{12,}'|`[^`\r\n]{12,}`|[A-Za-z0-9_./+=-]{20,})/gi, (match) => {
+    .replace(/\b(?:sk-ant-[A-Za-z0-9_-]{10,}|gh[opsru]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{20,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED_SECRET]')
+    .replace(/([?&](?:codexpro_token|token|access_token|auth_token|api[_-]?key)=)[^&\s"'`<>]{8,}/gi, '$1[REDACTED_SECRET]')
+    .replace(/(["']?[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}["']?\s*:\s*)(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi, '$1[REDACTED_SECRET]')
+    .replace(/\b[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}\s*=\s*(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi, (match) => {
       const index = match.indexOf('=');
       return index < 0 ? '[REDACTED_SECRET]' : `${match.slice(0, index).trimEnd()}= [REDACTED_SECRET]`;
     });
+}
+
+function redactEnvObject(env) {
+  const out = {};
+  for (const [key, value] of Object.entries(env)) {
+    out[key] = /(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)/i.test(key)
+      ? '<redacted>'
+      : redactForLog(String(value));
+  }
+  return out;
 }
 
 function trimBytes(value, maxBytes) {
@@ -3204,6 +3227,10 @@ function runControlPanel(details) {
 
 async function main() {
   let argv = process.argv.slice(2);
+  if (argv[0] === '--version' || argv[0] === '-v' || argv[0] === 'version') {
+    console.log(packageVersion());
+    return;
+  }
   let subcommand = argv[0];
   if (subcommand === 'stable-help') {
     printStableUrlHelp();
@@ -3264,6 +3291,10 @@ async function main() {
     argv.unshift('--tunnel', 'ngrok');
   }
   if (argv[0] === 'start' || argv[0] === 'connect') argv.shift();
+  if (argv[0] === '--version' || argv[0] === '-v' || argv[0] === 'version') {
+    console.log(packageVersion());
+    return;
+  }
   if (argv[0] === 'help') argv[0] = '--help';
   const args = parseArgs(argv);
   if (args.help) {
@@ -3299,9 +3330,6 @@ async function main() {
   if (tunnel === 'ngrok' && !stableHostname) {
     throw new Error('--hostname is required with ngrok tunnel mode. Example: codexpro ngrok --hostname your-domain.ngrok-free.dev');
   }
-  if (args.noAuth && tunnel !== 'none') {
-    throw new Error('--no-auth is only allowed with --tunnel none. Public tunnels require CODEXPRO_HTTP_TOKEN.');
-  }
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], 'agent');
   if (!['agent', 'handoff', 'pro'].includes(mode)) {
     throw new Error('--mode must be agent, handoff, or pro');
@@ -3309,6 +3337,9 @@ async function main() {
 
   const allowRoots = [root, ...(args.allowRoots ?? [])].map(realDir);
   const host = optionValue(args, profile, 'host', ['CODEXPRO_HOST'], '127.0.0.1');
+  if (args.noAuth && (tunnel !== 'none' || !isLoopbackHost(host))) {
+    throw new Error('--no-auth is only allowed with --tunnel none on a loopback host.');
+  }
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
   const bashTranscript = bashTranscriptOption(args, profile);
@@ -3324,7 +3355,7 @@ async function main() {
   if (!['minimal', 'standard', 'full'].includes(toolMode)) throw new Error('--tool-mode must be minimal, standard, or full');
 
   let token = args.noAuth ? '' : optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], '');
-  if (!token && tunnel !== 'none') token = stableToken();
+  if (!token && !args.noAuth) token = stableToken();
 
   const serverEnv = {
     ...process.env,
@@ -3342,7 +3373,8 @@ async function main() {
     CODEXPRO_WIDGET_DOMAIN: widgetDomain,
     CODEXPRO_TOOL_CARDS: toolCards ? '1' : '0',
     CODEXPRO_MODE: mode,
-    CODEXPRO_TUNNEL_MODE: tunnel === 'none' ? '0' : '1'
+    CODEXPRO_TUNNEL_MODE: tunnel === 'none' ? '0' : '1',
+    CODEXPRO_ALLOW_NO_HTTP_TOKEN: args.noAuth ? '1' : '0'
   };
   if (codexDir) serverEnv.CODEXPRO_CODEX_DIR = codexDir;
   if (args.logRequests || process.env.CODEXPRO_LOG_REQUESTS === '1') serverEnv.CODEXPRO_LOG_REQUESTS = '1';
@@ -3351,7 +3383,7 @@ async function main() {
   else delete serverEnv.CODEXPRO_HTTP_TOKEN;
 
   if (args.printEnv) {
-    console.log(JSON.stringify({ ...serverEnv, CODEXPRO_HTTP_TOKEN: token ? '<redacted>' : undefined }, null, 2));
+    console.log(JSON.stringify(redactEnvObject(serverEnv), null, 2));
   }
 
   const httpPath = path.join(projectRoot, 'dist', 'http.js');

--- a/scripts/doctor-smoke.mjs
+++ b/scripts/doctor-smoke.mjs
@@ -19,6 +19,17 @@ async function getFreePort() {
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-doctor-smoke-'));
 const home = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-doctor-home-'));
 const port = await getFreePort();
+const packageJson = JSON.parse(await fs.readFile(path.resolve('package.json'), 'utf8'));
+for (const args of [['--version'], ['-v'], ['version'], ['start', '--version']]) {
+  const version = spawnSync(process.execPath, ['scripts/codexpro.mjs', ...args], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, CODEXPRO_HOME: home },
+    encoding: 'utf8'
+  });
+  if (version.status !== 0 || version.stdout.trim() !== packageJson.version) {
+    throw new Error(`codexpro ${args.join(' ')} did not print version ${packageJson.version}\nstdout:\n${version.stdout}\nstderr:\n${version.stderr}`);
+  }
+}
 const result = spawnSync(process.execPath, [
   'scripts/codexpro.mjs',
   'doctor',

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -132,6 +132,7 @@ function hasToolCardStatusMeta(tools, name) {
   return Boolean(meta['openai/toolInvocation/invoking'] || meta['openai/toolInvocation/invoked']);
 }
 
+await expectHttpTokenRequired('loopback-default');
 await expectHttpTokenRequired('non-loopback', { CODEXPRO_HOST: '0.0.0.0' });
 await expectHttpTokenRequired('tunnel-mode', { CODEXPRO_TUNNEL_MODE: '1' });
 
@@ -306,7 +307,7 @@ try {
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);
   const queryToolNames = toolNames(queryTools);
-  for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'load_skill', 'show_changes', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+  for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'tree', 'search', 'load_skill', 'git_status', 'git_diff', 'show_changes', 'read_handoff', 'wait_for_handoff', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
     if (!queryToolNames.includes(expected)) {
       throw new Error(`URL-token MCP tools/list missing ${expected}; got ${queryToolNames.join(', ')}`);
     }
@@ -512,6 +513,30 @@ try {
 const cliRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-cli-http-smoke-'));
 await fs.mkdir(path.join(cliRoot, '.codex'), { recursive: true });
 const cliPort = await getFreePort();
+const badNoAuth = spawn(process.execPath, [
+  'scripts/codexpro.mjs',
+  'start',
+  '--root',
+  cliRoot,
+  '--tunnel',
+  'none',
+  '--no-auth',
+  '--host',
+  '0.0.0.0',
+  '--port',
+  String(cliPort)
+], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_HOME: await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-cli-http-bad-home-'))
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+const badNoAuthExit = await waitForExit(badNoAuth);
+if (badNoAuthExit.code === 0 || !badNoAuthExit.stderr.includes('--no-auth is only allowed')) {
+  throw new Error(`non-loopback --no-auth was not rejected\n${badNoAuthExit.stderr}`);
+}
 const cliChild = spawn(process.execPath, [
   'scripts/codexpro.mjs',
   'start',

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -186,6 +186,14 @@ const cardSearchMeta = cardTools.tools.find((tool) => tool.name === 'search')?._
 if (cardSearchMeta.ui?.resourceUri !== toolCardUri || cardSearchMeta['openai/outputTemplate'] !== toolCardUri) {
   throw new Error('CODEXPRO_TOOL_CARDS=1 did not opt search into widget metadata');
 }
+const cardOpened = await cardClient.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+const cardSearch = await cardClient.request('tools/call', {
+  name: 'search',
+  arguments: { workspace_id: cardOpened.structuredContent.workspace_id, query: 'read', path: 'demo.txt', max_results: 5 }
+});
+if (!cardSearch.structuredContent.text?.includes('read')) {
+  throw new Error(`CODEXPRO_TOOL_CARDS=1 search did not include structured text: ${JSON.stringify(cardSearch.structuredContent)}`);
+}
 await cardClient.close();
 const resources = await client.request('resources/list', {});
 const toolCard = resources.resources.find((resource) => resource.uri === toolCardUri);
@@ -275,12 +283,25 @@ if (openedByPath.structuredContent.workspace_id !== ws) {
   throw new Error(`open_workspace path alias returned ${openedByPath.structuredContent.workspace_id}, expected ${ws}`);
 }
 await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'demo.txt' } });
+await fs.writeFile(path.join(tmp, 'tokens.txt'), [
+  'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456',
+  'https://example.test/mcp?codexpro_token=verysecretcodexprotoken123&x=1',
+  'ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz123456',
+  '"api_key": "jsonsecretvalueabcdefghijklmnop"',
+  'service_token: yamlsecretvalueabcdefghijklmnop'
+].join('\n'), 'utf8');
 const secretRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'config.txt' } });
 const secretPayload = JSON.stringify(secretRead);
 if (secretPayload.includes('sk-realSecretValue123') || !secretPayload.includes('[REDACTED_SECRET]')) {
   throw new Error('read did not redact secret-looking content');
 }
+const tokenRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'tokens.txt' } });
+const tokenPayload = JSON.stringify(tokenRead);
+for (const leaked of ['ghp_abcdefghijklmnopqrstuvwxyz123456', 'verysecretcodexprotoken123', 'sk-ant-abcdefghijklmnopqrstuvwxyz123456', 'jsonsecretvalueabcdefghijklmnop', 'yamlsecretvalueabcdefghijklmnop']) {
+  if (tokenPayload.includes(leaked)) throw new Error(`read leaked token-like content: ${leaked}`);
+}
 await expectToolError('write', { workspace_id: ws, path: 'notes.md', content: 'OPENAI_API_KEY=sk-realSecretValue123\n' }, /Secret-looking content is blocked/);
+await expectToolError('write', { workspace_id: ws, path: 'notes.yaml', content: 'api_key: yamlsecretvalueabcdefghijklmnop\n' }, /Secret-looking content is blocked/);
 await client.request('tools/call', {
   name: 'write',
   arguments: {
@@ -341,7 +362,22 @@ if (!clientBuild.structuredContent.stdout?.includes('clients ok')) {
 }
 const exported = await client.request('tools/call', { name: 'export_pro_context', arguments: { workspace_id: ws, selected_paths: ['demo.txt'], max_files: 4, max_total_bytes: 80000 } });
 if (exported.structuredContent.path !== '.ai-bridge/pro-context.md') throw new Error('export_pro_context wrote an unexpected path');
+if (!exported.structuredContent.files_included?.includes('demo.txt')) {
+  throw new Error(`export_pro_context dropped an explicit selected path: ${JSON.stringify(exported.structuredContent.files_included)}`);
+}
 await fs.stat(path.join(tmp, '.ai-bridge', 'pro-context.md'));
+const oneFileExport = await client.request('tools/call', {
+  name: 'export_pro_context',
+  arguments: {
+    workspace_id: ws,
+    selected_paths: ['demo.txt'],
+    max_files: 1,
+    max_total_bytes: 80000
+  }
+});
+if (JSON.stringify(oneFileExport.structuredContent.files_included) !== JSON.stringify(['demo.txt'])) {
+  throw new Error(`export_pro_context did not prioritize selected path with max_files=1: ${JSON.stringify(oneFileExport.structuredContent.files_included)}`);
+}
 const exactExport = await client.request('tools/call', {
   name: 'export_pro_context',
   arguments: {
@@ -428,6 +464,9 @@ const waitCompleted = await client.request('tools/call', {
 if (waitCompleted.structuredContent.awaited_completed !== true || waitCompleted.structuredContent.state !== 'completed') {
   throw new Error(`wait_for_handoff did not report completion: ${JSON.stringify(waitCompleted.structuredContent)}`);
 }
+if (waitCompleted.structuredContent.awaited_terminal !== true || waitCompleted.structuredContent.succeeded !== true) {
+  throw new Error(`wait_for_handoff did not report terminal success fields: ${JSON.stringify(waitCompleted.structuredContent)}`);
+}
 if (waitCompleted.structuredContent.exit_code !== 0 || waitCompleted.structuredContent.status_file !== '.ai-bridge/agent-status.md') {
   throw new Error(`wait_for_handoff missing completion fields: ${JSON.stringify(waitCompleted.structuredContent)}`);
 }
@@ -437,6 +476,39 @@ const waitMismatch = await client.request('tools/call', {
 });
 if (waitMismatch.structuredContent.awaited_completed !== false || waitMismatch.structuredContent.state !== 'running' || waitMismatch.structuredContent.plan_hash_mismatch !== true) {
   throw new Error(`wait_for_handoff did not keep waiting on plan-hash mismatch: ${JSON.stringify(waitMismatch.structuredContent)}`);
+}
+await fs.writeFile(path.join(tmp, '.ai-bridge', 'handoff-run-state.json'), `${JSON.stringify({
+  ...runStatePayload,
+  state: 'failed',
+  plan_hash: 'failed-plan',
+  exit_code: 2,
+  status_file: 'demo.txt',
+  diff_file: '../demo.txt',
+  log_file: '.ai-bridge/execution-log.jsonl'
+}, null, 2)}\n`, 'utf8');
+const waitFailed = await client.request('tools/call', {
+  name: 'wait_for_handoff',
+  arguments: { workspace_id: ws, max_wait_seconds: 1, poll_ms: 250, plan_hash: 'failed-plan' }
+});
+if (waitFailed.structuredContent.awaited_terminal !== true || waitFailed.structuredContent.succeeded !== false || waitFailed.structuredContent.state !== 'failed') {
+  throw new Error(`wait_for_handoff did not report failed terminal state: ${JSON.stringify(waitFailed.structuredContent)}`);
+}
+if (waitFailed.structuredContent.status_file !== '.ai-bridge/agent-status.md' || waitFailed.structuredContent.diff_file !== '.ai-bridge/implementation-diff.patch') {
+  throw new Error(`wait_for_handoff trusted forged artifact paths: ${JSON.stringify(waitFailed.structuredContent)}`);
+}
+await fs.writeFile(path.join(tmp, '.ai-bridge', 'handoff-run-state.json'), `${JSON.stringify({
+  ...runStatePayload,
+  state: 'timed_out',
+  plan_hash: 'timed-out-plan',
+  exit_code: null,
+  timed_out: true
+}, null, 2)}\n`, 'utf8');
+const waitTimedOut = await client.request('tools/call', {
+  name: 'wait_for_handoff',
+  arguments: { workspace_id: ws, max_wait_seconds: 1, poll_ms: 250, plan_hash: 'timed-out-plan' }
+});
+if (waitTimedOut.structuredContent.awaited_terminal !== true || waitTimedOut.structuredContent.succeeded !== false || waitTimedOut.structuredContent.state !== 'timed_out') {
+  throw new Error(`wait_for_handoff did not report timed-out terminal state: ${JSON.stringify(waitTimedOut.structuredContent)}`);
 }
 await fs.rm(path.join(tmp, '.ai-bridge', 'handoff-run-state.json'), { force: true });
 await client.request('tools/call', { name: 'handoff_to_codex', arguments: { workspace_id: ws, title: 'Smoke Codex plan', plan: '- Verify demo.txt contains write.', append: true } });

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -1,0 +1,317 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+function assert(ok, message) {
+  if (!ok) throw new Error(message);
+}
+
+class McpStdioClient {
+  constructor(root, env = {}) {
+    this.child = spawn('node', ['dist/stdio.js'], {
+      cwd: path.resolve('.'),
+      env: {
+        ...process.env,
+        ...env,
+        CODEXPRO_ROOT: root,
+        CODEXPRO_ALLOWED_ROOTS: root,
+        CODEXPRO_TOOL_MODE: env.CODEXPRO_TOOL_MODE ?? 'full',
+        CODEXPRO_BASH_MODE: env.CODEXPRO_BASH_MODE ?? 'safe',
+        CODEXPRO_MAX_SEARCH_RESULTS: '2000',
+        CODEXPRO_MAX_OUTPUT_BYTES: '2000000',
+        CODEXPRO_TOOL_CARDS: env.CODEXPRO_TOOL_CARDS ?? '0'
+      }
+    });
+    this.buffer = '';
+    this.stderr = '';
+    this.nextId = 1;
+    this.pending = new Map();
+    this.child.stdout.on('data', (chunk) => this.onData(String(chunk)));
+    this.child.stderr.on('data', (chunk) => {
+      this.stderr += String(chunk);
+    });
+    this.child.on('exit', (code) => {
+      for (const { reject } of this.pending.values()) reject(new Error(`server exited ${code}\n${this.stderr}`));
+      this.pending.clear();
+    });
+  }
+
+  onData(chunk) {
+    this.buffer += chunk;
+    while (true) {
+      const index = this.buffer.indexOf('\n');
+      if (index < 0) return;
+      const line = this.buffer.slice(0, index).replace(/\r$/, '');
+      this.buffer = this.buffer.slice(index + 1);
+      if (!line.trim()) continue;
+      const msg = JSON.parse(line);
+      if (!msg.id || !this.pending.has(msg.id)) continue;
+      const { resolve, reject, timer } = this.pending.get(msg.id);
+      clearTimeout(timer);
+      this.pending.delete(msg.id);
+      if (msg.error) reject(new Error(msg.error.message));
+      else resolve(msg.result);
+    }
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timeout waiting for ${method}\n${this.stderr}`)), 20000);
+      timer.unref();
+      this.pending.set(id, { resolve, reject, timer });
+    });
+  }
+
+  notify(method, params = {}) {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+  }
+
+  close() {
+    this.child.kill('SIGTERM');
+  }
+}
+
+async function initClient(root, env) {
+  const client = new McpStdioClient(root, env);
+  await client.request('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'codexpro-stress', version: '0.1.0' }
+  });
+  client.notify('notifications/initialized');
+  return client;
+}
+
+async function makeFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-'));
+  await fs.writeFile(path.join(root, 'AGENTS.md'), '# Stress Agents\n\nKeep checks local.\n', 'utf8');
+  await fs.writeFile(path.join(root, 'demo.txt'), 'alpha\n--flag root\narrow -> value\n', 'utf8');
+  await fs.mkdir(path.join(root, 'many'), { recursive: true });
+  for (let file = 0; file < 50; file += 1) {
+    const lines = Array.from({ length: 60 }, (_, line) => `file ${file} line ${line} --flag -> stress-needle-${line % 11}`);
+    await fs.writeFile(path.join(root, 'many', `hits-${file}.txt`), `${lines.join('\n')}\n`, 'utf8');
+  }
+  for (let i = 0; i < 140; i += 1) {
+    const name = `stress-skill-${String(i).padStart(3, '0')}`;
+    const dir = path.join(root, '.codex', 'skills', name);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: Stress skill ${i}.\n---\n\n# Stress Skill ${i}\n`, 'utf8');
+  }
+  await fs.mkdir(path.join(root, '.ai-bridge'), { recursive: true });
+  await fs.writeFile(path.join(root, '.ai-bridge', 'agent-status.md'), '# Agent Status\n\nPASS stress handoff.\n', 'utf8');
+  await fs.writeFile(path.join(root, '.ai-bridge', 'implementation-diff.patch'), 'diff --git a/demo.txt b/demo.txt\n', 'utf8');
+  await fs.writeFile(path.join(root, '.ai-bridge', 'execution-log.jsonl'), `${JSON.stringify({ ts: new Date().toISOString(), event: 'stress' })}\n`, 'utf8');
+  return root;
+}
+
+async function runFullModeStress(root) {
+  const client = await initClient(root);
+  try {
+    const tools = await client.request('tools/list', {});
+    const names = tools.tools.map((tool) => tool.name);
+    for (const name of ['codexpro', 'codexpro_inventory', 'open_current_workspace', 'search', 'load_skill', 'wait_for_handoff', 'export_pro_context', 'bash']) {
+      assert(names.includes(name), `full mode missing ${name}`);
+    }
+
+    const config = await client.request('tools/call', { name: 'server_config', arguments: {} });
+    assert(config.structuredContent.toolMode === 'full', `expected full tool mode, got ${config.structuredContent.toolMode}`);
+    assert(config.structuredContent.registeredTools.includes('codexpro'), 'server_config missing codexpro supertool');
+
+    const superActions = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'list_actions' }
+    });
+    assert(superActions.structuredContent.actions.includes('search'), 'supertool actions missing search');
+    assert(superActions.structuredContent.actions.includes('export_pro_context'), 'supertool actions missing export_pro_context');
+
+    const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    assert(opened.structuredContent.skill_inventory.length === 0, 'default workspace open loaded skills');
+    const ws = opened.structuredContent.workspace_id;
+
+    const superOpened = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'open', args: { include_tree: false } }
+    });
+    assert(superOpened.structuredContent.wrapped_tool === 'open_current_workspace', 'supertool open alias did not wrap open_current_workspace');
+    assert(superOpened.structuredContent.skill_inventory.length === 0, 'supertool default workspace open loaded skills');
+
+    const withSkills = await client.request('tools/call', {
+      name: 'open_current_workspace',
+      arguments: { include_tree: false, include_skills: true, include_global_skills: false }
+    });
+    assert(withSkills.structuredContent.skill_inventory.length === 120, `expected capped 120 skills, got ${withSkills.structuredContent.skill_inventory.length}`);
+
+    const firstSkill = withSkills.structuredContent.skill_inventory[0];
+    const loaded = await client.request('tools/call', {
+      name: 'load_skill',
+      arguments: { workspace_id: ws, name: firstSkill.name, source: firstSkill.source, path: firstSkill.path }
+    });
+    assert(loaded.structuredContent.text.includes('# Stress Skill'), 'load_skill did not return skill body');
+
+    const largeSearch = await client.request('tools/call', {
+      name: 'search',
+      arguments: { workspace_id: ws, query: '--flag', path: 'many', max_results: 2000 }
+    });
+    assert(largeSearch.structuredContent.matches.length === 2000, `expected 2000 search matches, got ${largeSearch.structuredContent.matches.length}`);
+    assert(largeSearch.structuredContent.truncated === true, 'large search did not report truncation');
+    assert(!('text' in largeSearch.structuredContent), 'search duplicated text in structuredContent with cards off');
+
+    const superRead = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'read', args: { workspace_id: ws, path: 'demo.txt', start_line: 1, end_line: 3 } }
+    });
+    assert(superRead.structuredContent.wrapped_tool === 'read' && superRead.structuredContent.text.includes('--flag root'), 'supertool read failed');
+
+    const superSearch = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'search', args: { workspace_id: ws, query: 'stress-needle-3', path: 'many', max_results: 20 } }
+    });
+    assert(superSearch.structuredContent.wrapped_tool === 'search', 'supertool search did not report wrapped tool');
+    assert(superSearch.structuredContent.matches.length === 20, `supertool search returned ${superSearch.structuredContent.matches.length} matches`);
+
+    const arrows = await Promise.all(Array.from({ length: 12 }, () =>
+      client.request('tools/call', { name: 'search', arguments: { workspace_id: ws, query: '->', path: 'many', max_results: 25 } })
+    ));
+    assert(arrows.every((result) => result.structuredContent.matches.length === 25), 'concurrent arrow searches failed');
+
+    await fs.writeFile(path.join(root, '.ai-bridge', 'handoff-run-state.json'), `${JSON.stringify({
+      version: 1,
+      state: 'completed',
+      iteration: 7,
+      plan_hash: 'stress-plan',
+      executor: 'codex',
+      model: 'local-test',
+      exit_code: 0,
+      timed_out: false,
+      started_at: new Date(Date.now() - 1000).toISOString(),
+      finished_at: new Date().toISOString(),
+      status_file: '.ai-bridge/agent-status.md',
+      diff_file: '.ai-bridge/implementation-diff.patch',
+      log_file: '.ai-bridge/execution-log.jsonl'
+    }, null, 2)}\n`, 'utf8');
+    const completed = await client.request('tools/call', {
+      name: 'wait_for_handoff',
+      arguments: { workspace_id: ws, plan_hash: 'stress-plan', since_iteration: 6, max_wait_seconds: 1, poll_ms: 250 }
+    });
+    assert(completed.structuredContent.awaited_completed === true && completed.structuredContent.state === 'completed', 'wait_for_handoff did not complete expected state');
+    assert(String(completed.structuredContent.status_excerpt ?? '').includes('PASS stress handoff'), 'wait_for_handoff missed status excerpt');
+
+    const superWait = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'handoff_poll', args: { workspace_id: ws, plan_hash: 'stress-plan', since_iteration: 6, max_wait_seconds: 1, poll_ms: 250 } }
+    });
+    assert(superWait.structuredContent.wrapped_tool === 'wait_for_handoff' && superWait.structuredContent.succeeded === true, 'supertool handoff_poll failed');
+
+    const mismatch = await client.request('tools/call', {
+      name: 'wait_for_handoff',
+      arguments: { workspace_id: ws, plan_hash: 'wrong-plan', max_wait_seconds: 1, poll_ms: 250 }
+    });
+    assert(mismatch.structuredContent.awaited_completed === false && mismatch.structuredContent.plan_hash_mismatch === true, 'wait_for_handoff mismatch did not fail closed');
+
+    const exactExport = await client.request('tools/call', {
+      name: 'export_pro_context',
+      arguments: {
+        workspace_id: ws,
+        selected_paths: ['demo.txt'],
+        include_important_files: false,
+        include_changed_files: false,
+        include_diff: false,
+        include_ai_bridge: false,
+        max_files: 1,
+        max_total_bytes: 20000
+      }
+    });
+    assert(exactExport.structuredContent.files_included.length === 1 && exactExport.structuredContent.files_included[0] === 'demo.txt', `exact Pro export included wrong files: ${JSON.stringify(exactExport.structuredContent.files_included)}`);
+
+    const superExport = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: {
+        action: 'pro_export',
+        args: {
+          workspace_id: ws,
+          selected_paths: ['demo.txt'],
+          include_important_files: false,
+          include_changed_files: false,
+          include_diff: false,
+          include_ai_bridge: false,
+          max_files: 1,
+          max_total_bytes: 20000
+        }
+      }
+    });
+    assert(superExport.structuredContent.wrapped_tool === 'export_pro_context', 'supertool pro_export did not wrap export_pro_context');
+    assert(superExport.structuredContent.files_included.length === 1 && superExport.structuredContent.files_included[0] === 'demo.txt', `supertool Pro export included wrong files: ${JSON.stringify(superExport.structuredContent.files_included)}`);
+
+    const selfTest = await client.request('tools/call', { name: 'codexpro_self_test', arguments: { workspace_id: ws } });
+    assert(selfTest.structuredContent.status !== 'fail', `codexpro_self_test failed: ${JSON.stringify(selfTest.structuredContent.checks)}`);
+  } finally {
+    client.close();
+  }
+}
+
+async function runSupertoolModeStress(root) {
+  const client = await initClient(root, {
+    CODEXPRO_TOOL_MODE: 'minimal',
+    CODEXPRO_BASH_MODE: 'off'
+  });
+  try {
+    const tools = await client.request('tools/list', {});
+    const names = tools.tools.map((tool) => tool.name);
+    assert(names.includes('codexpro'), 'minimal mode missing codexpro supertool');
+    assert(!names.includes('bash'), 'minimal no-bash mode exposed bash');
+    assert(!names.includes('search'), 'minimal mode exposed search');
+
+    const actions = await client.request('tools/call', { name: 'codexpro', arguments: { action: 'list_actions' } });
+    assert(actions.structuredContent.actions.includes('read'), 'minimal supertool actions missing read');
+    assert(!actions.structuredContent.actions.includes('bash'), 'minimal no-bash supertool actions exposed bash');
+    assert(!actions.structuredContent.actions.includes('search'), 'minimal supertool actions exposed search');
+
+    const opened = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'open', args: { include_tree: false } }
+    });
+    const read = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'read', args: { workspace_id: opened.structuredContent.workspace_id, path: 'demo.txt', start_line: 1, end_line: 2 } }
+    });
+    assert(read.structuredContent.wrapped_tool === 'read' && read.structuredContent.text.includes('alpha'), 'minimal supertool read failed');
+
+    const blockedSearch = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'search', args: { workspace_id: opened.structuredContent.workspace_id, query: 'alpha' } }
+    });
+    assert(blockedSearch.isError === true && String(blockedSearch.structuredContent.error).includes('not available'), 'supertool allowed disabled search action');
+
+    const blockedBash = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'bash', args: { workspace_id: opened.structuredContent.workspace_id, command: 'pwd' } }
+    });
+    assert(blockedBash.isError === true && String(blockedBash.structuredContent.error).includes('not available'), 'supertool allowed disabled bash action');
+  } finally {
+    client.close();
+  }
+}
+
+async function runCardStress(root) {
+  const client = await initClient(root, { CODEXPRO_TOOL_CARDS: '1' });
+  try {
+    await client.request('tools/list', {});
+    const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    const search = await client.request('tools/call', {
+      name: 'search',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, query: '--flag', path: 'many', max_results: 10 }
+    });
+    assert(typeof search.structuredContent.text === 'string' && search.structuredContent.text.includes('--flag'), 'tool-card search did not include structured text');
+  } finally {
+    client.close();
+  }
+}
+
+const root = await makeFixture();
+await runFullModeStress(root);
+await runSupertoolModeStress(root);
+await runCardStress(root);
+console.log(`✓ stress test passed (${root})`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -278,6 +278,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
   const authToken = process.env.CODEXPRO_HTTP_TOKEN ?? process.env.CODEBASE_BRIDGE_HTTP_TOKEN;
   const allowNoToken = boolFrom(process.env.CODEXPRO_ALLOW_NO_HTTP_TOKEN, false);
   const requireHttpToken =
+    (!authToken && !allowNoToken) ||
     boolFrom(process.env.CODEXPRO_REQUIRE_HTTP_TOKEN, false) ||
     boolFrom(process.env.CODEXPRO_TUNNEL_MODE, false) ||
     (!isLoopbackHost(host) && !allowNoToken);

--- a/src/proContext.ts
+++ b/src/proContext.ts
@@ -181,9 +181,13 @@ export async function buildProContext(
   const changedFileCandidates = includeChangedFiles ? changedFiles : [];
   const selectedPaths = unique(options.selectedPaths ?? []);
   const extraGlobFiles = await filesForGlobs(guard, workspace, options.extraGlobs ?? [], maxFiles);
-  const candidates = unique([...importantFiles, ...changedFileCandidates, ...selectedPaths, ...extraGlobFiles])
+  const selectedSet = new Set(selectedPaths);
+  const candidates = unique([...selectedPaths, ...changedFileCandidates, ...importantFiles, ...extraGlobFiles])
     .filter((rel) => rel !== `${config.contextDir}/pro-context.md`)
     .sort((a, b) => {
+      const aSelected = selectedSet.has(a) ? 0 : 1;
+      const bSelected = selectedSet.has(b) ? 0 : 1;
+      if (aSelected !== bSelected) return aSelected - bSelected;
       const aImportant = isLikelyImportantConfig(a) ? 0 : 1;
       const bImportant = isLikelyImportantConfig(b) ? 0 : 1;
       if (aImportant !== bImportant) return aImportant - bImportant;

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,6 +1,10 @@
 const OPENAI_SECRET_PATTERN = /\bsk-[A-Za-z0-9_-]{10,}\b/g;
-const SECRET_ASSIGNMENT_PATTERN = /\b[A-Za-z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]*\s*=\s*(?:"[^"\r\n]{12,}"|'[^'\r\n]{12,}'|`[^`\r\n]{12,}`|[A-Za-z0-9_./+=-]{20,})/gi;
-const SECRET_PATTERNS = [OPENAI_SECRET_PATTERN, SECRET_ASSIGNMENT_PATTERN];
+const COMMON_TOKEN_PATTERN = /\b(?:sk-ant-[A-Za-z0-9_-]{10,}|gh[opsru]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{20,})\b/g;
+const BEARER_TOKEN_PATTERN = /\b(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi;
+const QUERY_TOKEN_PATTERN = /([?&](?:codexpro_token|token|access_token|auth_token|api[_-]?key)=)[^&\s"'`<>]{8,}/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}\s*=\s*(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi;
+const SECRET_FIELD_PATTERN = /(["']?[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}["']?\s*:\s*)(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi;
+const SECRET_PATTERNS = [OPENAI_SECRET_PATTERN, COMMON_TOKEN_PATTERN, BEARER_TOKEN_PATTERN, QUERY_TOKEN_PATTERN, SECRET_ASSIGNMENT_PATTERN, SECRET_FIELD_PATTERN];
 
 export function hasSecretValue(text: string): boolean {
   for (const pattern of SECRET_PATTERNS) {
@@ -16,7 +20,11 @@ export function hasSecretValue(text: string): boolean {
 export function redactSensitiveText(text: string): string {
   return text
     .replace(SECRET_ASSIGNMENT_PATTERN, (match) => isPlaceholderSecret(match) ? match : redactSecretAssignment(match))
-    .replace(OPENAI_SECRET_PATTERN, (match) => isPlaceholderSecret(match) ? match : "[REDACTED_SECRET]");
+    .replace(SECRET_FIELD_PATTERN, (match, prefix) => isPlaceholderSecret(match) ? match : `${prefix}[REDACTED_SECRET]`)
+    .replace(BEARER_TOKEN_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
+    .replace(QUERY_TOKEN_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
+    .replace(OPENAI_SECRET_PATTERN, (match) => isPlaceholderSecret(match) ? match : "[REDACTED_SECRET]")
+    .replace(COMMON_TOKEN_PATTERN, (match) => isPlaceholderSecret(match) ? match : "[REDACTED_SECRET]");
 }
 
 export function redactStructured<T>(value: T, depth = 0): T {

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -38,7 +38,7 @@ function truncateLine(line: string, max = 400): string {
 
 async function runRipgrep(config: CodexProConfig, guard: PathGuard, workspace: Workspace, options: SearchOptions): Promise<SearchResult> {
   const target = guard.resolve(workspace, options.root ?? ".");
-  const args = ["--line-number", "--no-heading", "--color=never", "--max-columns", "500", "--max-count", "50"];
+  const args = ["--line-number", "--with-filename", "--no-heading", "--color=never", "--max-columns", "500", "--max-count", "50"];
   if (!options.regex) args.push("--fixed-strings");
   if (!options.includeHidden) args.push("--hidden", "-g", "!.*", "-g", "!**/.*");
   for (const glob of config.blockedGlobs) args.push("-g", `!${glob}`);
@@ -138,6 +138,9 @@ export async function searchWorkspace(config: CodexProConfig, guard: PathGuard, 
 
   if (await commandExists("rg")) {
     return runRipgrep(config, guard, workspace, options);
+  }
+  if (options.regex) {
+    throw new CodexProError("regex search requires ripgrep. Install rg or retry with regex=false.");
   }
   return runNodeSearch(config, guard, workspace, options);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,6 +157,42 @@ function registerToolCardResource(server: McpServer, config: CodexProConfig): vo
   }
 }
 
+type CodexToolHandler = (args: any) => Promise<any> | any;
+
+const SUPERTOOL_NAME = "codexpro";
+const SUPERTOOL_ACTION_ALIASES: Record<string, string> = {
+  actions: "list_actions",
+  config: "server_config",
+  self_test: "codexpro_self_test",
+  inventory: "codexpro_inventory",
+  open: "open_current_workspace",
+  snapshot: "workspace_snapshot",
+  changes: "show_changes",
+  handoff_poll: "wait_for_handoff",
+  pro_export: "export_pro_context",
+  agent_handoff: "handoff_to_agent",
+  codex_handoff: "handoff_to_codex"
+};
+
+const registeredToolHandlersByServer = new WeakMap<object, Map<string, CodexToolHandler>>();
+
+function rememberRegisteredToolHandler(server: McpServer, name: string, handler: CodexToolHandler): void {
+  const key = server as object;
+  const handlers = registeredToolHandlersByServer.get(key) ?? new Map<string, CodexToolHandler>();
+  if (!registeredToolHandlersByServer.has(key)) registeredToolHandlersByServer.set(key, handlers);
+  handlers.set(name, handler);
+}
+
+function registeredToolHandler(server: McpServer, name: string): CodexToolHandler | undefined {
+  return registeredToolHandlersByServer.get(server as object)?.get(name);
+}
+
+function normalizeSupertoolAction(value: unknown): string {
+  const raw = String(value ?? "list_actions").trim();
+  const normalized = raw.toLowerCase().replace(/[\s-]+/g, "_");
+  return SUPERTOOL_ACTION_ALIASES[normalized] ?? normalized;
+}
+
 
 function isContextPath(config: CodexProConfig, relPath: string): boolean {
   const normalized = relPath.split(path.sep).join("/").replace(/^\.\//, "");
@@ -220,6 +256,7 @@ function registerToolCompat(
 }
 
 const MINIMAL_TOOL_NAMES = [
+  SUPERTOOL_NAME,
   "server_config",
   "codexpro_self_test",
   "open_current_workspace",
@@ -243,6 +280,7 @@ const STANDARD_TOOL_NAMES = [
 ] as const;
 
 const FULL_TOOL_NAMES = [
+  SUPERTOOL_NAME,
   "server_config",
   "codexpro_self_test",
   "codexpro_inventory",
@@ -328,11 +366,12 @@ function registerCodexTool(
   server: McpServer,
   name: string,
   options: Record<string, unknown>,
-  handler: (args: any) => Promise<any> | any
+  handler: CodexToolHandler
 ): void {
   if (!shouldRegisterTool(config, name)) return;
   registerToolCompat(server, name, descriptorOptionsForConfig(config, options), handler);
   rememberRegisteredTool(server, name);
+  rememberRegisteredToolHandler(server, name, handler);
 }
 
 function serverInstructions(config: CodexProConfig): string {
@@ -635,6 +674,83 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
   registerCodexTool(
     config,
     server,
+    SUPERTOOL_NAME,
+    {
+      title: "CodexPro Supertool",
+      description:
+        "Stable wrapper for advanced ChatGPT connector setups. Pass action plus args to call an already-registered CodexPro tool without changing the visible schema; it cannot call tools disabled by the current mode.",
+      inputSchema: {
+        action: z.string().optional().describe("Action or registered tool name. Use list_actions to see what this server mode allows."),
+        args: z.record(z.any()).optional().describe("Arguments for the selected action. Same shape as the wrapped CodexPro tool.")
+      },
+      annotations: BASH_ANNOTATIONS,
+      _meta: {
+        ...toolCardMeta(),
+        "openai/toolInvocation/invoking": "Running CodexPro supertool action...",
+        "openai/toolInvocation/invoked": "CodexPro supertool action complete"
+      }
+    },
+    async (args) => {
+      const action = normalizeSupertoolAction(args.action);
+      const names = registeredToolNames(server).filter((name) => name !== SUPERTOOL_NAME);
+      if (action === "list_actions" || action === "help") {
+        const text = [
+          "# CodexPro Supertool",
+          "",
+          "Use `codexpro` only when a stable wrapper is useful for ChatGPT connector caching or custom workflows. The explicit tools remain the preferred default because they give clearer descriptions and validation.",
+          "",
+          "## Available actions",
+          "",
+          names.length ? names.map((name) => `- ${name}`).join("\n") : "- none",
+          "",
+          "## Usage",
+          "",
+          "```json",
+          JSON.stringify({ action: "search", args: { workspace_id: "ws_...", query: "needle", path: "src" } }, null, 2),
+          "```"
+        ].join("\n");
+        return textResult(text, {
+          actions: names,
+          action_count: names.length,
+          aliases: SUPERTOOL_ACTION_ALIASES,
+          tool_mode: config.toolMode,
+          bash_mode: config.bashMode,
+          write_mode: config.writeMode
+        });
+      }
+
+      if (action === SUPERTOOL_NAME) {
+        throw new CodexProError("codexpro cannot call itself. Use action=list_actions to inspect available wrapped actions.");
+      }
+
+      const handler = registeredToolHandler(server, action);
+      if (!handler) {
+        throw new CodexProError(
+          `CodexPro action is not available in the current mode: ${action}. ` +
+            "Call codexpro with action=list_actions, or restart CodexPro with a broader tool mode if that action should be exposed."
+        );
+      }
+
+      const childArgs =
+        args.args && typeof args.args === "object" && !Array.isArray(args.args)
+          ? args.args
+          : {};
+      const result = await handler(childArgs);
+      if (result && typeof result === "object") {
+        const structured = result.structuredContent;
+        result.structuredContent = {
+          codexpro_super_action: action,
+          wrapped_tool: action,
+          ...(structured && typeof structured === "object" && !Array.isArray(structured) ? structured : {})
+        };
+      }
+      return result;
+    }
+  );
+
+  registerCodexTool(
+    config,
+    server,
     "server_config",
     {
       title: "Server Config",
@@ -718,8 +834,12 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       check("bash mode", config.bashMode === "full" ? "warn" : "pass", config.bashMode);
       check(
         "http auth",
-        config.requireHttpToken && !config.authToken ? "fail" : "pass",
-        config.requireHttpToken ? "token required for public/non-loopback access" : "loopback token not required"
+        "pass",
+        config.authToken
+          ? "token configured"
+          : config.requireHttpToken
+            ? "token required when serving HTTP"
+            : "token auth explicitly disabled"
       );
       const expectedTools = toolNamesForMode(config).sort();
       const actualTools = registeredToolNames(server).sort();
@@ -956,7 +1076,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
         source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source when multiple skills share a name."),
         path: z.string().optional().describe("Exact sanitized path from skill_inventory when name/source are still ambiguous."),
-        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: true."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: false."),
         max_bytes: z.number().int().min(1000).max(100000).optional().describe("Maximum bytes to return from SKILL.md. Default: 40000.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
@@ -972,7 +1092,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         name: String(args.name ?? ""),
         source: args.source,
         path: typeof args.path === "string" ? args.path : undefined,
-        includeGlobal: parseBool(args.include_global_skills, true),
+        includeGlobal: parseBool(args.include_global_skills, false),
         maxBytes: limitInt(args.max_bytes, 40_000, 1_000, 100_000)
       });
       const truncated = loaded.truncated ? "\n\n[truncated: increase max_bytes if more context is required]" : "";
@@ -1208,7 +1328,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         query: z.string().describe("Text or regex to search for."),
-        regex: z.boolean().optional().describe("Treat query as a regular expression. Default: false."),
+        regex: z.boolean().optional().describe("Treat query as a regular expression. Requires ripgrep. Default: false."),
         path: z.string().optional().describe("Directory or file relative to workspace root. Default: ."),
         glob: z.string().optional().describe("Optional glob, for example src/**/*.ts."),
         include_hidden: z.boolean().optional().describe("Include hidden files that are not blocked. Default: false."),
@@ -1622,6 +1742,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
           : undefined;
 
       const stateRel = `${config.contextDir}/handoff-run-state.json`;
+      const contextPrefix = `${config.contextDir.replace(/\/+$/, "")}/`;
       const terminalStates = new Set(["completed", "failed", "timed_out"]);
 
       const readState = async (): Promise<Record<string, any> | undefined> => {
@@ -1671,12 +1792,19 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
           return undefined;
         }
       };
+      const bridgeArtifact = (value: unknown, fallback: string): string => {
+        const raw = typeof value === "string" && value.trim() ? value.trim() : fallback;
+        const normalized = path.posix.normalize(raw.split(path.sep).join("/")).replace(/^\.\//, "");
+        return normalized.startsWith(contextPrefix) ? normalized : fallback;
+      };
 
       const structured: Record<string, unknown> = {
         workspace_id: workspace.id,
         root: workspace.root,
         state: reportedState,
         awaited_completed: completed,
+        awaited_terminal: completed,
+        succeeded: completed && state?.state === "completed",
         state_file: stateRel,
         ...(state ? { run_state: state.state } : {}),
         ...(typeof state?.iteration === "number" ? { iteration: state.iteration } : {}),
@@ -1692,10 +1820,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       };
 
       if (completed) {
-        const statusFile = String(state?.status_file ?? `${config.contextDir}/agent-status.md`);
-        const diffFile = String(state?.diff_file ?? `${config.contextDir}/implementation-diff.patch`);
-        const logFile = String(state?.log_file ?? `${config.contextDir}/execution-log.jsonl`);
-        const testsFile = state?.tests_file ? String(state.tests_file) : `${config.contextDir}/loop-tests.txt`;
+        const statusFile = bridgeArtifact(state?.status_file, `${config.contextDir}/agent-status.md`);
+        const diffFile = bridgeArtifact(state?.diff_file, `${config.contextDir}/implementation-diff.patch`);
+        const logFile = bridgeArtifact(state?.log_file, `${config.contextDir}/execution-log.jsonl`);
+        const testsFile = bridgeArtifact(state?.tests_file, `${config.contextDir}/loop-tests.txt`);
         structured.status_file = statusFile;
         structured.diff_file = diffFile;
         structured.log_file = logFile;

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "./config.js";
 import { createCodexProServer } from "./server.js";
 
 async function main(): Promise<void> {
+  process.env.CODEXPRO_ALLOW_NO_HTTP_TOKEN ??= "1";
   const config = loadConfig();
   const server = createCodexProServer(config);
   const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- Harden CodexPro's local HTTP/auth defaults and `--no-auth` escape hatch.
- Add the stable `codexpro` supertool wrapper for cache-stable advanced workflows; it can only call actions already registered by the active tool/write/bash mode.
- Tighten skill loading, handoff polling, Pro export selection, search parsing, and secret redaction.
- Add reusable full-mode and supertool stress coverage with `npm run stress`.
- Update docs/prompts for current tool-surface reality, `wait_for_handoff`, `.ai-bridge/handoff-run-state.json`, the supertool, and GPT-5.5/App surface boundaries.

## What changed

### Safety and auth

- Direct HTTP now fails closed without a token by default, including loopback. Stdio explicitly opts out because it is not serving HTTP.
- `codexpro start --tunnel none` now generates a token unless `--no-auth` is explicitly passed.
- `--no-auth` is restricted to `--tunnel none` on loopback hosts, so `--host 0.0.0.0 --no-auth` is rejected.
- Redaction now covers bearer headers, URL query tokens such as `codexpro_token`, common GitHub/npm/Anthropic token shapes, and JSON/YAML-style secret fields.
- Redaction regexes are bounded so large diffs do not hang the loop-handoff path.

### Tool behavior

- Adds `codexpro`, a stable supertool wrapper with `action` + `args` for advanced/custom workflows and ChatGPT connector cache churn. It routes through the already-registered handler map, so it cannot unlock `bash`, `write`, `edit`, `search`, or full-only tools when the current mode hides them.
- `load_skill` no longer scans global user/plugin skills by default; global skill loading is explicit.
- `wait_for_handoff` now constrains returned artifact excerpts to the configured `.ai-bridge` directory and exposes `awaited_terminal` plus `succeeded` so failed/timed-out terminal runs are not mislabeled as success.
- `export_pro_context` prioritizes explicit `selected_paths` before auto-included files, even with tight `max_files` limits.
- Search always passes `--with-filename` to ripgrep so single-file searches parse correctly.
- Regex search now requires ripgrep; the Node fallback remains for fixed-string search to avoid JS regex backtracking risk.
- `codexpro --version`, `codexpro -v`, `codexpro version`, and `codexpro start --version` now print the package version.

### Coverage

- Adds `scripts/stress.mjs` and `npm run stress` for full tool-mode stress coverage: supertool action listing, supertool `open`/`read`/`search`/`handoff_poll`/`pro_export`, minimal/no-bash supertool refusal checks, skill cap, card payload switch, large search, leading-dash/arrow search, handoff terminal states, exact Pro export, and self-test.
- Expands smoke/http smoke coverage for local auth defaults, non-loopback `--no-auth`, token redaction, Pro export priority, timed-out handoff state, card runtime search payloads, and HTTP full tool inventory.

## Boundary / truth

This PR improves CodexPro's local server, tool behavior, safety defaults, wrapper surface, and test coverage. It does not and cannot make a ChatGPT model surface call CodexPro tools when that chat does not expose Apps/MCP app actions. For those sessions, the supported path remains exporting repo context through the Pro context fallback and then handing a plan back to a tool-capable surface or local executor.

## Validation

- `npm run build`
- `npm run smoke`
- `npm run stress`
- `npm audit --audit-level=high`
- `git diff --check`
- `npm pack --dry-run`
