### PR TITLE
Fix supertool error tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ show_changes
 Full mode adds:
 
 - `codexpro_inventory` — list discovered skill names and configured MCP server names without exposing MCP command arguments or secrets.
-- `list_workspaces` — show opened workspaces in the current MCP session.
+- `list_workspaces` — show opened workspaces for the current CodexPro server/config.
 - `workspace_snapshot` — project status plus `.ai-bridge` handoff context.
 - `git_status` — inspect git status.
 - `git_diff` — inspect current diff.
@@ -343,6 +343,8 @@ _meta["openai/widgetCSP"]
 `CODEXPRO_WIDGET_DOMAIN` defaults to `https://rebel0789.github.io` for this package. For app submission, set it to a dedicated HTTPS origin you control, for example `https://widgets.yourdomain.com`. The CSP lists are intentionally strict because the widget has no external fetches, fonts, scripts, images, or iframes.
 
 After enabling cards, upgrading, or changing widget metadata, open the CodexPro app settings in ChatGPT Developer Mode and click `Refresh` / `Refresh actions` so ChatGPT reloads the tool descriptors and resource URI.
+
+If an old ChatGPT conversation still sees old tools or fails during discovery while `/healthz` and a fresh raw MCP `tools/list` are correct, treat that chat as stale. Start a brand-new ChatGPT chat, and for major visible schema/tool-count changes create a fresh connector/app name as well.
 
 ## Other Install Paths
 

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -285,6 +285,12 @@ async function runSupertoolModeStress(root) {
     });
     assert(blockedSearch.isError === true && String(blockedSearch.structuredContent.error).includes('not available'), 'supertool allowed disabled search action');
 
+    const missingRead = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'read', args: { workspace_id: opened.structuredContent.workspace_id, path: 'missing.txt' } }
+    });
+    assert(missingRead.isError === true && missingRead.structuredContent.codexpro_tool === 'read' && missingRead.structuredContent.wrapped_tool === 'read', 'supertool failed read was not tagged as read');
+
     const blockedBash = await client.request('tools/call', {
       name: 'codexpro',
       arguments: { action: 'bash', args: { workspace_id: opened.structuredContent.workspace_id, command: 'pwd' } }

--- a/src/server.ts
+++ b/src/server.ts
@@ -735,7 +735,12 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         args.args && typeof args.args === "object" && !Array.isArray(args.args)
           ? args.args
           : {};
-      const result = await handler(childArgs);
+      let result: any;
+      try {
+        result = await handler(childArgs);
+      } catch (error) {
+        result = errorResult(error);
+      }
       if (result && typeof result === "object") {
         const structured = result.structuredContent;
         result.structuredContent = {
@@ -1117,7 +1122,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     "list_workspaces",
     {
       title: "List Workspaces",
-      description: "List currently opened CodexPro workspaces for this MCP session.",
+      description: "List currently opened CodexPro workspaces for this server/config.",
       inputSchema: {},
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
@@ -1130,7 +1135,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const current = workspaces.listWorkspaces();
       const text = current.length
         ? current.map((workspace) => `- ${workspace.id} — ${workspace.root} (opened ${workspace.openedAt})`).join("\n")
-        : "No workspaces opened yet. Call open_workspace first.";
+        : "No workspaces opened on this CodexPro server/config yet. Call open_workspace first.";
       return textResult(text, { workspaces: current, count: current.length });
     }
   );


### PR DESCRIPTION
## Summary
- keep failed wrapped supertool calls tagged as the child action instead of `codexpro`
- add stress coverage for a failed wrapped `read` call in supertool mode
- clarify stale ChatGPT chat/tool-cache behavior and server-scoped workspace wording

## Verification
- `npm run build`
- `npm run stress`
- `npm run smoke`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`