### PR TITLE
[codex] fix stress hardening regressions

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -388,6 +388,16 @@ function writeOption(args, profile, mode) {
   return effectiveWriteMode(mode, optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff'));
 }
 
+function validateChoice(flag, value, allowed) {
+  if (allowed.includes(value)) return value;
+  throw new Error(`--${flag} must be ${allowed.slice(0, -1).join(', ')}, or ${allowed.at(-1)}`);
+}
+
+function optionalChoice(flag, value, allowed) {
+  if (!value) return '';
+  return validateChoice(flag, value, allowed);
+}
+
 function optionalWriteOption(args, profile, mode) {
   const requested = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], '');
   return requested ? effectiveWriteMode(mode, requested) : '';
@@ -820,7 +830,7 @@ function runHelperScript(scriptName, args) {
   const scriptPath = path.join(projectRoot, 'scripts', scriptName);
   const result = spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: projectRoot,
-    env: process.env,
+    env: { ...process.env, CODEXPRO_CALLER_CWD: process.cwd() },
     stdio: 'inherit'
   });
   if (result.error) throw result.error;
@@ -919,9 +929,16 @@ function waitForCloudflareUrl(child, timeoutMs = 45000) {
       const text = String(chunk);
       buffer += text;
       const match = buffer.match(re);
-      if (match?.[0]) {
+      const tunnelUrl = match?.find((url) => {
+        try {
+          return new URL(url).hostname !== 'api.trycloudflare.com';
+        } catch {
+          return false;
+        }
+      });
+      if (tunnelUrl) {
         clearTimeout(timer);
-        resolve(match[0]);
+        resolve(tunnelUrl);
       }
     };
     child.stdout.on('data', onData);
@@ -2538,6 +2555,10 @@ async function runDoctor(argv) {
   record(fs.existsSync(httpPath) && fs.existsSync(serverPath) ? 'ok' : 'fail', 'Build artifacts', fs.existsSync(httpPath) ? 'dist ready' : 'missing dist/http.js; run npm install && npm run build');
   record(fs.existsSync(path.join(projectRoot, 'package.json')) ? 'ok' : 'fail', 'Package root', projectRoot);
   record(profile.profilePath ? 'ok' : 'warn', 'Saved profile', profile.profilePath ? profileSummary(profile) || profile.profilePath : 'none for this workspace');
+  record(['agent', 'handoff', 'pro'].includes(mode) ? 'ok' : 'fail', 'Mode', ['agent', 'handoff', 'pro'].includes(mode) ? mode : '--mode must be agent, handoff, or pro');
+  record(['off', 'safe', 'full'].includes(bash) ? 'ok' : 'fail', 'Bash mode', ['off', 'safe', 'full'].includes(bash) ? bash : '--bash must be off, safe, or full');
+  record(['off', 'handoff', 'workspace'].includes(write) ? 'ok' : 'fail', 'Write mode', ['off', 'handoff', 'workspace'].includes(write) ? write : '--write must be off, handoff, or workspace');
+  record(['minimal', 'standard', 'full'].includes(toolMode) ? 'ok' : 'fail', 'Tool mode', ['minimal', 'standard', 'full'].includes(toolMode) ? toolMode : '--tool-mode must be minimal, standard, or full');
   record(clipboard ? 'ok' : 'warn', 'Clipboard', clipboard || 'not found; URL will be printed for manual copy');
   record(browser ? 'ok' : 'warn', 'Browser open', browser || 'not found; open ChatGPT manually');
 
@@ -2765,10 +2786,7 @@ async function maybeConfigureFirstRun(root, args, profile) {
 }
 
 function commandPreview(args) {
-  return ['codexpro', ...args].map((part) => {
-    if (/^[A-Za-z0-9_./:@=-]+$/.test(part)) return part;
-    return JSON.stringify(part);
-  }).join(' ');
+  return shellCommandPreview(['codexpro', ...args]);
 }
 
 async function runSetupWizard(argv) {
@@ -3006,7 +3024,7 @@ function saveSettingsFromArgs(root, args, profile) {
   if (!['agent', 'handoff', 'pro'].includes(mode)) {
     throw new Error('--mode must be agent, handoff, or pro');
   }
-  const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? '');
+  const toolMode = optionalChoice('tool-mode', optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? ''), ['minimal', 'standard', 'full']);
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], profile.widgetDomain ?? '');
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
   const bashTranscript = bashTranscriptOption(args, profile);
