### PR TITLE
[codex] fix edge case hardening

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -874,12 +874,16 @@ function portInUseHelp(host, port) {
   ].join('\n');
 }
 
-async function assertPortAvailable(host, port) {
+function normalizePort(port) {
   const numericPort = Number(port);
   if (!Number.isInteger(numericPort) || numericPort <= 0 || numericPort > 65535) {
     throw new Error(`Invalid port: ${port}`);
   }
+  return String(numericPort);
+}
 
+async function assertPortAvailable(host, port) {
+  const numericPort = Number(normalizePort(port));
   await new Promise((resolve, reject) => {
     const server = net.createServer();
     server.once('error', (error) => {
@@ -2517,7 +2521,14 @@ async function runDoctor(argv) {
   const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], '8787'));
   const mode = optionValue(args, profile, 'mode', ['CODEXPRO_MODE'], 'agent');
   const bash = optionValue(args, profile, 'bash', ['CODEXPRO_BASH_MODE'], 'safe');
-  const write = writeOption(args, profile, mode);
+  const rawWrite = optionValue(args, profile, 'write', ['CODEXPRO_WRITE_MODE'], mode === 'agent' ? 'workspace' : 'handoff');
+  let write = String(rawWrite);
+  let writeError = '';
+  try {
+    write = effectiveWriteMode(mode, rawWrite);
+  } catch (error) {
+    writeError = error instanceof Error ? error.message : String(error);
+  }
   const toolMode = optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], 'standard');
   const stableHostname = args.hostname
     ?? args.url
@@ -2557,7 +2568,7 @@ async function runDoctor(argv) {
   record(profile.profilePath ? 'ok' : 'warn', 'Saved profile', profile.profilePath ? profileSummary(profile) || profile.profilePath : 'none for this workspace');
   record(['agent', 'handoff', 'pro'].includes(mode) ? 'ok' : 'fail', 'Mode', ['agent', 'handoff', 'pro'].includes(mode) ? mode : '--mode must be agent, handoff, or pro');
   record(['off', 'safe', 'full'].includes(bash) ? 'ok' : 'fail', 'Bash mode', ['off', 'safe', 'full'].includes(bash) ? bash : '--bash must be off, safe, or full');
-  record(['off', 'handoff', 'workspace'].includes(write) ? 'ok' : 'fail', 'Write mode', ['off', 'handoff', 'workspace'].includes(write) ? write : '--write must be off, handoff, or workspace');
+  record(!writeError && ['off', 'handoff', 'workspace'].includes(write) ? 'ok' : 'fail', 'Write mode', writeError || write);
   record(['minimal', 'standard', 'full'].includes(toolMode) ? 'ok' : 'fail', 'Tool mode', ['minimal', 'standard', 'full'].includes(toolMode) ? toolMode : '--tool-mode must be minimal, standard, or full');
   record(clipboard ? 'ok' : 'warn', 'Clipboard', clipboard || 'not found; URL will be printed for manual copy');
   record(browser ? 'ok' : 'warn', 'Browser open', browser || 'not found; open ChatGPT manually');
@@ -2822,8 +2833,7 @@ async function runSetupWizard(argv) {
     const defaultPort = String(optionValue(defaults, profile, 'port', ['CODEXPRO_PORT'], '8787'));
     const defaultMode = normalizeSetupChoice(optionValue(defaults, profile, 'mode', ['CODEXPRO_MODE'], 'agent'), ['agent', 'handoff', 'pro'], 'agent');
 
-    const port = await ask(rl, 'Which local port should CodexPro use?', defaultPort);
-    if (!/^\d+$/.test(port)) throw new Error('Port must be a number.');
+    const port = normalizePort(await ask(rl, 'Which local port should CodexPro use?', defaultPort));
     const modeAnswer = await ask(rl, 'Mode: agent, handoff, or pro?', defaultMode);
     const mode = normalizeSetupChoice(modeAnswer, ['agent', 'handoff', 'pro'], defaultMode);
 
@@ -2843,7 +2853,7 @@ async function runSetupWizard(argv) {
     const codexSessions = codexSessionsOption(defaults, profile);
     const codexDir = optionValue(defaults, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], '');
     const write = optionalWriteOption(defaults, profile, mode);
-    const toolMode = optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], '');
+    const toolMode = optionalChoice('tool-mode', optionValue(defaults, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], ''), ['minimal', 'standard', 'full']);
     const widgetDomain = optionValue(defaults, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], '');
     const toolCardsEntry = toolCardsProfileEntry(defaults, profile);
     if (bash) args.push('--bash', bash);
