### PR TITLE
Fix handoff exits and guard escapes

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1113,11 +1113,13 @@ function splitCommandTemplate(input) {
   const tokens = [];
   let current = '';
   let quote = '';
+  let tokenStarted = false;
   const text = String(input);
   for (let i = 0; i < text.length; i += 1) {
     const char = text[i];
     if (char === '\\') {
       const next = text[i + 1];
+      tokenStarted = true;
       if (next && (next === quote || next === '\\' || (!quote && /\s|["']/.test(next)))) {
         current += next;
         i += 1;
@@ -1128,24 +1130,30 @@ function splitCommandTemplate(input) {
     }
     if (quote) {
       if (char === quote) quote = '';
-      else current += char;
+      else {
+        tokenStarted = true;
+        current += char;
+      }
       continue;
     }
     if (char === '"' || char === "'") {
       quote = char;
+      tokenStarted = true;
       continue;
     }
     if (/\s/.test(char)) {
-      if (current) {
+      if (tokenStarted) {
         tokens.push(current);
         current = '';
+        tokenStarted = false;
       }
       continue;
     }
+    tokenStarted = true;
     current += char;
   }
   if (quote) throw new Error('Custom command has an unterminated quote.');
-  if (current) tokens.push(current);
+  if (tokenStarted) tokens.push(current);
   return tokens;
 }
 
@@ -1217,6 +1225,7 @@ function executorCommandPreview(commandInfo) {
 function runProcessCaptured(command, args, options) {
   const timeoutMs = options.timeoutMs;
   const maxOutputBytes = options.maxOutputBytes;
+  const retainedOutputBytes = maxOutputBytes + 1;
   const started = Date.now();
   return new Promise((resolve) => {
     const child = spawn(command, args, {
@@ -1228,6 +1237,14 @@ function runProcessCaptured(command, args, options) {
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    const appendBounded = (current, chunk) => {
+      if (Buffer.byteLength(current, 'utf8') > retainedOutputBytes) return current;
+      const next = current + String(chunk);
+      const buffer = Buffer.from(next, 'utf8');
+      return buffer.byteLength > retainedOutputBytes
+        ? buffer.subarray(0, retainedOutputBytes).toString('utf8')
+        : next;
+    };
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill('SIGTERM');
@@ -1238,12 +1255,10 @@ function runProcessCaptured(command, args, options) {
     timer.unref();
 
     child.stdout.on('data', (chunk) => {
-      stdout += String(chunk);
-      if (Buffer.byteLength(stdout, 'utf8') > maxOutputBytes * 2) child.kill('SIGTERM');
+      stdout = appendBounded(stdout, chunk);
     });
     child.stderr.on('data', (chunk) => {
-      stderr += String(chunk);
-      if (Buffer.byteLength(stderr, 'utf8') > maxOutputBytes * 2) child.kill('SIGTERM');
+      stderr = appendBounded(stderr, chunk);
     });
     child.on('error', (error) => {
       clearTimeout(timer);
@@ -1430,7 +1445,7 @@ async function executeHandoffRequest(request, args, options = {}) {
     timeoutMs: request.timeoutMs,
     maxOutputBytes: request.maxOutputBytes
   });
-  const diffText = readGitDiff(request.root, request.maxOutputBytes);
+  const diffText = readGitDiffExcludingContext(request.root, request.contextDir, request.maxOutputBytes);
   const outputs = writeExecutionOutputs(request.root, request.contextDir, request.commandInfo, result, diffText);
 
   const runState = result.timedOut ? 'timed_out' : (result.exitCode === 0 ? 'completed' : 'failed');
@@ -1472,7 +1487,7 @@ async function runExecuteHandoff(argv) {
   }
 
   const execution = await executeHandoffRequest(request, args);
-  if (execution.result?.exitCode && execution.result.exitCode !== 0) process.exitCode = execution.result.exitCode;
+  if (execution.result && execution.result.exitCode !== 0) process.exitCode = execution.result.exitCode ?? 1;
 }
 
 function planHash(planText) {
@@ -1662,7 +1677,7 @@ async function runWatchHandoff(argv) {
     });
 
     if (args.once) {
-      if (exitCode && exitCode !== 0) process.exitCode = exitCode;
+      if (execution.result && execution.result.exitCode !== 0) process.exitCode = execution.result.exitCode ?? 1;
       return;
     }
 

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -71,6 +71,25 @@ if (missingPlaceholder.status === 0 || !missingPlaceholder.stderr.includes('must
   throw new Error(`custom command without plan placeholder should fail\nstdout:\n${missingPlaceholder.stdout}\nstderr:\n${missingPlaceholder.stderr}`);
 }
 
+await fs.writeFile(path.join(root, 'empty-arg-agent.mjs'), `
+const emptyIndex = process.argv.indexOf('--empty');
+if (emptyIndex < 0 || process.argv[emptyIndex + 1] !== '') {
+  console.error(\`EMPTY_ARG=\${JSON.stringify(process.argv[emptyIndex + 1])}\`);
+  process.exit(7);
+}
+`, 'utf8');
+const emptyArg = run([
+  'execute-handoff',
+  '--root',
+  root,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} empty-arg-agent.mjs --empty "" --task-file {{plan_file}}`,
+  '--yes'
+]);
+requireSuccess(emptyArg, 'execute-handoff empty quoted arg');
+
 const executed = run([
   'execute-handoff',
   '--root',
@@ -113,6 +132,85 @@ if (runState.exit_code !== 0 || runState.timed_out !== false || runState.executo
 }
 if (!runState.plan_hash || !runState.started_at || !runState.finished_at || runState.status_file !== '.ai-bridge/agent-status.md') {
   throw new Error(`handoff-run-state missing lifecycle fields\n${runStateRaw}`);
+}
+
+const executeStagedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-execute-staged-untracked-'));
+await fs.mkdir(path.join(executeStagedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(executeStagedRoot, '.ai-bridge', 'current-plan.md'), '# Staged plan\n\nStage one edit and create one file.\n', 'utf8');
+await fs.writeFile(path.join(executeStagedRoot, 'app.txt'), 'base\n', 'utf8');
+await fs.writeFile(path.join(executeStagedRoot, 'stage-agent.mjs'), `
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+fs.appendFileSync('app.txt', 'staged change\\n');
+spawnSync('git', ['add', 'app.txt'], { stdio: 'inherit' });
+fs.writeFileSync('new-feature.txt', 'new feature\\n');
+`, 'utf8');
+requireSuccess(spawnSync('git', ['init'], { cwd: executeStagedRoot, encoding: 'utf8' }), 'execute staged git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: executeStagedRoot, encoding: 'utf8' }), 'execute staged git add');
+requireSuccess(run([
+  'execute-handoff',
+  '--root',
+  executeStagedRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} stage-agent.mjs --task-file {{plan_file}}`,
+  '--yes'
+]), 'execute-handoff staged/untracked diff');
+const executeStagedDiff = await fs.readFile(path.join(executeStagedRoot, '.ai-bridge', 'implementation-diff.patch'), 'utf8');
+if (!executeStagedDiff.includes('# Staged diff') || !executeStagedDiff.includes('staged change') || !executeStagedDiff.includes('# Untracked files') || !executeStagedDiff.includes('new-feature.txt')) {
+  throw new Error(`execute-handoff diff missed staged or untracked changes\n${executeStagedDiff}`);
+}
+
+const timeoutRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-execute-timeout-'));
+await fs.mkdir(path.join(timeoutRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(timeoutRoot, '.ai-bridge', 'current-plan.md'), '# Timeout plan\n\nSleep too long.\n', 'utf8');
+await fs.writeFile(path.join(timeoutRoot, 'slow-agent.mjs'), `setTimeout(() => {}, 5000);\n`, 'utf8');
+const timeoutRun = run([
+  'execute-handoff',
+  '--root',
+  timeoutRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} slow-agent.mjs --task-file {{plan_file}}`,
+  '--timeout-ms',
+  '50',
+  '--yes'
+]);
+if (timeoutRun.status === 0) {
+  throw new Error(`execute-handoff timeout exited successfully\nstdout:\n${timeoutRun.stdout}\nstderr:\n${timeoutRun.stderr}`);
+}
+const timeoutState = await fs.readFile(path.join(timeoutRoot, '.ai-bridge', 'handoff-run-state.json'), 'utf8');
+if (!timeoutState.includes('"state": "timed_out"') || !timeoutState.includes('"exit_code": null')) {
+  throw new Error(`execute-handoff timeout state was wrong\n${timeoutState}`);
+}
+
+const noisyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-execute-noisy-'));
+await fs.mkdir(path.join(noisyRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(noisyRoot, '.ai-bridge', 'current-plan.md'), '# Noisy plan\n\nPrint a lot, then edit.\n', 'utf8');
+await fs.writeFile(path.join(noisyRoot, 'app.txt'), 'base\n', 'utf8');
+await fs.writeFile(path.join(noisyRoot, 'noisy-agent.mjs'), `
+import fs from 'node:fs';
+console.log('x'.repeat(200000));
+fs.appendFileSync('app.txt', 'after noisy output\\n');
+`, 'utf8');
+requireSuccess(run([
+  'execute-handoff',
+  '--root',
+  noisyRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} noisy-agent.mjs --task-file {{plan_file}}`,
+  '--max-output-bytes',
+  '2048',
+  '--yes'
+]), 'execute-handoff noisy output');
+const noisyApp = await fs.readFile(path.join(noisyRoot, 'app.txt'), 'utf8');
+const noisyStatus = await fs.readFile(path.join(noisyRoot, '.ai-bridge', 'agent-status.md'), 'utf8');
+if (!noisyApp.includes('after noisy output') || !noisyStatus.includes('[output truncated to 4000 bytes]')) {
+  throw new Error(`execute-handoff output cap killed or failed to truncate\napp:\n${noisyApp}\nstatus:\n${noisyStatus}`);
 }
 
 const watchRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-watch-handoff-'));
@@ -175,6 +273,33 @@ const watchState = await fs.readFile(path.join(watchRoot, '.ai-bridge', 'watch-h
 const watchLog = await fs.readFile(path.join(watchRoot, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
 if (!watchState.includes('lastPlanHash') || !watchLog.includes('"event":"watch_handoff_started"') || !watchLog.includes('"event":"watch_handoff_finished"')) {
   throw new Error(`watch did not write state/log\nstate:\n${watchState}\nlog:\n${watchLog}`);
+}
+
+const watchTimeoutRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-watch-timeout-'));
+await fs.mkdir(path.join(watchTimeoutRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(watchTimeoutRoot, '.ai-bridge', 'current-plan.md'), '# Watch timeout\n\nSleep too long.\n', 'utf8');
+await fs.writeFile(path.join(watchTimeoutRoot, 'slow-agent.mjs'), `setTimeout(() => {}, 5000);\n`, 'utf8');
+const watchTimeoutRun = run([
+  'watch-handoff',
+  '--root',
+  watchTimeoutRoot,
+  '--agent',
+  'custom',
+  '--command',
+  `${quoteArg(process.execPath)} slow-agent.mjs --task-file {{plan_file}}`,
+  '--once',
+  '--timeout-ms',
+  '50',
+  '--yes',
+  '--debounce-ms',
+  '0'
+]);
+if (watchTimeoutRun.status === 0) {
+  throw new Error(`watch-handoff timeout exited successfully\nstdout:\n${watchTimeoutRun.stdout}\nstderr:\n${watchTimeoutRun.stderr}`);
+}
+const watchTimeoutState = await fs.readFile(path.join(watchTimeoutRoot, '.ai-bridge', 'handoff-run-state.json'), 'utf8');
+if (!watchTimeoutState.includes('"state": "timed_out"') || !watchTimeoutState.includes('"exit_code": null')) {
+  throw new Error(`watch-handoff timeout state was wrong\n${watchTimeoutState}`);
 }
 
 const loopRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-handoff-'));
@@ -354,31 +479,31 @@ if (!barePassLog.includes('"stop_reason":"unknown_verdict"')) {
   throw new Error(`loop did not reject bare PASS as unknown verdict\nlog:\n${barePassLog}`);
 }
 
-const stagedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-staged-change-'));
-await fs.mkdir(path.join(stagedRoot, '.ai-bridge'), { recursive: true });
-await fs.writeFile(path.join(stagedRoot, '.ai-bridge', 'current-plan.md'), '# Staged plan\n\nStage a change.\n', 'utf8');
-await fs.writeFile(path.join(stagedRoot, 'app.txt'), 'start\n', 'utf8');
-await fs.writeFile(path.join(stagedRoot, 'stage-agent.mjs'), `
+const loopStagedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-loop-staged-change-'));
+await fs.mkdir(path.join(loopStagedRoot, '.ai-bridge'), { recursive: true });
+await fs.writeFile(path.join(loopStagedRoot, '.ai-bridge', 'current-plan.md'), '# Staged plan\n\nStage a change.\n', 'utf8');
+await fs.writeFile(path.join(loopStagedRoot, 'app.txt'), 'start\n', 'utf8');
+await fs.writeFile(path.join(loopStagedRoot, 'stage-agent.mjs'), `
 import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 fs.appendFileSync('app.txt', 'staged change\\n');
 const result = spawnSync('git', ['add', 'app.txt'], { stdio: 'inherit' });
 process.exit(result.status ?? 1);
 `, 'utf8');
-await fs.writeFile(path.join(stagedRoot, 'reviewer.mjs'), `
+await fs.writeFile(path.join(loopStagedRoot, 'reviewer.mjs'), `
 import fs from 'node:fs';
 const diffPath = process.argv[process.argv.indexOf('--diff') + 1];
 const diff = fs.readFileSync(diffPath, 'utf8');
 if (!diff.includes('# Staged diff') || !diff.includes('staged change')) process.exit(4);
 console.log('CODEXPRO_REVIEW=PASS');
 `, 'utf8');
-requireSuccess(spawnSync('git', ['init'], { cwd: stagedRoot, encoding: 'utf8' }), 'staged git init');
-requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: stagedRoot, encoding: 'utf8' }), 'staged git add');
+requireSuccess(spawnSync('git', ['init'], { cwd: loopStagedRoot, encoding: 'utf8' }), 'staged git init');
+requireSuccess(spawnSync('git', ['add', 'app.txt'], { cwd: loopStagedRoot, encoding: 'utf8' }), 'staged git add');
 
 const stagedRun = run([
   'loop-handoff',
   '--root',
-  stagedRoot,
+  loopStagedRoot,
   '--agent',
   'custom',
   '--command',

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -123,6 +123,22 @@ await fs.writeFile(path.join(tmp, '.agents', 'skills', 'smoke-skill', 'SKILL.md'
   '# Duplicate Smoke Skill',
   ''
 ].join('\n'), 'utf8');
+const outsideSkillRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-outside-skills-'));
+await fs.mkdir(path.join(outsideSkillRoot, 'outside-skill'), { recursive: true });
+await fs.writeFile(path.join(outsideSkillRoot, 'outside-skill', 'SKILL.md'), [
+  '---',
+  'name: outside-skill',
+  'description: Outside workspace skill.',
+  '---',
+  '',
+  '# Outside Skill',
+  ''
+].join('\n'), 'utf8');
+try {
+  await fs.symlink(outsideSkillRoot, path.join(tmp, 'skills'), 'dir');
+} catch (error) {
+  if (process.platform !== 'win32' || error?.code !== 'EPERM') throw error;
+}
 await fs.writeFile(path.join(tmp, 'package.json'), JSON.stringify({
   scripts: {
     'build:clients': "node -e \"console.log('clients ok')\""
@@ -130,6 +146,18 @@ await fs.writeFile(path.join(tmp, 'package.json'), JSON.stringify({
 }, null, 2), 'utf8');
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-outside-'));
 await fs.writeFile(path.join(outside, 'secret.txt'), 'do-not-read', 'utf8');
+const danglingSymlinks = [];
+for (const [linkPath, targetPath] of [
+  ['dangling-outside.txt', path.join(outside, 'created-outside.txt')],
+  ['dangling-env.txt', path.join(tmp, '.env')]
+]) {
+  try {
+    await fs.symlink(targetPath, path.join(tmp, linkPath));
+    danglingSymlinks.push(linkPath);
+  } catch (error) {
+    if (process.platform !== 'win32' || error?.code !== 'EPERM') throw error;
+  }
+}
 let symlinkEscapePath = 'secret-link.txt';
 try {
   await fs.symlink(path.join(outside, 'secret.txt'), path.join(tmp, symlinkEscapePath));
@@ -250,6 +278,9 @@ const currentWithSkills = await client.request('tools/call', { name: 'open_curre
 if (!currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
   throw new Error('open_current_workspace did not discover workspace skill inventory when requested');
 }
+if (currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'outside-skill')) {
+  throw new Error('open_current_workspace followed a symlinked workspace skill root outside the workspace');
+}
 const selfTest = await client.request('tools/call', {
   name: 'codexpro_self_test',
   arguments: {
@@ -291,6 +322,7 @@ if (loadedSkill.structuredContent.skill?.name !== 'smoke-skill' || !loadedSkill.
   throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
 }
 await expectToolError('load_skill', { name: 'missing-skill' }, /Skill not found/);
+await expectToolError('load_skill', { name: 'outside-skill', source: 'workspace', include_global_skills: false }, /Skill not found/);
 const inventory = await client.request('tools/call', { name: 'codexpro_inventory', arguments: { include_global_skills: false, include_mcp_servers: false } });
 if (inventory.structuredContent.codexpro_tool !== 'codexpro_inventory') throw new Error('inventory result was not tagged for widget rendering');
 const opened = await client.request('tools/call', { name: 'open_workspace', arguments: { root: tmp, include_tree: true } });
@@ -337,6 +369,9 @@ if (envRefPayload.includes('[REDACTED_SECRET]')) {
 }
 const symlinkRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: symlinkEscapePath } });
 if (!symlinkRead.isError) throw new Error('symlink escape read was not blocked');
+for (const linkPath of danglingSymlinks) {
+  await expectToolError('write', { workspace_id: ws, path: linkPath, content: 'escaped write\n' }, /symlink/i);
+}
 await client.request('tools/call', { name: 'edit', arguments: { workspace_id: ws, path: 'demo.txt', old_text: 'read\nread', new_text: 'read\nwrite' } });
 const changes = await client.request('tools/call', { name: 'show_changes', arguments: { workspace_id: ws } });
 if (!changes.structuredContent.changed || !changes.structuredContent.diff.includes('demo.txt')) {

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -3,7 +3,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { CodexProConfig } from "./config.js";
-import type { Workspace } from "./guard.js";
+import { isSubpath, type Workspace } from "./guard.js";
 
 export interface SkillInventoryItem {
   name: string;
@@ -79,6 +79,14 @@ async function safeReaddir(dir: string): Promise<fs.Dirent[]> {
   }
 }
 
+function realpathOrUndefined(filePath: string): string | undefined {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
 function displayPath(absPath: string, workspaceRoot: string): string {
   const home = os.homedir();
   if (absPath === workspaceRoot) return "$WORKSPACE";
@@ -150,10 +158,16 @@ async function discoverSkillRecords(
   options: { includeGlobal?: boolean; maxSkills?: number } = {}
 ): Promise<SkillInventoryRecord[]> {
   const maxSkills = Math.max(1, Math.min(options.maxSkills ?? 120, 500));
-  const roots = [
+  const workspaceRoots = [
     path.join(workspace.root, ".codex", "skills"),
     path.join(workspace.root, ".agents", "skills"),
-    path.join(workspace.root, "skills"),
+    path.join(workspace.root, "skills")
+  ].flatMap((dir) => {
+    const real = realpathOrUndefined(dir);
+    return real && isSubpath(real, workspace.root) ? [real] : [];
+  });
+  const roots = [
+    ...workspaceRoots,
     ...(options.includeGlobal
       ? [
           path.join(os.homedir(), ".codex", "skills"),
@@ -171,20 +185,22 @@ async function discoverSkillRecords(
 
   const items: SkillInventoryRecord[] = [];
   for (const file of skillFiles.slice(0, maxSkills)) {
+    const realFile = realpathOrUndefined(file) ?? file;
+    if (isSubpath(file, workspace.root) && !isSubpath(realFile, workspace.root)) continue;
     let text = "";
     try {
-      text = await safeReadText(file);
+      text = await safeReadText(realFile);
     } catch {
       // Keep the skill visible even if the file cannot be read.
     }
-    const name = frontmatterValue(text, "name") ?? path.basename(path.dirname(file));
+    const name = frontmatterValue(text, "name") ?? path.basename(path.dirname(realFile));
     const description = frontmatterValue(text, "description");
     items.push({
       name,
       description,
-      source: skillSource(file, workspace.root),
-      path: displayPath(file, workspace.root),
-      absPath: file
+      source: skillSource(realFile, workspace.root),
+      path: displayPath(realFile, workspace.root),
+      absPath: realFile
     });
   }
 
@@ -240,6 +256,12 @@ export async function loadSkill(
   const [skill] = matches;
   if (path.basename(skill.absPath) !== "SKILL.md") {
     throw new Error(`Refusing to load non-skill file: ${skill.path}`);
+  }
+  if (skill.source === "workspace") {
+    const realSkillPath = realpathOrUndefined(skill.absPath);
+    if (!realSkillPath || !isSubpath(realSkillPath, workspace.root)) {
+      throw new Error(`Refusing to load workspace skill outside workspace: ${skill.path}`);
+    }
   }
   const maxBytes = Math.max(1_000, Math.min(options.maxBytes ?? 40_000, 100_000));
   const loaded = await readTextWithStats(skill.absPath, maxBytes);

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -149,6 +149,13 @@ export class PathGuard {
     }
 
     if (options.forWrite) {
+      try {
+        if (fs.lstatSync(absPath).isSymbolicLink()) {
+          throw new CodexProError(`Refusing to write through a symlink: ${inputPath}`);
+        }
+      } catch (error) {
+        if (error instanceof CodexProError) throw error;
+      }
       const parent = closestExistingParent(path.dirname(absPath));
       const realParent = maybeRealpath(parent);
       if (realParent && !isSubpath(realParent, workspace.root)) {


### PR DESCRIPTION
## Summary
- reject final-path symlink writes and skip symlinked workspace skill roots that resolve outside the workspace
- preserve staged and untracked diffs for `execute-handoff` while still excluding `.ai-bridge` context artifacts
- make `execute-handoff` / `watch-handoff --once` exit nonzero on timeout or signal-killed child processes
- keep noisy agent output bounded without killing the child process before it can finish
- preserve empty quoted args in custom handoff command templates

## Verification
- `npm run stress`
- `npm run smoke`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- `git diff --check`

## Notes
This does not change the GPT-5.5 Pro boundary: CodexPro still cannot make a ChatGPT model surface call MCP/App tools if OpenAI does not expose tools for that selected surface.