@@ -3014,6 +3032,7 @@ function saveSettingsFromArgs(root, args, profile) {
   const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], profile.codexDir ?? '');
   const { bashSession, requireBashSession } = bashSessionOptions(args, profile);
   const write = writeOption(args, profile, mode);
+  const bash = optionalChoice('bash', optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], profile.bash ?? ''), ['off', 'safe', 'full']);
   const tunnelName = args.tunnelName ?? profile.tunnelName ?? '';
   const ngrokConfig = resolveConfigPath(root, args.ngrokConfig ?? profile.ngrokConfig ?? '');
   const cloudflareConfig = resolveConfigPath(root, args.cloudflareConfig ?? profile.cloudflareConfig ?? '');
@@ -3031,7 +3050,7 @@ function saveSettingsFromArgs(root, args, profile) {
     ...(cloudflareConfig ? { cloudflareConfig } : {}),
     ...(cloudflareTokenFile ? { cloudflareTokenFile } : {}),
     ...(token ? { token } : {}),
-    ...(args.bash ?? profile.bash ? { bash: args.bash ?? profile.bash } : {}),
+    ...(bash ? { bash } : {}),
     ...(bashTranscript !== 'compact' ? { bashTranscript } : {}),
     ...(codexSessions !== 'off' ? { codexSessions } : {}),
     ...(codexDir ? { codexDir } : {}),
@@ -3378,9 +3397,9 @@ async function main() {
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], 'https://rebel0789.github.io');
   const toolCards = optionBool(args, profile, 'toolCards', ['CODEXPRO_TOOL_CARDS'], false);
-  if (!['off', 'safe', 'full'].includes(bash)) throw new Error('--bash must be off, safe, or full');
-  if (!['off', 'handoff', 'workspace'].includes(write)) throw new Error('--write must be off, handoff, or workspace');
-  if (!['minimal', 'standard', 'full'].includes(toolMode)) throw new Error('--tool-mode must be minimal, standard, or full');
+  validateChoice('bash', bash, ['off', 'safe', 'full']);
+  validateChoice('write', write, ['off', 'handoff', 'workspace']);
+  validateChoice('tool-mode', toolMode, ['minimal', 'standard', 'full']);
 
   let token = args.noAuth ? '' : optionValue(args, profile, 'token', ['CODEXPRO_HTTP_TOKEN', 'CODEBASE_BRIDGE_HTTP_TOKEN'], '');
   if (!token && !args.noAuth) token = stableToken();