@@ -3026,7 +3036,7 @@ function saveSettingsFromArgs(root, args, profile) {
   }
   const toolMode = optionalChoice('tool-mode', optionValue(args, profile, 'toolMode', ['CODEXPRO_TOOL_MODE'], profile.toolMode ?? ''), ['minimal', 'standard', 'full']);
   const widgetDomain = optionValue(args, profile, 'widgetDomain', ['CODEXPRO_WIDGET_DOMAIN'], profile.widgetDomain ?? '');
-  const port = String(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
+  const port = normalizePort(optionValue(args, profile, 'port', ['CODEXPRO_PORT'], profile.port ?? '8787'));
   const bashTranscript = bashTranscriptOption(args, profile);
   const codexSessions = codexSessionsOption(args, profile);
   const codexDir = optionValue(args, profile, 'codexDir', ['CODEXPRO_CODEX_DIR'], profile.codexDir ?? '');

--- a/scripts/doctor-smoke.mjs
+++ b/scripts/doctor-smoke.mjs
@@ -67,6 +67,7 @@ await fs.writeFile(path.join(home, 'profiles', `${invalidId}.json`), JSON.string
   updatedAt: new Date().toISOString(),
   tunnel: 'none',
   bash: 'banana',
+  write: 'banana',
   toolMode: 'banana'
 }, null, 2), 'utf8');
 const invalidDoctor = spawnSync(process.execPath, [
@@ -82,7 +83,7 @@ const invalidDoctor = spawnSync(process.execPath, [
   encoding: 'utf8'
 });
 const invalidOutput = `${invalidDoctor.stdout}\n${invalidDoctor.stderr}`;
-if (invalidDoctor.status === 0 || !invalidOutput.includes('Bash mode') || !invalidOutput.includes('Tool mode')) {
+if (invalidDoctor.status === 0 || !invalidOutput.includes('Bash mode') || !invalidOutput.includes('Write mode') || !invalidOutput.includes('Tool mode')) {
   throw new Error(`doctor did not reject invalid saved profile\nstdout:\n${invalidDoctor.stdout}\nstderr:\n${invalidDoctor.stderr}`);
 }
 

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -209,6 +209,19 @@ try {
   if (authorized.status !== 200) {
     throw new Error(`expected authenticated healthz to return 200, got ${authorized.status}`);
   }
+  const authorizedJson = await authorized.json();
+  if (authorizedJson.authRequired !== true) {
+    throw new Error(`expected authenticated healthz to report authRequired=true, got ${JSON.stringify(authorizedJson)}`);
+  }
+
+  for (const header of [`bearer ${token}`, `Bearer    ${token}`]) {
+    const variant = await fetch(`${baseUrl}/healthz`, {
+      headers: { Authorization: header }
+    });
+    if (variant.status !== 200) {
+      throw new Error(`expected authorization header variant ${JSON.stringify(header)} to return 200, got ${variant.status}`);
+    }
+  }
 
   const queryAuthorized = await fetch(`${baseUrl}/healthz?codexpro_token=${encodeURIComponent(token)}`);
   if (queryAuthorized.status !== 200) {
@@ -338,6 +351,17 @@ try {
     savedProfile.token !== token
   ) {
     throw new Error(`admin profile save wrote unexpected profile: ${JSON.stringify(savedProfile)}`);
+  }
+
+  const localProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ tunnel: 'none' })
+  });
+  const localProfileJson = await localProfile.json();
+  const localSavedProfile = JSON.parse(await fs.readFile(localProfileJson.profile_path, 'utf8'));
+  if (localProfile.status !== 200 || localSavedProfile.hostname || localProfileJson.profile?.hostname || localProfileJson.effective?.hostname) {
+    throw new Error(`admin profile local-only save kept a stale hostname: ${JSON.stringify(localProfileJson)} ${JSON.stringify(localSavedProfile)}`);
   }
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);

--- a/scripts/pro-apply.mjs
+++ b/scripts/pro-apply.mjs
@@ -55,12 +55,16 @@ async function readStdin() {
   return Buffer.concat(chunks).toString('utf8');
 }
 
