### PR TITLE
[codex] Fix release truth and CLI safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.28.6
+
+- Added the stable `codexpro` supertool wrapper for advanced connector-cache/custom workflows, while preserving tool/write/bash mode gates.
+- Hardened direct HTTP auth defaults, local `--no-auth`, token redaction, search parsing, selected-path Pro exports, and handoff polling state.
+- Added `npm run stress` to cover full-mode MCP behavior, supertool dispatch, skill caps, card payloads, search edge cases, Pro export, and handoff polling.
+- Fixed CLI env precedence so `CODEXPRO_HOST` / `CODEXPRO_PORT` override generic `HOST` / `PORT`, preventing ambient process env from widening a launcher-validated bind.
+- Normalized stable public hostnames in CLI settings/setup/start flows and accepted common `--flag=value` syntax.
+
 - Made ChatGPT tool-card descriptor metadata opt-in with `CODEXPRO_TOOL_CARDS=1`, so default `tools/list` responses stay plain MCP and avoid fragile widget metadata during tool discovery.
 - Added `codexpro loop-handoff` for bounded local execute/review loops over `.ai-bridge/current-plan.md`, with a required local `--review-command`, `--max-iters`, dry-run preview, optional test command capture, and stop conditions for no diff, repeated diff, missing follow-up plans, reviewer errors, and human cancellation.
 - Hardened `loop-handoff` external-command boundaries: commands are preflighted before execution, reviewer verdicts require explicit `CODEXPRO_REVIEW=...` assignment lines by default, and reviewer `PASS` no longer masks failed executor/test/reviewer commands unless the user opts into the supported override behavior.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Standard mode exposes:
 - `open_current_workspace` — open the configured default workspace without accepting a path. Fastest/safest first call.
 - `open_workspace` — open a local project directory using `root` or `path` and return workspace id, git status, AGENTS.md status, optional skill discovery, and optional file tree.
 - `tree` — inspect files.
-- `search` — search code with ripgrep or a Node fallback.
+- `search` — search code; literal search falls back to Node when ripgrep is unavailable, while regex search requires ripgrep.
 - `load_skill` — load bounded `SKILL.md` instructions for a discovered workspace, user, or plugin skill by name, with optional source/path disambiguation.
 - `read` — read text files with line numbers.
 - `write` — create/overwrite files and return a diff. Advertised only when `CODEXPRO_WRITE_MODE=workspace`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -458,6 +458,7 @@ codexpro settings delete --yes</code></pre>
             <h3>Focused local repo actions exposed through MCP.</h3>
           </div>
           <div class="tool-list">
+            <span>codexpro</span>
             <span>server_config</span>
             <span>codexpro_self_test</span>
             <span>open_current_workspace</span>
@@ -470,6 +471,7 @@ codexpro settings delete --yes</code></pre>
             <span>bash</span>
             <span>show_changes</span>
             <span>read_handoff</span>
+            <span>wait_for_handoff</span>
             <span>export_pro_context</span>
             <span>handoff_to_agent</span>
           </div>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -287,7 +287,9 @@ codexpro start</code></pre>
             <h3>默认精简的仓库读取、编辑、验证和 handoff。</h3>
           </div>
           <div class="tool-list">
+            <span>codexpro</span>
             <span>server_config</span>
+            <span>codexpro_self_test</span>
             <span>open_current_workspace</span>
             <span>open_workspace</span>
             <span>tree</span>
@@ -298,6 +300,7 @@ codexpro start</code></pre>
             <span>bash</span>
             <span>show_changes</span>
             <span>read_handoff</span>
+            <span>wait_for_handoff</span>
             <span>export_pro_context</span>
             <span>handoff_to_agent</span>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexpro",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexpro",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexpro",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "A local MCP/App SDK-style connector that lets ChatGPT inspect, edit, and hand off work to Codex inside a local dev workspace.",
   "type": "module",
   "license": "MIT",

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -292,7 +292,10 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const raw = argv[i];
     if (!raw.startsWith('--')) continue;