--- a/scripts/doctor-smoke.mjs
+++ b/scripts/doctor-smoke.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
@@ -54,6 +55,35 @@ for (const expected of ['CodexPro doctor', 'Node', 'Build artifacts', 'Local por
   if (!output.includes(expected)) {
     throw new Error(`doctor output missing ${expected}\n${output}`);
   }
+}
+
+const invalidRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-doctor-invalid-'));
+const invalidRealRoot = await fs.realpath(invalidRoot);
+const invalidId = createHash('sha256').update(invalidRealRoot).digest('hex').slice(0, 24);
+await fs.mkdir(path.join(home, 'profiles'), { recursive: true });
+await fs.writeFile(path.join(home, 'profiles', `${invalidId}.json`), JSON.stringify({
+  version: 1,
+  root: invalidRealRoot,
+  updatedAt: new Date().toISOString(),
+  tunnel: 'none',
+  bash: 'banana',
+  toolMode: 'banana'
+}, null, 2), 'utf8');
+const invalidDoctor = spawnSync(process.execPath, [
+  'scripts/codexpro.mjs',
+  'doctor',
+  '--root',
+  invalidRoot,
+  '--port',
+  String(await getFreePort())
+], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_HOME: home },
+  encoding: 'utf8'
+});
+const invalidOutput = `${invalidDoctor.stdout}\n${invalidDoctor.stderr}`;
+if (invalidDoctor.status === 0 || !invalidOutput.includes('Bash mode') || !invalidOutput.includes('Tool mode')) {
+  throw new Error(`doctor did not reject invalid saved profile\nstdout:\n${invalidDoctor.stdout}\nstderr:\n${invalidDoctor.stderr}`);
 }
 
 console.log('✓ doctor smoke test passed');

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -71,7 +71,7 @@ async function waitForHealthJson(url, timeoutMs = 15000) {
   throw new Error(`timeout waiting for ${url}\n${lastError}`);
 }
 
