### PR TITLE
Fix MCP bin help and docs truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ CodexPro is not a rate-limit bypass, model proxy, hosted SaaS, or OS sandbox. It
 | Default tool surface | `CODEXPRO_TOOL_MODE=standard` |
 | Full diagnostics | `codexpro start --tool-mode full` |
 | No ChatGPT-triggered shell | `codexpro start --no-bash` |
-| Compact chat transcript | default bash cards; use `--bash-transcript full` only when needed |
+| Compact chat transcript | default compact bash output; use `--bash-transcript full` only when needed |
 | Local Codex history lookup | opt in with `--codex-sessions metadata` or `read` |
+
+The GitHub `main` README can describe changes before they reach npm. Check the npm badge/version when installing with `npm install -g codexpro`; use the source-checkout path below for unreleased `main` behavior.
 
 ## Product Boundary
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,6 +41,8 @@ CodexPro 需要 Node.js 20+，以及能使用 Apps / Developer Mode 的 ChatGPT 
 npm install -g codexpro
 ```
 
+GitHub `main` 文档可能早于 npm 发布；用 `npm install -g codexpro` 前请看 npm badge/version，未发布的 `main` 行为请用下面的 source checkout 方式。
+
 进入你想让 ChatGPT 工作的仓库，然后运行 setup：
 
 ```bash
@@ -100,7 +102,7 @@ ChatGPT Web 可以操作：
 
 默认 `CODEXPRO_TOOL_MODE=standard`，只暴露常用编码循环、`codexpro_self_test`、`show_changes`、上下文导出和 handoff。演示时可以用 `--tool-mode minimal`，需要完整兼容工具时用 `--tool-mode full`。
 
-默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 仍会发现已安装的 user/plugin skills，并可用 `load_skill` 按名称、source 和显示出的 path 加载需要的 `SKILL.md`；如果仍有重名匹配，CodexPro 会报歧义错误，不会随便选一个，也不会把几十个 skill 变成单独 action。
+默认工具数量较少是故意的：ChatGPT 面对少量高信号工具时更稳定。workspace open 默认不做 skill discovery；需要 repo-local skills 时传 `include_skills=true`，需要 user/plugin skills 时再加 `include_global_skills=true`。然后用 `load_skill` 按名称、source 和显示出的 path 加载需要的 `SKILL.md`；如果仍有重名匹配，CodexPro 会报歧义错误，不会随便选一个，也不会把几十个 skill 变成单独 action。
 
 CodexPro 默认给 ChatGPT 暴露纯 MCP 工具描述，不附带 widget/card metadata。需要紧凑 v9 卡片时用 `CODEXPRO_TOOL_CARDS=1` 启动；server config、自测、workspace 摘要、读写 diff、bash 验证、git/tree/search/context 和 handoff/export 都有结构化视图。git、skills、tree、terminal 输出、context 和 raw diff 会折叠或截断，避免在聊天里刷出大段原始数据。`CODEXPRO_WIDGET_DOMAIN` 用于设置 ChatGPT widget iframe 的专用 HTTPS origin，正式提交 app 前应换成你控制的独立域名。
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@
 codexpro setup</code>
             <button class="copy-button" data-copy="npm install -g codexpro&#10;codexpro setup">Copy</button>
           </div>
+          <p class="eyebrow">Main docs may be ahead of npm; check the npm version or use a source checkout for unreleased behavior.</p>
           <div class="hero-proof" aria-label="Core capabilities">
             <span>one workspace</span>
             <span>token-protected URL</span>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -48,6 +48,7 @@
 codexpro setup</code>
             <button class="copy-button" data-copy="npm install -g codexpro&#10;codexpro setup">复制</button>
           </div>
+          <p class="eyebrow">main 文档可能早于 npm 发布；全局安装前请看 npm 版本，未发布行为用 source checkout。</p>
           <div class="hero-proof" aria-label="核心能力">
             <span>AGENTS.md 上下文</span>
             <span>.ai-bridge handoff</span>
@@ -333,8 +334,8 @@ codexpro start</code></pre>
           </article>
           <article>
             <small>可视卡片</small>
-            <h3>只给关键动作卡片</h3>
-            <p>open workspace 摘要、write/edit diff、show_changes 审查和 handoff 导出会显示紧凑卡片。skills、git 和 tree 详情默认折叠；<code>load_skill</code> 按需加载有限长度的说明，bash 保持纯数据。</p>
+            <h3>默认关闭，需要时开启</h3>
+            <p>默认只暴露纯 MCP 描述。用 <code>CODEXPRO_TOOL_CARDS=1</code> 开启后，workspace 摘要、读写 diff、bash、git/tree/search/context 和 handoff/export 都会使用紧凑结构化视图；长输出会折叠或截断。</p>
           </article>
           <article>
             <small>上下文持久化</small>

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -59,6 +59,23 @@ class McpStdioClient {
   }
 }
 