-    const key = raw.slice(2);
+    const option = raw.slice(2);
+    const eq = option.indexOf('=');
+    const key = eq >= 0 ? option.slice(0, eq) : option;
+    const inlineValue = eq >= 0 ? option.slice(eq + 1) : undefined;
     if (key === 'help') out.help = true;
     else if (key === 'allow-home') out.allowHome = true;
     else if (key === 'no-auth') out.noAuth = true;
@@ -323,9 +326,9 @@ function parseArgs(argv) {
     else if (key === 'no-install-cloudflared') out.noInstallCloudflared = true;
     else if (key === 'agent') {
       const next = argv[i + 1];
-      if (next && !next.startsWith('--')) {
-        out.agent = next;
-        i += 1;
+      if (inlineValue !== undefined || (next && !next.startsWith('--'))) {
+        out.agent = inlineValue ?? next;
+        if (inlineValue === undefined) i += 1;
       } else {
         out.mode = 'agent';
       }
@@ -336,10 +339,11 @@ function parseArgs(argv) {
     else if (key === 'print-env') out.printEnv = true;
     else {
       const next = argv[i + 1];
-      if (!next || next.startsWith('--')) throw new Error(`Missing value for --${key}`);
-      i += 1;
-      if (key === 'allow-root') out.allowRoots.push(next);
-      else out[key.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = next;
+      const value = inlineValue ?? next;
+      if (value === undefined || (inlineValue === undefined && value.startsWith('--'))) throw new Error(`Missing value for --${key}`);
+      if (inlineValue === undefined) i += 1;
+      if (key === 'allow-root') out.allowRoots.push(value);
+      else out[key.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value;
     }
   }
   return out;
@@ -950,16 +954,18 @@ function endpointWithToken(endpoint, token) {
   return url.toString();
 }
 
+function normalizePublicHostname(value) {
+  const raw = String(value ?? '').trim().replace(/\/+$/, '');
+  if (!raw) return '';
+  const url = new URL(raw.includes('://') ? raw : `https://${raw}`);
+  if (url.protocol !== 'https:') throw new Error('hostname must use https when a scheme is provided.');
+  if (url.search || url.hash) throw new Error('hostname must not include query strings or fragments.');
+  if (url.pathname !== '/' && url.pathname !== '/mcp') throw new Error('hostname must be a host, URL root, or /mcp URL.');
+  return url.host;
+}
+
 function publicBaseFromHostname(hostname) {
-  const raw = hostname.includes('://') ? hostname : `https://${hostname}`;
-  const url = new URL(raw);
-  if (url.pathname === '/mcp' || url.pathname.endsWith('/mcp')) {
-    url.pathname = url.pathname.slice(0, -4) || '/';
-  }
-  url.pathname = url.pathname.replace(/\/+$/, '');
-  url.search = '';
-  url.hash = '';
-  return url.toString().replace(/\/$/, '');
+  return `https://${normalizePublicHostname(hostname)}`;
 }
 
 function readTokenFile(filePath) {
@@ -2615,6 +2621,7 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
       optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'NGROK_DOMAIN'], '')
     );
     if (!hostname) throw new Error('Ngrok setup needs your reserved domain, for example name.ngrok-free.dev.');
+    hostname = normalizePublicHostname(hostname);
     ngrokConfig = optionValue(defaults, profile, 'ngrokConfig', ['NGROK_CONFIG', 'CODEXPRO_NGROK_CONFIG'], '');
   } else if (tunnel === 'cloudflare-named') {
     hostname = await ask(
@@ -2623,6 +2630,7 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
       optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME'], '')
     );
     if (!hostname) throw new Error('Stable public URL setup needs a real hostname, for example codexpro.yourdomain.com.');
+    hostname = normalizePublicHostname(hostname);
     tunnelName = await ask(rl, 'Cloudflare tunnel name', optionValue(defaults, profile, 'tunnelName', ['CODEXPRO_TUNNEL_NAME', 'CLOUDFLARE_TUNNEL_NAME'], 'codexpro'));
     cloudflareConfig = optionValue(defaults, profile, 'cloudflareConfig', ['CODEXPRO_CLOUDFLARE_CONFIG', 'CLOUDFLARE_TUNNEL_CONFIG'], '');
     cloudflareTokenFile = optionValue(defaults, profile, 'cloudflareTokenFile', ['CODEXPRO_CLOUDFLARE_TUNNEL_TOKEN_FILE', 'CLOUDFLARE_TUNNEL_TOKEN_FILE'], '');
@@ -2831,12 +2839,13 @@ async function runSetupWizard(argv) {
       args.push('--tunnel', 'none');
     } else if (tunnelChoice === 'stable') {
       profileTunnel = 'cloudflare-named';
-      const hostname = await ask(
+      let hostname = await ask(
         rl,
         'Stable Cloudflare hostname, without /mcp',
         optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME'], '')
       );
       if (!hostname) throw new Error('Stable public URL setup needs a real hostname, for example codexpro.yourdomain.com.');
+      hostname = normalizePublicHostname(hostname);
       profileHostname = hostname;
       const tunnelName = await ask(rl, 'Cloudflare tunnel name', optionValue(defaults, profile, 'tunnelName', ['CODEXPRO_TUNNEL_NAME', 'CLOUDFLARE_TUNNEL_NAME'], 'codexpro'));
       profileTunnelName = tunnelName;
@@ -2847,12 +2856,13 @@ async function runSetupWizard(argv) {
       if (profileCloudflareTokenFile) args.push('--cloudflare-token-file', profileCloudflareTokenFile);
     } else if (tunnelChoice === 'ngrok') {
       profileTunnel = 'ngrok';
-      const hostname = await ask(
+      let hostname = await ask(
         rl,
         'Ngrok domain or URL, without /mcp',
         optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'NGROK_DOMAIN'], '')
       );
       if (!hostname) throw new Error('Ngrok setup needs your reserved domain, for example name.ngrok-free.dev.');
+      hostname = normalizePublicHostname(hostname);
       profileHostname = hostname;
       args.push('--tunnel', 'ngrok', '--hostname', hostname);
       const ngrokConfig = optionValue(defaults, profile, 'ngrokConfig', ['NGROK_CONFIG', 'CODEXPRO_NGROK_CONFIG'], '');
@@ -2970,7 +2980,8 @@ function saveSettingsFromArgs(root, args, profile) {
   if (!['none', 'cloudflare', 'cloudflare-named', 'ngrok'].includes(tunnel)) {
     throw new Error('--tunnel must be none, cloudflare, cloudflare-named, or ngrok');
   }
-  const hostname = args.hostname ?? args.url ?? profile.hostname ?? '';
+  const rawHostname = args.hostname ?? args.url ?? profile.hostname ?? '';
+  const hostname = (tunnel === 'ngrok' || tunnel === 'cloudflare-named') ? normalizePublicHostname(rawHostname) : String(rawHostname ?? '').trim();
   if ((tunnel === 'ngrok' || tunnel === 'cloudflare-named') && !hostname) {
     throw new Error('--hostname is required for ngrok and cloudflare-named settings.');
   }

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -170,13 +170,17 @@ await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKIL
   ''
 ].join('\n'), 'utf8');
 const port = await getFreePort();
+const genericPort = await getFreePort();
 const token = 'codexpro-http-smoke-token';
 const child = spawn('node', ['dist/http.js'], {
   cwd: path.resolve('.'),
   env: {
     ...process.env,
+    HOST: '0.0.0.0',
+    PORT: String(genericPort),
     CODEXPRO_ROOT: root,
     CODEXPRO_ALLOWED_ROOTS: root,
+    CODEXPRO_HOST: '127.0.0.1',
     CODEXPRO_PORT: String(port),
     CODEXPRO_HTTP_TOKEN: token,
     CODEXPRO_BASH_MODE: 'safe',

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -107,6 +107,10 @@ const empty = run(['settings', 'show', '--root', root], env);
 if (!empty.includes('No saved settings')) {
   throw new Error(`expected empty settings output, got:\n${empty}`);
 }
+const emptyEquals = run([`settings`, `show`, `--root=${root}`], env);
+if (!emptyEquals.includes('No saved settings')) {
+  throw new Error(`expected --root= settings output, got:\n${emptyEquals}`);
+}
 
 const saved = run([
   'settings',
@@ -163,6 +167,17 @@ runFail([
   'raw-cloudflare-token'
 ], env, /does not save raw --cloudflare-token/i);
 
+runFail([
+  'settings',
+  'set',
+  '--root',
+  policyRoot,
+  '--tunnel',
+  'ngrok',
+  '--hostname',
+  'http://policy.ngrok-free.app'
+], env, /hostname must use https/i);
+
 run([
   'settings',
   'set',
@@ -171,7 +186,7 @@ run([
   '--tunnel',
   'ngrok',
   '--hostname',
-  'policy.ngrok-free.app',
+  'https://policy.ngrok-free.app/mcp',
   '--mode',
   'handoff',
   '--write',
@@ -181,7 +196,7 @@ run([
 ], env);
 const policyProfile = await readProfile(policyRoot, home);
 const realPolicyRoot = await fs.realpath(policyRoot);
-if (policyProfile.write !== 'handoff' || policyProfile.ngrokConfig !== path.join(realPolicyRoot, 'ngrok.yml')) {
+if (policyProfile.write !== 'handoff' || policyProfile.hostname !== 'policy.ngrok-free.app' || policyProfile.ngrokConfig !== path.join(realPolicyRoot, 'ngrok.yml')) {
   throw new Error(`settings policy profile did not normalize write/path values: ${JSON.stringify(policyProfile)}`);
 }
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -286,6 +286,8 @@ await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws
 await fs.writeFile(path.join(tmp, 'tokens.txt'), [
   'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456',
   'https://example.test/mcp?codexpro_token=verysecretcodexprotoken123&x=1',
+  'codexpro_token=secretsecret12345',
+  '"codexpro_token": "shortcodextoken"',
   'ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz123456',
   '"api_key": "jsonsecretvalueabcdefghijklmnop"',
   'service_token: yamlsecretvalueabcdefghijklmnop'
@@ -297,10 +299,11 @@ if (secretPayload.includes('sk-realSecretValue123') || !secretPayload.includes('
 }
 const tokenRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'tokens.txt' } });
 const tokenPayload = JSON.stringify(tokenRead);
-for (const leaked of ['ghp_abcdefghijklmnopqrstuvwxyz123456', 'verysecretcodexprotoken123', 'sk-ant-abcdefghijklmnopqrstuvwxyz123456', 'jsonsecretvalueabcdefghijklmnop', 'yamlsecretvalueabcdefghijklmnop']) {
+for (const leaked of ['ghp_abcdefghijklmnopqrstuvwxyz123456', 'verysecretcodexprotoken123', 'secretsecret12345', 'shortcodextoken', 'sk-ant-abcdefghijklmnopqrstuvwxyz123456', 'jsonsecretvalueabcdefghijklmnop', 'yamlsecretvalueabcdefghijklmnop']) {
   if (tokenPayload.includes(leaked)) throw new Error(`read leaked token-like content: ${leaked}`);
 }
 await expectToolError('write', { workspace_id: ws, path: 'notes.md', content: 'OPENAI_API_KEY=sk-realSecretValue123\n' }, /Secret-looking content is blocked/);
+await expectToolError('write', { workspace_id: ws, path: 'token.txt', content: 'codexpro_token=shorttok\n' }, /Secret-looking content is blocked/);
 await expectToolError('write', { workspace_id: ws, path: 'notes.yaml', content: 'api_key: yamlsecretvalueabcdefghijklmnop\n' }, /Secret-looking content is blocked/);
 await client.request('tools/call', {
   name: 'write',
@@ -490,7 +493,7 @@ const waitFailed = await client.request('tools/call', {
   name: 'wait_for_handoff',
   arguments: { workspace_id: ws, max_wait_seconds: 1, poll_ms: 250, plan_hash: 'failed-plan' }
 });
-if (waitFailed.structuredContent.awaited_terminal !== true || waitFailed.structuredContent.succeeded !== false || waitFailed.structuredContent.state !== 'failed') {
+if (waitFailed.structuredContent.awaited_terminal !== true || waitFailed.structuredContent.awaited_completed !== false || waitFailed.structuredContent.succeeded !== false || waitFailed.structuredContent.state !== 'failed') {
   throw new Error(`wait_for_handoff did not report failed terminal state: ${JSON.stringify(waitFailed.structuredContent)}`);
 }
 if (waitFailed.structuredContent.status_file !== '.ai-bridge/agent-status.md' || waitFailed.structuredContent.diff_file !== '.ai-bridge/implementation-diff.patch') {
@@ -507,7 +510,7 @@ const waitTimedOut = await client.request('tools/call', {
   name: 'wait_for_handoff',
   arguments: { workspace_id: ws, max_wait_seconds: 1, poll_ms: 250, plan_hash: 'timed-out-plan' }
 });
-if (waitTimedOut.structuredContent.awaited_terminal !== true || waitTimedOut.structuredContent.succeeded !== false || waitTimedOut.structuredContent.state !== 'timed_out') {
+if (waitTimedOut.structuredContent.awaited_terminal !== true || waitTimedOut.structuredContent.awaited_completed !== false || waitTimedOut.structuredContent.succeeded !== false || waitTimedOut.structuredContent.state !== 'timed_out') {
   throw new Error(`wait_for_handoff did not report timed-out terminal state: ${JSON.stringify(waitTimedOut.structuredContent)}`);
 }
 await fs.rm(path.join(tmp, '.ai-bridge', 'handoff-run-state.json'), { force: true });

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -163,13 +163,13 @@ async function runFullModeStress(root) {
       name: 'codexpro',
       arguments: { action: 'read', args: { workspace_id: ws, path: 'demo.txt', start_line: 1, end_line: 3 } }
     });
-    assert(superRead.structuredContent.wrapped_tool === 'read' && superRead.structuredContent.text.includes('--flag root'), 'supertool read failed');
+    assert(superRead.structuredContent.codexpro_tool === 'read' && superRead.structuredContent.wrapped_tool === 'read' && superRead.structuredContent.text.includes('--flag root'), 'supertool read failed');
 
     const superSearch = await client.request('tools/call', {
       name: 'codexpro',
       arguments: { action: 'search', args: { workspace_id: ws, query: 'stress-needle-3', path: 'many', max_results: 20 } }
     });
-    assert(superSearch.structuredContent.wrapped_tool === 'search', 'supertool search did not report wrapped tool');
+    assert(superSearch.structuredContent.codexpro_tool === 'search' && superSearch.structuredContent.wrapped_tool === 'search', 'supertool search did not report wrapped tool');
     assert(superSearch.structuredContent.matches.length === 20, `supertool search returned ${superSearch.structuredContent.matches.length} matches`);
 
     const arrows = await Promise.all(Array.from({ length: 12 }, () =>
@@ -203,7 +203,7 @@ async function runFullModeStress(root) {
       name: 'codexpro',
       arguments: { action: 'handoff_poll', args: { workspace_id: ws, plan_hash: 'stress-plan', since_iteration: 6, max_wait_seconds: 1, poll_ms: 250 } }
     });
-    assert(superWait.structuredContent.wrapped_tool === 'wait_for_handoff' && superWait.structuredContent.succeeded === true, 'supertool handoff_poll failed');
+    assert(superWait.structuredContent.codexpro_tool === 'wait_for_handoff' && superWait.structuredContent.wrapped_tool === 'wait_for_handoff' && superWait.structuredContent.succeeded === true, 'supertool handoff_poll failed');
 
     const mismatch = await client.request('tools/call', {
       name: 'wait_for_handoff',
@@ -242,7 +242,7 @@ async function runFullModeStress(root) {
         }
       }
     });
-    assert(superExport.structuredContent.wrapped_tool === 'export_pro_context', 'supertool pro_export did not wrap export_pro_context');
+    assert(superExport.structuredContent.codexpro_tool === 'export_pro_context' && superExport.structuredContent.wrapped_tool === 'export_pro_context', 'supertool pro_export did not wrap export_pro_context');
     assert(superExport.structuredContent.files_included.length === 1 && superExport.structuredContent.files_included[0] === 'demo.txt', `supertool Pro export included wrong files: ${JSON.stringify(superExport.structuredContent.files_included)}`);
 
     const selfTest = await client.request('tools/call', { name: 'codexpro_self_test', arguments: { workspace_id: ws } });
@@ -277,7 +277,7 @@ async function runSupertoolModeStress(root) {
       name: 'codexpro',
       arguments: { action: 'read', args: { workspace_id: opened.structuredContent.workspace_id, path: 'demo.txt', start_line: 1, end_line: 2 } }
     });
-    assert(read.structuredContent.wrapped_tool === 'read' && read.structuredContent.text.includes('alpha'), 'minimal supertool read failed');
+    assert(read.structuredContent.codexpro_tool === 'read' && read.structuredContent.wrapped_tool === 'read' && read.structuredContent.text.includes('alpha'), 'minimal supertool read failed');
 
     const blockedSearch = await client.request('tools/call', {
       name: 'codexpro',

--- a/src/config.ts
+++ b/src/config.ts
@@ -274,7 +274,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
         ? args["tool-cards"]
         : undefined;
   const extraBlockedGlobs = splitList(process.env.CODEXPRO_BLOCKED_GLOBS, ",");
-  const host = hostArg ?? process.env.HOST ?? process.env.CODEXPRO_HOST ?? "127.0.0.1";
+  const host = hostArg ?? process.env.CODEXPRO_HOST ?? process.env.HOST ?? "127.0.0.1";
   const authToken = process.env.CODEXPRO_HTTP_TOKEN ?? process.env.CODEBASE_BRIDGE_HTTP_TOKEN;
   const allowNoToken = boolFrom(process.env.CODEXPRO_ALLOW_NO_HTTP_TOKEN, false);
   const requireHttpToken =
@@ -292,7 +292,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     defaultRoot,
     allowedRoots,
     host,
-    port: numberFrom(portArg ?? process.env.PORT ?? process.env.CODEXPRO_PORT, 8787, 1, 65535),
+    port: numberFrom(portArg ?? process.env.CODEXPRO_PORT ?? process.env.PORT, 8787, 1, 65535),
     widgetDomain: widgetDomainFrom(widgetDomainArg ?? process.env.CODEXPRO_WIDGET_DOMAIN),
     authToken,
     requireHttpToken,

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -2,9 +2,11 @@ const OPENAI_SECRET_PATTERN = /\bsk-[A-Za-z0-9_-]{10,}\b/g;
 const COMMON_TOKEN_PATTERN = /\b(?:sk-ant-[A-Za-z0-9_-]{10,}|gh[opsru]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{20,})\b/g;
 const BEARER_TOKEN_PATTERN = /\b(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi;
 const QUERY_TOKEN_PATTERN = /([?&](?:codexpro_token|token|access_token|auth_token|api[_-]?key)=)[^&\s"'`<>]{8,}/gi;
+const CODEXPRO_TOKEN_ASSIGNMENT_PATTERN = /\b(codexpro_token\s*=\s*)(?:"[^"\r\n]{8,512}"|'[^'\r\n]{8,512}'|`[^`\r\n]{8,512}`|[A-Za-z0-9_./+=-]{8,512})/gi;
+const CODEXPRO_TOKEN_FIELD_PATTERN = /(["']?codexpro_token["']?\s*:\s*)(?:"[^"\r\n]{8,512}"|'[^'\r\n]{8,512}'|`[^`\r\n]{8,512}`|[A-Za-z0-9_./+=-]{8,512})/gi;
 const SECRET_ASSIGNMENT_PATTERN = /\b[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}\s*=\s*(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi;
 const SECRET_FIELD_PATTERN = /(["']?[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}["']?\s*:\s*)(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi;
-const SECRET_PATTERNS = [OPENAI_SECRET_PATTERN, COMMON_TOKEN_PATTERN, BEARER_TOKEN_PATTERN, QUERY_TOKEN_PATTERN, SECRET_ASSIGNMENT_PATTERN, SECRET_FIELD_PATTERN];
+const SECRET_PATTERNS = [OPENAI_SECRET_PATTERN, COMMON_TOKEN_PATTERN, BEARER_TOKEN_PATTERN, QUERY_TOKEN_PATTERN, CODEXPRO_TOKEN_ASSIGNMENT_PATTERN, CODEXPRO_TOKEN_FIELD_PATTERN, SECRET_ASSIGNMENT_PATTERN, SECRET_FIELD_PATTERN];
 
 export function hasSecretValue(text: string): boolean {
   for (const pattern of SECRET_PATTERNS) {
@@ -19,6 +21,8 @@ export function hasSecretValue(text: string): boolean {
 
 export function redactSensitiveText(text: string): string {
   return text
+    .replace(CODEXPRO_TOKEN_ASSIGNMENT_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
+    .replace(CODEXPRO_TOKEN_FIELD_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
     .replace(SECRET_ASSIGNMENT_PATTERN, (match) => isPlaceholderSecret(match) ? match : redactSecretAssignment(match))
     .replace(SECRET_FIELD_PATTERN, (match, prefix) => isPlaceholderSecret(match) ? match : `${prefix}[REDACTED_SECRET]`)
     .replace(BEARER_TOKEN_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)

--- a/src/server.ts
+++ b/src/server.ts
@@ -667,7 +667,7 @@ function getSharedWorkspaceManager(config: CodexProConfig): WorkspaceManager {
 export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = getSharedWorkspaceManager(config);
   const guard = new PathGuard(config);
-  const server = new McpServer({ name: "CodexPro", version: "0.28.5" }, { instructions: serverInstructions(config) });
+  const server = new McpServer({ name: "CodexPro", version: "0.28.6" }, { instructions: serverInstructions(config) });
   registeredToolNamesByServer.set(server as object, []);
   registerToolCardResource(server, config);
 
@@ -739,6 +739,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       if (result && typeof result === "object") {
         const structured = result.structuredContent;
         result.structuredContent = {
+          codexpro_tool: action,
+          codexpro_title: action,
           codexpro_super_action: action,
           wrapped_tool: action,
           ...(structured && typeof structured === "object" && !Array.isArray(structured) ? structured : {})
@@ -1770,9 +1772,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         state = await readState();
       }
 
-      const completed = isAwaited(state);
+      const awaitedTerminal = isAwaited(state);
+      const awaitedCompleted = awaitedTerminal && state?.state === "completed";
       const planHashMismatch = Boolean(expectedPlanHash && state && state.plan_hash !== expectedPlanHash);
-      const reportedState = completed
+      const reportedState = awaitedTerminal
         ? String(state?.state)
         : state
           ? state.state === "running" || planHashMismatch || sinceIteration !== undefined
@@ -1802,9 +1805,9 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         workspace_id: workspace.id,
         root: workspace.root,
         state: reportedState,
-        awaited_completed: completed,
-        awaited_terminal: completed,
-        succeeded: completed && state?.state === "completed",
+        awaited_completed: awaitedCompleted,
+        awaited_terminal: awaitedTerminal,
+        succeeded: awaitedCompleted,
         state_file: stateRel,
         ...(state ? { run_state: state.state } : {}),
         ...(typeof state?.iteration === "number" ? { iteration: state.iteration } : {}),
@@ -1816,10 +1819,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         ...(state?.finished_at ? { finished_at: state.finished_at } : {}),
         ...(state?.executor ? { executor: state.executor } : {}),
         ...(state?.model ? { model: state.model } : {}),
-        ...(completed ? {} : { next_poll_after_seconds: Math.max(1, Math.ceil(pollMs / 1000)) })
+        ...(awaitedTerminal ? {} : { next_poll_after_seconds: Math.max(1, Math.ceil(pollMs / 1000)) })
       };
 
-      if (completed) {
+      if (awaitedTerminal) {
         const statusFile = bridgeArtifact(state?.status_file, `${config.contextDir}/agent-status.md`);
         const diffFile = bridgeArtifact(state?.diff_file, `${config.contextDir}/implementation-diff.patch`);
         const logFile = bridgeArtifact(state?.log_file, `${config.contextDir}/execution-log.jsonl`);
@@ -1848,7 +1851,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
 
       const summary = !state
         ? `No handoff run state found at ${stateRel}. Start a run with handoff_to_agent + local execute-handoff/watch-handoff, then call wait_for_handoff again.`
-        : completed
+        : awaitedTerminal
           ? `Handoff run ${state.state} (iteration ${state.iteration ?? 1}, exit ${state.exit_code ?? "null"}).`
           : planHashMismatch
             ? `Executor has not completed the expected plan yet (last known run plan_hash=${state.plan_hash ?? "unknown"}). Still waiting.`
@@ -1861,10 +1864,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         "",
         `State file: ${stateRel}`,
         ...(state?.plan_hash ? [`Plan hash: ${state.plan_hash}`] : []),
-        ...(completed && structured.status_excerpt ? ["", "## Status", "", `\`\`\`text\n${structured.status_excerpt}\n\`\`\``] : []),
-        ...(completed && structured.diff_excerpt ? ["", "## Diff", "", `\`\`\`diff\n${structured.diff_excerpt}\n\`\`\``] : []),
-        ...(completed && structured.tests_excerpt ? ["", "## Tests", "", `\`\`\`text\n${structured.tests_excerpt}\n\`\`\``] : []),
-        ...(completed && structured.log_excerpt ? ["", "## Log tail", "", `\`\`\`text\n${structured.log_excerpt}\n\`\`\``] : [])
+        ...(awaitedTerminal && structured.status_excerpt ? ["", "## Status", "", `\`\`\`text\n${structured.status_excerpt}\n\`\`\``] : []),
+        ...(awaitedTerminal && structured.diff_excerpt ? ["", "## Diff", "", `\`\`\`diff\n${structured.diff_excerpt}\n\`\`\``] : []),
+        ...(awaitedTerminal && structured.tests_excerpt ? ["", "## Tests", "", `\`\`\`text\n${structured.tests_excerpt}\n\`\`\``] : []),
+        ...(awaitedTerminal && structured.log_excerpt ? ["", "## Log tail", "", `\`\`\`text\n${structured.log_excerpt}\n\`\`\``] : [])
       ];
       return textResult(lines.join("\n"), structured);
     }


### PR DESCRIPTION
## Summary

- Bump CodexPro to `0.28.6` so merged post-`0.28.5` hardening does not pack as an already-published version.
- Fix CLI/env safety gaps: CodexPro-specific `CODEXPRO_HOST` / `CODEXPRO_PORT` now beat generic `HOST` / `PORT`; CLI accepts `--flag=value`; stable public hostnames are normalized/rejected consistently with admin.
- Fix MCP result truth: supertool-wrapped calls keep the child `codexpro_tool` tag, failed/timed-out handoffs are terminal but not `awaited_completed`, and short explicit `codexpro_token=` assignments/fields are redacted/blocked.
- Align docs/site tool lists and search fallback wording with runtime behavior.

## Validation

- `node --check scripts/codexpro.mjs`
- `npm run build`
- `node scripts/settings-smoke.mjs`
- `node scripts/http-smoke.mjs`
- `node scripts/smoke.mjs`
- `node scripts/stress.mjs`
- `npm run smoke`
- `npm run stress`
- `npm audit --audit-level=high`
- `git diff --check`
- `npm pack --dry-run`