-async function expectHttpTokenRequired(name, overrides = {}) {
+async function expectHttpTokenRequired(name, overrides = {}, options = {}) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), `codexpro-http-no-token-${name}-`));
   const port = await getFreePort();
   const env = {
@@ -86,7 +86,7 @@ async function expectHttpTokenRequired(name, overrides = {}) {
   };
   delete env.CODEXPRO_HTTP_TOKEN;
   delete env.CODEBASE_BRIDGE_HTTP_TOKEN;
-  delete env.CODEXPRO_ALLOW_NO_HTTP_TOKEN;
+  if (!options.keepAllowNoToken) delete env.CODEXPRO_ALLOW_NO_HTTP_TOKEN;
 
   const child = spawn('node', ['dist/http.js'], {
     cwd: path.resolve('.'),
@@ -134,6 +134,7 @@ function hasToolCardStatusMeta(tools, name) {
 
 await expectHttpTokenRequired('loopback-default');
 await expectHttpTokenRequired('non-loopback', { CODEXPRO_HOST: '0.0.0.0' });
+await expectHttpTokenRequired('non-loopback-allow-no-token', { CODEXPRO_HOST: '0.0.0.0', CODEXPRO_ALLOW_NO_HTTP_TOKEN: '1' }, { keepAllowNoToken: true });
 await expectHttpTokenRequired('tunnel-mode', { CODEXPRO_TUNNEL_MODE: '1' });
 
 async function withClient(url, fn) {
@@ -212,6 +213,36 @@ try {
   const queryAuthorized = await fetch(`${baseUrl}/healthz?codexpro_token=${encodeURIComponent(token)}`);
   if (queryAuthorized.status !== 200) {
     throw new Error(`expected URL-token healthz to return 200, got ${queryAuthorized.status}`);
+  }
+
+  const badAdminJson = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{"tunnel":'
+  });
+  const badAdminBody = await badAdminJson.json();
+  if (badAdminJson.status !== 400 || badAdminBody.error?.code !== 'invalid_json') {
+    throw new Error(`expected invalid admin JSON to return structured 400, got ${badAdminJson.status} ${JSON.stringify(badAdminBody)}`);
+  }
+
+  const badMcpJson = await fetch(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{"jsonrpc":'
+  });
+  const badMcpBody = await badMcpJson.json();
+  if (badMcpJson.status !== 400 || badMcpBody.error?.code !== -32700) {
+    throw new Error(`expected invalid MCP JSON to return JSON-RPC parse error, got ${badMcpJson.status} ${JSON.stringify(badMcpBody)}`);
+  }
+
+  const hugeMcpJson = await fetch(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { filler: 'x'.repeat(21 * 1024 * 1024) } })
+  });
+  const hugeMcpBody = await hugeMcpJson.json();
+  if (hugeMcpJson.status !== 413 || hugeMcpBody.error?.code !== -32000) {
+    throw new Error(`expected oversized MCP body to return JSON-RPC payload error, got ${hugeMcpJson.status} ${JSON.stringify(hugeMcpBody)}`);
   }
 
   const favicon = await fetch(`${baseUrl}/favicon.ico`);

--- a/scripts/pro-apply.mjs
+++ b/scripts/pro-apply.mjs
@@ -26,14 +26,16 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const raw = argv[i];
     if (!raw.startsWith('--')) continue;
-    const key = raw.slice(2);
+    const eq = raw.indexOf('=');
+    const key = eq === -1 ? raw.slice(2) : raw.slice(2, eq);
+    const inlineValue = eq === -1 ? undefined : raw.slice(eq + 1);
     if (key === 'help') out.help = true;
     else if (key === 'stdin') out.stdin = true;
     else if (key === 'append') out.append = true;
     else {
-      const next = argv[i + 1];
+      const next = inlineValue ?? argv[i + 1];
       if (!next || next.startsWith('--')) throw new Error(`Missing value for --${key}`);
-      i += 1;
+      if (inlineValue === undefined) i += 1;
       out[key.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = next;
     }
   }
@@ -57,7 +59,8 @@ async function readPlan(args) {
   if (args.stdin && args.file) throw new Error('Use either --stdin or --file, not both.');
   if (args.stdin) return readStdin();
   if (!args.file) throw new Error('Missing --file <path> or --stdin.');
-  return fsp.readFile(path.resolve(args.file), 'utf8');
+  const callerCwd = process.env.CODEXPRO_CALLER_CWD || process.cwd();
+  return fsp.readFile(path.isAbsolute(args.file) ? args.file : path.resolve(callerCwd, args.file), 'utf8');
 }
 
 function normalizePlan(rawPlan, title) {
@@ -89,11 +92,11 @@ async function main() {
   const guard = new PathGuard(config);
   const workspaces = new WorkspaceManager(config);
   const workspace = workspaces.openWorkspace(config.defaultRoot);
-  await ensureAiBridge(config, guard, workspace);
 
   const planPath = `${config.contextDir}/current-plan.md`;
   const rawPlan = await readPlan(args);
   const newPlan = normalizePlan(rawPlan, args.title);
+  await ensureAiBridge(config, guard, workspace);
   let content = newPlan;
 
   if (args.append) {

--- a/scripts/pro-bundle.mjs
+++ b/scripts/pro-bundle.mjs
@@ -33,7 +33,9 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const raw = argv[i];
     if (!raw.startsWith('--')) continue;
-    const key = raw.slice(2);
+    const eq = raw.indexOf('=');
+    const key = eq === -1 ? raw.slice(2) : raw.slice(2, eq);
+    const inlineValue = eq === -1 ? undefined : raw.slice(eq + 1);
     if (key === 'help') out.help = true;
     else if (key === 'copy') out.copy = true;
     else if (key === 'no-important-files') out.noImportantFiles = true;
@@ -41,9 +43,9 @@ function parseArgs(argv) {
     else if (key === 'no-diff') out.noDiff = true;
     else if (key === 'no-ai-bridge') out.noAiBridge = true;
     else {
-      const next = argv[i + 1];
+      const next = inlineValue ?? argv[i + 1];
       if (!next || next.startsWith('--')) throw new Error(`Missing value for --${key}`);
-      i += 1;
+      if (inlineValue === undefined) i += 1;
       if (key === 'path') out.paths.push(next);
       else if (key === 'glob') out.globs.push(next);
       else out[key.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = next;

--- a/scripts/pro-smoke.mjs
+++ b/scripts/pro-smoke.mjs
@@ -15,19 +15,36 @@ function run(args, options = {}) {
   return result;
 }
 
+function runFail(args, options = {}) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+    ...options
+  });
+  if (result.status === 0) {
+    throw new Error(`${args.join(' ')} unexpectedly passed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  return result;
+}
+
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-pro-smoke-'));
+const codexproCli = path.resolve('scripts/codexpro.mjs');
 await fs.writeFile(path.join(root, 'README.md'), '# Demo\n', 'utf8');
 await fs.writeFile(path.join(root, 'demo.txt'), 'alpha\nbeta\n', 'utf8');
 
-run(['scripts/pro-bundle.mjs', '--root', root, '--path', 'demo.txt', '--max-files', '4', '--max-total-bytes', '80000']);
+run(['scripts/pro-bundle.mjs', `--root=${root}`, '--path=demo.txt', '--max-files', '4', '--max-total-bytes', '80000']);
 const proContext = await fs.readFile(path.join(root, '.ai-bridge', 'pro-context.md'), 'utf8');
 if (!proContext.includes('CodexPro Context Bundle') || !proContext.includes('demo.txt')) {
   throw new Error('pro context bundle did not include expected content');
 }
+
+const selectedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-pro-selected-'));
+await fs.writeFile(path.join(selectedRoot, 'README.md'), '# Selected\n', 'utf8');
+await fs.writeFile(path.join(selectedRoot, 'demo.txt'), 'selected only\n', 'utf8');
 run([
   'scripts/pro-bundle.mjs',
-  '--root', root,
-  '--path', 'demo.txt',
+  `--root=${selectedRoot}`,
+  '--path=demo.txt',
   '--no-important-files',
   '--no-changed-files',
   '--no-diff',
@@ -35,7 +52,11 @@ run([
   '--max-files', '4',
   '--max-total-bytes', '80000'
 ]);
-const exactProContext = await fs.readFile(path.join(root, '.ai-bridge', 'pro-context.md'), 'utf8');
+const selectedBridgeFiles = await fs.readdir(path.join(selectedRoot, '.ai-bridge'));
+if (selectedBridgeFiles.join(',') !== 'pro-context.md') {
+  throw new Error(`selected-only pro context created unexpected bridge files: ${selectedBridgeFiles.join(', ')}`);
+}
+const exactProContext = await fs.readFile(path.join(selectedRoot, '.ai-bridge', 'pro-context.md'), 'utf8');
 if (!exactProContext.includes('Auto-include important root files: no') || !exactProContext.includes('Auto-include changed files: no')) {
   throw new Error('selected-only pro context did not record disabled auto-inclusion settings');
 }
@@ -43,16 +64,28 @@ if (!exactProContext.includes('### demo.txt') || exactProContext.includes('### R
   throw new Error('selected-only pro context did not include exactly the requested file');
 }
 
+run([codexproCli, 'pro-bundle', `--root=${root}`, '--path=demo.txt', '--max-files=4', '--max-total-bytes=80000']);
+
 const planFile = path.join(root, 'plan.md');
 await fs.writeFile(planFile, 'Inspect demo.txt and keep changes narrow.\n', 'utf8');
-run(['scripts/pro-apply.mjs', '--root', root, '--file', planFile, '--title', 'Smoke Pro Plan']);
+run(['scripts/pro-apply.mjs', `--root=${root}`, `--file=${planFile}`, '--title', 'Smoke Pro Plan']);
+run([codexproCli, 'pro-apply', `--root=${root}`, '--file=plan.md', '--title', 'Relative Pro Plan'], { cwd: root });
 const currentPlan = await fs.readFile(path.join(root, '.ai-bridge', 'current-plan.md'), 'utf8');
-if (!currentPlan.includes('Smoke Pro Plan') || !currentPlan.includes('Inspect demo.txt')) {
+if (!currentPlan.includes('Relative Pro Plan') || !currentPlan.includes('Inspect demo.txt')) {
   throw new Error('pro apply did not write expected current-plan content');
 }
 const executionLog = await fs.readFile(path.join(root, '.ai-bridge', 'execution-log.jsonl'), 'utf8');
 if (!executionLog.includes('"event":"pro_apply"')) {
   throw new Error('pro apply did not append execution-log event');
+}
+
+const missingRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-pro-missing-'));
+runFail(['scripts/pro-apply.mjs', `--root=${missingRoot}`, '--file=missing-plan.md'], { env: { ...process.env, CODEXPRO_CALLER_CWD: missingRoot } });
+try {
+  await fs.stat(path.join(missingRoot, '.ai-bridge'));
+  throw new Error('failed pro-apply created .ai-bridge before validating input');
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error;
 }
 
 console.log('✓ pro CLI smoke test passed');

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -233,6 +233,28 @@ if (guardedProfile.bashSession !== 'guarded-main' || guardedProfile.requireBashS
   throw new Error(`settings profile did not persist bash session guard: ${JSON.stringify(guardedProfile)}`);
 }
 
+runFail([
+  'settings',
+  'set',
+  '--root',
+  policyRoot,
+  '--tunnel',
+  'none',
+  '--bash',
+  'banana'
+], env, /--bash must be off, safe, or full/i);
+
+runFail([
+  'settings',
+  'set',
+  '--root',
+  policyRoot,
+  '--tunnel',
+  'none',
+  '--tool-mode',
+  'banana'
+], env, /--tool-mode must be minimal, standard, or full/i);
+
 const runtimePort = await getFreePort();
 const runtimePath = await runtimeStatusPath(runtimeRoot, home);
 run([
@@ -254,6 +276,37 @@ await withStartedCodexPro([
   const runtime = await waitForJson(runtimePath, (data) => data.toolCards === true, 'tool-cards runtime status');
   if (runtime.toolCards !== true) {
     throw new Error(`runtime status did not persist toolCards: ${JSON.stringify(runtime)}`);
+  }
+});
+
+const cloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-'));
+const cloudflarePort = await getFreePort();
+const cloudflarePath = await runtimeStatusPath(cloudflareRoot, home);
+const fakeCloudflared = path.join(home, 'fake-cloudflared.mjs');
+await fs.writeFile(fakeCloudflared, [
+  '#!/usr/bin/env node',
+  "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
+  "console.error('https://api.trycloudflare.com/tunnel');",
+  "setTimeout(() => console.error('https://real-codexpro.trycloudflare.com'), 100);",
+  'setInterval(() => {}, 1000);',
+  ''
+].join('\n'), { mode: 0o700 });
+await withStartedCodexPro([
+  '--root',
+  cloudflareRoot,
+  '--tunnel',
+  'cloudflare',
+  '--cloudflared',
+  fakeCloudflared,
+  '--port',
+  String(cloudflarePort),
+  '--token',
+  'codexpro-cloudflare-token',
+  '--no-copy-url'
+], env, async () => {
+  const runtime = await waitForJson(cloudflarePath, (data) => data.endpoint?.includes('trycloudflare.com'), 'cloudflare runtime status');
+  if (runtime.endpoint.includes('api.trycloudflare.com') || !runtime.endpoint.startsWith('https://real-codexpro.trycloudflare.com/mcp')) {
+    throw new Error(`quick tunnel saved the wrong endpoint: ${JSON.stringify(runtime)}`);
   }
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -276,7 +276,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
   const extraBlockedGlobs = splitList(process.env.CODEXPRO_BLOCKED_GLOBS, ",");
   const host = hostArg ?? process.env.CODEXPRO_HOST ?? process.env.HOST ?? "127.0.0.1";
   const authToken = process.env.CODEXPRO_HTTP_TOKEN ?? process.env.CODEBASE_BRIDGE_HTTP_TOKEN;
-  const allowNoToken = boolFrom(process.env.CODEXPRO_ALLOW_NO_HTTP_TOKEN, false);
+  const allowNoToken = boolFrom(process.env.CODEXPRO_ALLOW_NO_HTTP_TOKEN, false) && isLoopbackHost(host);
   const requireHttpToken =
     (!authToken && !allowNoToken) ||
     boolFrom(process.env.CODEXPRO_REQUIRE_HTTP_TOKEN, false) ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -1675,6 +1675,40 @@ async function main(): Promise<void> {
   app.get("/mcp", handleSessionRequest);
   app.delete("/mcp", handleSessionRequest);
 
+  app.use((error: unknown, req: Request, res: Response, next: NextFunction) => {
+    if (!error || typeof error !== "object" || !("type" in error)) {
+      next(error);
+      return;
+    }
+    const type = String((error as { type?: unknown }).type ?? "");
+    if (type !== "entity.parse.failed" && type !== "entity.too.large") {
+      next(error);
+      return;
+    }
+    const status = type === "entity.too.large" ? 413 : 400;
+    if (req.path === "/mcp") {
+      res.status(status).json({
+        jsonrpc: "2.0",
+        error: {
+          code: type === "entity.too.large" ? -32000 : -32700,
+          message: type === "entity.too.large" ? "Payload too large." : "Parse error."
+        },
+        id: null
+      });
+      return;
+    }
+    if (req.path === "/admin/profile") {
+      jsonError(
+        res,
+        status,
+        type === "entity.too.large" ? "payload_too_large" : "invalid_json",
+        type === "entity.too.large" ? "Request body is too large." : "Request body must be valid JSON."
+      );
+      return;
+    }
+    next(error);
+  });
+
   app.listen(config.port, config.host, () => {
     console.error(`[CodexPro] HTTP MCP listening on http://${config.host}:${config.port}/mcp`);
     console.error(`[CodexPro] defaultRoot=${config.defaultRoot}`);

--- a/src/proContext.ts
+++ b/src/proContext.ts
@@ -308,9 +308,13 @@ export async function exportProContext(
   workspace: Workspace,
   options: ProContextOptions = {}
 ): Promise<ProContextResult> {
-  await ensureAiBridge(config, guard, workspace);
+  if (options.includeAiBridge !== false) {
+    await ensureAiBridge(config, guard, workspace);
+  }
   const built = await buildProContext(config, guard, workspace, options);
   built.markdown = redactSensitiveText(built.markdown);
+  const contextDir = guard.resolve(workspace, config.contextDir, { forWrite: true });
+  await fsp.mkdir(contextDir.absPath, { recursive: true, mode: 0o700 });
   const relPath = `${config.contextDir}/pro-context.md`;
   const write = await writeTextFile(config, guard, workspace, relPath, built.markdown, {
     createDirs: true,


### PR DESCRIPTION
## Summary
- keep the no-token HTTP escape hatch loopback-only so non-loopback binds still fail closed without CODEXPRO_HTTP_TOKEN
- return structured JSON/JSON-RPC errors for malformed or oversized HTTP bodies
- fix Pro helper cwd and --flag=value handling, and avoid scaffolding the full bridge for selected-only Pro bundles
- harden Cloudflare quick-tunnel URL parsing, saved settings validation, doctor profile checks, and setup command shell quoting

## Truth / support boundary
This improves repo-owned behavior only. It does not make GPT-5.5 Pro call MCP/App tools when OpenAI blocks tool calls on that model/surface. The supported path remains: gather/export context through a tool-capable model or agent mode, then hand that context to Pro reasoning.

## Validation
- npm run build
- node scripts/pro-smoke.mjs
- node scripts/doctor-smoke.mjs
- node scripts/settings-smoke.mjs
- node scripts/http-smoke.mjs
- npm run smoke
- npm run stress
- npm audit --audit-level=high
- npm pack --dry-run --json
- git diff --check
- local PTY setup preview: path containing $HOME is single-quoted in the printed command

## PR triage
Open PRs checked on 2026-06-29: #40, #19, and #18 are outsider PRs; #42 is an owner draft but dirty/combined. I did not merge them. This PR carries the minimal useful Cloudflare quick-tunnel behavior from #40 plus the confirmed new stress-test fixes.