+const pkg = JSON.parse(await fs.readFile('package.json', 'utf8'));
+
+function assertCommand(args, expected) {
+  const result = spawnSync(process.execPath, args, { cwd: path.resolve('.'), encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  }
+  if (!result.stdout.includes(expected)) {
+    throw new Error(`${args.join(' ')} did not print ${expected}: ${result.stdout}`);
+  }
+}
+
+assertCommand(['dist/stdio.js', '--version'], pkg.version);
+assertCommand(['dist/stdio.js', '--help'], 'CodexPro MCP stdio server');
+assertCommand(['dist/http.js', '--version'], pkg.version);
+assertCommand(['dist/http.js', '--help'], 'CodexPro MCP HTTP server');
+
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-smoke-'));
 await fs.writeFile(path.join(tmp, 'demo.txt'), 'alpha\nread\nread\nomega\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'config.txt'), 'OPENAI_API_KEY=sk-realSecretValue123\n', 'utf8');

--- a/src/http.ts
+++ b/src/http.ts
@@ -408,6 +408,20 @@ const LOCAL_FAVICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 6
   <rect x="8" y="8" width="48" height="48" rx="12" fill="#ffffff" fill-opacity=".12" stroke="#ffffff" stroke-opacity=".38"/>
   <path d="M38.4 40.3c-1.8 1.1-3.9 1.7-6.3 1.7-6.1 0-10.3-4.2-10.3-10s4.2-10 10.4-10c2.4 0 4.5.6 6.2 1.7l-2.1 4.1c-1.1-.7-2.3-1-3.8-1-2.9 0-4.9 2.1-4.9 5.2s2 5.2 4.9 5.2c1.5 0 2.8-.4 3.9-1.1l2 4.2Z" fill="#ffffff"/>
 </svg>`;
+const CODEXPRO_VERSION = "0.28.6";
+
+function printHelp(): void {
+  console.log(`CodexPro MCP HTTP server
+
+Usage:
+  codexpro-mcp-http --root /path/to/repo --port 8787
+  codexpro-mcp-http --version
+  codexpro-mcp-http --help
+
+Set CODEXPRO_HTTP_TOKEN for public/tunnel use.
+For trusted local-only testing, set CODEXPRO_ALLOW_NO_HTTP_TOKEN=1.
+Most users should run: codexpro start`);
+}
 
 function onboardingPage(config: CodexProConfig): string {
   const localMcp = `http://${config.host}:${config.port}/mcp`;
@@ -1406,6 +1420,16 @@ function onboardingPage(config: CodexProConfig): string {
 }
 
 async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--version") || argv.includes("-v") || argv[0] === "version") {
+    console.log(CODEXPRO_VERSION);
+    return;
+  }
+  if (argv.includes("--help") || argv[0] === "help") {
+    printHelp();
+    return;
+  }
+
   const config = loadConfig();
   if (config.requireHttpToken && !config.authToken) {
     throw new Error(

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -3,7 +3,30 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { loadConfig } from "./config.js";
 import { createCodexProServer } from "./server.js";
 
+const CODEXPRO_VERSION = "0.28.6";
+
+function printHelp(): void {
+  console.log(`CodexPro MCP stdio server
+
+Usage:
+  codexpro-mcp --root /path/to/repo [--allow-root /path]
+  codexpro-mcp --version
+  codexpro-mcp --help
+
+Most users should run: codexpro start`);
+}
+
 async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--version") || argv.includes("-v") || argv[0] === "version") {
+    console.log(CODEXPRO_VERSION);
+    return;
+  }
+  if (argv.includes("--help") || argv[0] === "help") {
+    printHelp();
+    return;
+  }
+
   process.env.CODEXPRO_ALLOW_NO_HTTP_TOKEN ??= "1";
   const config = loadConfig();
   const server = createCodexProServer(config);


### PR DESCRIPTION
## Summary
- make `codexpro-mcp` and `codexpro-mcp-http` handle `--help` and `--version` before starting transports or checking HTTP auth
- add smoke coverage for direct MCP bin help/version output
- correct stale docs around compact bash output, opt-in skill discovery, opt-in cards, and main-vs-npm release truth

## Verification
- `npm run smoke`
- `npm run stress`
- `npm audit --audit-level=high`
- `git diff --check`
- `npm pack --dry-run --json`
- temp `npm pack` + global-prefix install, then `codexpro`, `codexpro-mcp`, and `codexpro-mcp-http` `--version`/`--help` checks