### PR TITLE
Fix timeout escalation and ripgrep regex search

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1237,6 +1237,7 @@ function runProcessCaptured(command, args, options) {
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    let closed = false;
     const appendBounded = (current, chunk) => {
       if (Buffer.byteLength(current, 'utf8') > retainedOutputBytes) return current;
       const next = current + String(chunk);
@@ -1249,7 +1250,7 @@ function runProcessCaptured(command, args, options) {
       timedOut = true;
       child.kill('SIGTERM');
       setTimeout(() => {
-        if (!child.killed) child.kill('SIGKILL');
+        if (!closed) child.kill('SIGKILL');
       }, 1500).unref();
     }, timeoutMs);
     timer.unref();
@@ -1273,6 +1274,7 @@ function runProcessCaptured(command, args, options) {
       });
     });
     child.on('close', (exitCode, signal) => {
+      closed = true;
       clearTimeout(timer);
       const out = trimBytes(stdout, maxOutputBytes);
       const err = trimBytes(`${stderr}${timedOut ? `\n[codexpro] Command timed out after ${timeoutMs} ms.` : ''}`, maxOutputBytes);

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -186,6 +186,38 @@ if (!timeoutState.includes('"state": "timed_out"') || !timeoutState.includes('"e
   throw new Error(`execute-handoff timeout state was wrong\n${timeoutState}`);
 }
 
+if (process.platform !== 'win32') {
+  const stubbornRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-execute-stubborn-timeout-'));
+  await fs.mkdir(path.join(stubbornRoot, '.ai-bridge'), { recursive: true });
+  await fs.writeFile(path.join(stubbornRoot, '.ai-bridge', 'current-plan.md'), '# Stubborn timeout plan\n\nIgnore SIGTERM.\n', 'utf8');
+  await fs.writeFile(path.join(stubbornRoot, 'stubborn-agent.mjs'), `
+process.on('SIGTERM', () => console.log('ignored SIGTERM'));
+setTimeout(() => process.exit(42), 6000);
+setInterval(() => {}, 1000);
+`, 'utf8');
+  const stubbornStarted = Date.now();
+  const stubbornRun = run([
+    'execute-handoff',
+    '--root',
+    stubbornRoot,
+    '--agent',
+    'custom',
+    '--command',
+    `${quoteArg(process.execPath)} stubborn-agent.mjs --task-file {{plan_file}}`,
+    '--timeout-ms',
+    '1000',
+    '--yes'
+  ]);
+  const stubbornDuration = Date.now() - stubbornStarted;
+  if (stubbornRun.status === 0 || stubbornDuration > 5000) {
+    throw new Error(`execute-handoff stubborn timeout did not escalate\nstatus: ${stubbornRun.status}\nduration: ${stubbornDuration}\nstdout:\n${stubbornRun.stdout}\nstderr:\n${stubbornRun.stderr}`);
+  }
+  const stubbornStatus = await fs.readFile(path.join(stubbornRoot, '.ai-bridge', 'agent-status.md'), 'utf8');
+  if (!stubbornStatus.includes('Timed out: yes') || !stubbornStatus.includes('Signal: SIGKILL')) {
+    throw new Error(`execute-handoff stubborn timeout status was wrong\n${stubbornStatus}`);
+  }
+}
+
 const noisyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-execute-noisy-'));
 await fs.mkdir(path.join(noisyRoot, '.ai-bridge'), { recursive: true });
 await fs.writeFile(path.join(noisyRoot, '.ai-bridge', 'current-plan.md'), '# Noisy plan\n\nPrint a lot, then edit.\n', 'utf8');

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -239,6 +239,15 @@ const cardSearch = await cardClient.request('tools/call', {
 if (!cardSearch.structuredContent.text?.includes('read')) {
   throw new Error(`CODEXPRO_TOOL_CARDS=1 search did not include structured text: ${JSON.stringify(cardSearch.structuredContent)}`);
 }
+if (spawnSync(process.platform === 'win32' ? 'where' : 'sh', process.platform === 'win32' ? ['rg'] : ['-lc', 'command -v rg >/dev/null 2>&1']).status === 0) {
+  const cardRegexSearch = await cardClient.request('tools/call', {
+    name: 'search',
+    arguments: { workspace_id: cardOpened.structuredContent.workspace_id, query: '(?i)READ', path: 'demo.txt', regex: true, max_results: 5 }
+  });
+  if (!cardRegexSearch.structuredContent.matches?.length || cardRegexSearch.structuredContent.used !== 'ripgrep') {
+    throw new Error(`ripgrep regex search did not accept rg syntax: ${JSON.stringify(cardRegexSearch.structuredContent)}`);
+  }
+}
 await cardClient.close();
 const resources = await client.request('resources/list', {});
 const toolCard = resources.resources.find((resource) => resource.uri === toolCardUri);

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -158,6 +158,14 @@ async function runFullModeStress(root) {
     assert(largeSearch.structuredContent.matches.length === 2000, `expected 2000 search matches, got ${largeSearch.structuredContent.matches.length}`);
     assert(largeSearch.structuredContent.truncated === true, 'large search did not report truncation');
     assert(!('text' in largeSearch.structuredContent), 'search duplicated text in structuredContent with cards off');
+
+    if (spawnSync(process.platform === 'win32' ? 'where' : 'sh', process.platform === 'win32' ? ['rg'] : ['-lc', 'command -v rg >/dev/null 2>&1']).status === 0) {
+      const rgRegex = await client.request('tools/call', {
+        name: 'search',
+        arguments: { workspace_id: ws, query: '(?i)STRESS-NEEDLE-3', path: 'many', regex: true, max_results: 10 }
+      });
+      assert(rgRegex.structuredContent.used === 'ripgrep' && rgRegex.structuredContent.matches.length === 10, 'ripgrep regex search rejected rg syntax');
+    }
 
     const superRead = await client.request('tools/call', {
       name: 'codexpro',

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -25,7 +25,9 @@ export interface SearchResult {
 
 function commandExists(command: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn("/bin/sh", ["-lc", `command -v ${command} >/dev/null 2>&1`], { stdio: "ignore" });
+    const child = process.platform === "win32"
+      ? spawn("where", [command], { stdio: "ignore", shell: false })
+      : spawn("/bin/sh", ["-lc", `command -v ${command} >/dev/null 2>&1`], { stdio: "ignore" });
     child.on("close", (code) => resolve(code === 0));
     child.on("error", () => resolve(false));
   });
@@ -127,15 +129,6 @@ export async function searchWorkspace(config: CodexProConfig, guard: PathGuard, 
     includeHidden: Boolean(rawOptions.includeHidden),
     maxResults: Math.max(1, Math.min(rawOptions.maxResults ?? config.maxSearchResults, config.maxSearchResults))
   };
-  if (options.regex) {
-    try {
-      // Validate early for fallback and clearer errors.
-      new RegExp(options.query);
-    } catch (error) {
-      throw new CodexProError(`Invalid regex: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-
   if (await commandExists("rg")) {
     return runRipgrep(config, guard, workspace, options);
   }


### PR DESCRIPTION
## Summary
- escalate timed-out local agent commands to SIGKILL based on process close state, not `child.killed`
- allow ripgrep-native regex syntax like `(?i)needle` by removing JavaScript regex prevalidation when `rg` is available
- detect `rg` on Windows with `where` instead of hardcoded `/bin/sh`
- add smoke/stress coverage for SIGTERM-ignoring handoff agents and ripgrep regex syntax

## Verification
- `node --check scripts/codexpro.mjs && node --check scripts/execute-handoff-smoke.mjs && node --check scripts/smoke.mjs && node --check scripts/stress.mjs`
- `npm run build`
- `node scripts/execute-handoff-smoke.mjs`
- `node scripts/smoke.mjs`
- `node scripts/stress.mjs`
- `npm run smoke`
- `npm run stress`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- `git diff --check`

## Notes
No npm publish in this PR. The public registry is still `codexpro@0.28.5` until an explicit publish happens.