+function resolvePlanPath(args) {
+  const callerCwd = process.env.CODEXPRO_CALLER_CWD || process.cwd();
+  return path.isAbsolute(args.file) ? args.file : path.resolve(callerCwd, args.file);
+}
+
 async function readPlan(args) {
   if (args.stdin && args.file) throw new Error('Use either --stdin or --file, not both.');
   if (args.stdin) return readStdin();
   if (!args.file) throw new Error('Missing --file <path> or --stdin.');
-  const callerCwd = process.env.CODEXPRO_CALLER_CWD || process.cwd();
-  return fsp.readFile(path.isAbsolute(args.file) ? args.file : path.resolve(callerCwd, args.file), 'utf8');
+  return fsp.readFile(resolvePlanPath(args), 'utf8');
 }
 
 function normalizePlan(rawPlan, title) {
@@ -118,7 +122,7 @@ async function main() {
   const executionLogResolved = guard.resolve(workspace, executionLogRel, { forWrite: true });
   const event = jsonlEvent('pro_apply', {
     plan_path: planPath,
-    source_file: args.file ? path.resolve(args.file) : 'stdin',
+    source_file: args.file ? resolvePlanPath(args) : 'stdin',
     append: Boolean(args.append)
   });
   await fsp.appendFile(logResolved.absPath, event, 'utf8');

--- a/scripts/pro-smoke.mjs
+++ b/scripts/pro-smoke.mjs
@@ -78,6 +78,10 @@ const executionLog = await fs.readFile(path.join(root, '.ai-bridge', 'execution-
 if (!executionLog.includes('"event":"pro_apply"')) {
   throw new Error('pro apply did not append execution-log event');
 }
+const proApplyEvents = executionLog.trim().split('\n').map((line) => JSON.parse(line));
+if (!proApplyEvents.some((event) => event.source_file === planFile)) {
+  throw new Error(`pro apply logged the wrong source file\n${executionLog}`);
+}
 
 const missingRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-pro-missing-'));
 runFail(['scripts/pro-apply.mjs', `--root=${missingRoot}`, '--file=missing-plan.md'], { env: { ...process.env, CODEXPRO_CALLER_CWD: missingRoot } });

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -255,6 +255,17 @@ runFail([
   'banana'
 ], env, /--tool-mode must be minimal, standard, or full/i);
 
+runFail([
+  'settings',
+  'set',
+  '--root',
+  policyRoot,
+  '--tunnel',
+  'none',
+  '--port',
+  'abc'
+], env, /Invalid port: abc/i);
+
 const runtimePort = await getFreePort();
 const runtimePath = await runtimeStatusPath(runtimeRoot, home);
 run([

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -151,6 +151,19 @@ async function runFullModeStress(root) {
     });
     assert(loaded.structuredContent.text.includes('# Stress Skill'), 'load_skill did not return skill body');
 
+    const inventory = await client.request('tools/call', {
+      name: 'codexpro_inventory',
+      arguments: { workspace_id: ws, include_global_skills: false, include_mcp_servers: false, max_skills: 140 }
+    });
+    assert(inventory.structuredContent.skill_count === 140, `expected 140 inventory skills, got ${inventory.structuredContent.skill_count}`);
+    const lastSkill = inventory.structuredContent.skills.find((skill) => skill.name === 'stress-skill-139');
+    assert(lastSkill, 'inventory did not include stress-skill-139');
+    const loadedLast = await client.request('tools/call', {
+      name: 'load_skill',
+      arguments: { workspace_id: ws, name: lastSkill.name, source: lastSkill.source, path: lastSkill.path }
+    });
+    assert(loadedLast.structuredContent.text.includes('# Stress Skill 139'), 'load_skill did not load high-cap inventory skill');
+
     const largeSearch = await client.request('tools/call', {
       name: 'search',
       arguments: { workspace_id: ws, query: '--flag', path: 'many', max_results: 2000 }
@@ -219,6 +232,14 @@ async function runFullModeStress(root) {
     });
     assert(mismatch.structuredContent.awaited_completed === false && mismatch.structuredContent.plan_hash_mismatch === true, 'wait_for_handoff mismatch did not fail closed');
 
+    await fs.rm(path.join(root, '.ai-bridge', 'handoff-run-state.json'), { force: true });
+    const slowPollStart = Date.now();
+    await client.request('tools/call', {
+      name: 'wait_for_handoff',
+      arguments: { workspace_id: ws, max_wait_seconds: 1, poll_ms: 5000 }
+    });
+    assert(Date.now() - slowPollStart < 2500, 'wait_for_handoff exceeded max_wait_seconds by a full poll interval');
+
     const exactExport = await client.request('tools/call', {
       name: 'export_pro_context',
       arguments: {
@@ -257,6 +278,34 @@ async function runFullModeStress(root) {
     assert(selfTest.structuredContent.status !== 'fail', `codexpro_self_test failed: ${JSON.stringify(selfTest.structuredContent.checks)}`);
   } finally {
     client.close();
+  }
+}
+
+async function runGlobalSkillStress(root) {
+  void root;
+  const isolatedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-global-root-'));
+  const name = `000-codexpro-global-stress-${Date.now()}`;
+  const dir = path.join(os.homedir(), '.codex', 'skills', name);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: Global stress skill.\n---\n\n# Global Only Skill\n`, 'utf8');
+  let client;
+  try {
+    client = await initClient(isolatedRoot);
+    const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    const inventory = await client.request('tools/call', {
+      name: 'codexpro_inventory',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, include_mcp_servers: false, max_skills: 500 }
+    });
+    const skill = inventory.structuredContent.skills.find((item) => item.name === name);
+    assert(skill, 'default inventory did not include global skill');
+    const loaded = await client.request('tools/call', {
+      name: 'load_skill',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, name: skill.name, source: skill.source, path: skill.path }
+    });
+    assert(loaded.structuredContent.text.includes('# Global Only Skill'), 'default load_skill did not load inventory global skill');
+  } finally {
+    client?.close();
+    await fs.rm(dir, { recursive: true, force: true });
   }
 }
 
@@ -309,6 +358,28 @@ async function runSupertoolModeStress(root) {
   }
 }
 
+async function runMinimalHandoffStress(root) {
+  const client = await initClient(root, {
+    CODEXPRO_TOOL_MODE: 'minimal',
+    CODEXPRO_BASH_MODE: 'off',
+    CODEXPRO_WRITE_MODE: 'handoff'
+  });
+  try {
+    const tools = await client.request('tools/list', {});
+    const names = tools.tools.map((tool) => tool.name);
+    assert(names.includes('handoff_to_agent'), 'minimal handoff mode missing handoff_to_agent');
+    const actions = await client.request('tools/call', { name: 'codexpro', arguments: { action: 'list_actions' } });
+    assert(actions.structuredContent.actions.includes('handoff_to_agent'), 'minimal handoff supertool actions missing handoff_to_agent');
+    const handoff = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'agent_handoff', args: { title: 'Stress Plan', plan: '- keep it narrow' } }
+    });
+    assert(handoff.structuredContent.codexpro_tool === 'handoff_to_agent' && handoff.structuredContent.wrapped_tool === 'handoff_to_agent', 'minimal handoff supertool did not write plan');
+  } finally {
+    client.close();
+  }
+}
+
 async function runCardStress(root) {
   const client = await initClient(root, { CODEXPRO_TOOL_CARDS: '1' });
   try {
@@ -326,6 +397,8 @@ async function runCardStress(root) {
 
 const root = await makeFixture();
 await runFullModeStress(root);
+await runGlobalSkillStress(root);
 await runSupertoolModeStress(root);
+await runMinimalHandoffStress(root);
 await runCardStress(root);
 console.log(`✓ stress test passed (${root})`);

--- a/src/http.ts
+++ b/src/http.ts
@@ -332,6 +332,7 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
     noInstallCloudflared: input.noInstallCloudflared ?? current.noInstallCloudflared
   };
   next.hostname = normalizePublicHostname(next.hostname);
+  if (next.tunnel !== "ngrok" && next.tunnel !== "cloudflare-named") next.hostname = "";
   next.widgetDomain = normalizeWidgetDomain(next.widgetDomain);
   if ((next.tunnel === "ngrok" || next.tunnel === "cloudflare-named") && !next.hostname) {
     throw new Error("hostname is required for ngrok and cloudflare-named profiles.");
@@ -1498,9 +1499,7 @@ async function main(): Promise<void> {
       next();
       return;
     }
-    const bearer = req.headers.authorization?.startsWith("Bearer ")
-      ? req.headers.authorization.slice("Bearer ".length)
-      : undefined;
+    const bearer = req.headers.authorization?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
     const queryToken = typeof req.query.codexpro_token === "string"
       ? req.query.codexpro_token
       : typeof req.query.token === "string"
@@ -1578,7 +1577,7 @@ async function main(): Promise<void> {
       widgetDomain: config.widgetDomain,
       contextDir: config.contextDir,
       authEnabled: Boolean(config.authToken),
-      authRequired: config.requireHttpToken
+      authRequired: Boolean(config.authToken)
     });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -330,6 +330,7 @@ function toolNamesForMode(config: CodexProConfig): string[] {
       if (toolIndex !== -1) names.splice(toolIndex, 1);
     }
   }
+  if (config.writeMode === "handoff" && !names.includes("handoff_to_agent")) names.push("handoff_to_agent");
   for (const name of codexSessionToolNames(config)) {
     if (!names.includes(name)) names.push(name);
   }
@@ -356,6 +357,7 @@ function shouldRegisterTool(config: CodexProConfig, name: string): boolean {
   if ((name === "write" || name === "edit") && config.writeMode !== "workspace") return false;
   if (name === "codex_sessions") return config.codexSessions !== "off";
   if (name === "read_codex_session") return config.codexSessions === "read";
+  if (name === "handoff_to_agent" && config.writeMode === "handoff") return true;
   if (config.toolMode === "full") return true;
   if (config.toolMode === "minimal") return MINIMAL_TOOLS.has(name);
   return STANDARD_TOOLS.has(name);
@@ -1083,7 +1085,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
         source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source when multiple skills share a name."),
         path: z.string().optional().describe("Exact sanitized path from skill_inventory when name/source are still ambiguous."),
-        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: false."),
+        include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: auto when source/path is not workspace."),
+        max_skills: z.number().int().min(1).max(500).optional().describe("Maximum skills to scan while resolving the requested skill. Default: 500."),
         max_bytes: z.number().int().min(1000).max(100000).optional().describe("Maximum bytes to return from SKILL.md. Default: 40000.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
@@ -1095,11 +1098,16 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     },
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
+      const requestedPath = typeof args.path === "string" ? args.path : undefined;
+      const includeGlobalDefault =
+        (args.source !== undefined && args.source !== "workspace") ||
+        Boolean(requestedPath && !requestedPath.startsWith("$WORKSPACE/"));
       const loaded = await loadSkill(workspace, {
         name: String(args.name ?? ""),
         source: args.source,
-        path: typeof args.path === "string" ? args.path : undefined,
-        includeGlobal: parseBool(args.include_global_skills, false),
+        path: requestedPath,
+        includeGlobal: parseBool(args.include_global_skills, includeGlobalDefault),
+        maxSkills: limitInt(args.max_skills, 500, 1, 500),
         maxBytes: limitInt(args.max_bytes, 40_000, 1_000, 100_000)
       });
       const truncated = loaded.truncated ? "\n\n[truncated: increase max_bytes if more context is required]" : "";
@@ -1773,7 +1781,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const deadline = Date.now() + maxWaitSeconds * 1000;
       let state = await readState();
       while (Date.now() < deadline && !isAwaited(state)) {
-        await new Promise((resolve) => setTimeout(resolve, pollMs));
+        await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, Math.max(0, deadline - Date.now()))));
         state = await readState();
       }
 


### PR DESCRIPTION
## Summary
- fix HTTP edge cases: case-insensitive Bearer parsing, truthful health auth status, and clearing stale public hostnames when switching profiles to local-only
- fix CLI/profile edge cases: doctor reports invalid saved write mode, settings/setup validate ports and tool-mode, and pro-apply logs the actual caller-relative plan path
- fix tool surface edge cases: high-cap inventory skills can be loaded, exact non-workspace inventory skills can load by default, minimal handoff mode keeps handoff_to_agent, and wait_for_handoff respects max_wait_seconds

## Validation
- node --check scripts/codexpro.mjs scripts/pro-apply.mjs scripts/pro-smoke.mjs scripts/http-smoke.mjs scripts/stress.mjs scripts/settings-smoke.mjs scripts/doctor-smoke.mjs
- npm run build
- node scripts/pro-smoke.mjs
- node scripts/doctor-smoke.mjs
- node scripts/settings-smoke.mjs
- node scripts/http-smoke.mjs
- node scripts/stress.mjs
- npm run smoke
- npm run stress
- npm audit --audit-level=high
- npm pack --dry-run --json
- git diff --check

## Notes
This is repo-owned hardening only. It does not change the external OpenAI/GPT-5.5 Pro tool-call boundary.