### PR TITLE
[codex] harden redaction inventory and git status stress

### DIFF
--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import net from 'node:net';
@@ -197,6 +198,18 @@ await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKIL
 const port = await getFreePort();
 const genericPort = await getFreePort();
 const token = 'codexpro-http-smoke-token';
+const runtimeQuerySecret = 'runtimequerysecret1234567890';
+const runtimeAccessSecret = 'runtimeaccesssecret1234567890';
+const runtimeCloudflareSecret = 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJodHRwLXNtb2tlIn0.signature1234567890';
+const runtimeId = createHash('sha256').update(root).digest('hex').slice(0, 24);
+await fs.mkdir(path.join(profileHome, 'runtime'), { recursive: true });
+await fs.writeFile(path.join(profileHome, 'runtime', `${runtimeId}.json`), JSON.stringify({
+  version: 1,
+  root,
+  endpoint: `https://runtime.example/mcp?token=${runtimeQuerySecret}`,
+  localStatusUrl: `http://127.0.0.1:${port}/?codexpro_token=${token}&access_token=${runtimeAccessSecret}`,
+  note: `cloudflared tunnel run --token ${runtimeCloudflareSecret}`
+}, null, 2), 'utf8');
 const child = spawn('node', ['dist/http.js'], {
   cwd: path.resolve('.'),
   env: {
@@ -306,6 +319,9 @@ try {
   if (homeText.includes(token)) {
     throw new Error('onboarding page leaked the raw auth token');
   }
+  for (const leaked of [runtimeQuerySecret, runtimeAccessSecret, runtimeCloudflareSecret]) {
+    if (homeText.includes(leaked)) throw new Error(`onboarding page leaked runtime secret: ${leaked}`);
+  }
 
   const profileBefore = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`);
   const profileBeforeJson = await profileBefore.json();
@@ -314,6 +330,9 @@ try {
   }
   if (JSON.stringify(profileBeforeJson).includes(token)) {
     throw new Error('admin profile GET leaked the raw auth token');
+  }
+  for (const leaked of [runtimeQuerySecret, runtimeAccessSecret, runtimeCloudflareSecret]) {
+    if (JSON.stringify(profileBeforeJson).includes(leaked)) throw new Error(`admin profile GET leaked runtime secret: ${leaked}`);
   }
 
   const invalidProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -353,7 +353,10 @@ await fs.writeFile(path.join(tmp, 'tokens.txt'), [
   '"codexpro_token": "shortcodextoken"',
   'ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz123456',
   '"api_key": "jsonsecretvalueabcdefghijklmnop"',
-  'service_token: yamlsecretvalueabcdefghijklmnop'
+  'service_token: yamlsecretvalueabcdefghijklmnop',
+  'ngrok config add-authtoken 2abcDEFghiJKLmnopQRSTuvWXyz_1234567890',
+  'cloudflared tunnel run --token eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJjb2RleHBybyJ9.signature1234567890',
+  'cloudflared tunnel run --token-file /Users/rebel/.codexpro/cloudflare-tunnel-token'
 ].join('\n'), 'utf8');
 const secretRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'config.txt' } });
 const secretPayload = JSON.stringify(secretRead);
@@ -362,8 +365,11 @@ if (secretPayload.includes('sk-realSecretValue123') || !secretPayload.includes('
 }
 const tokenRead = await client.request('tools/call', { name: 'read', arguments: { workspace_id: ws, path: 'tokens.txt' } });
 const tokenPayload = JSON.stringify(tokenRead);
-for (const leaked of ['ghp_abcdefghijklmnopqrstuvwxyz123456', 'verysecretcodexprotoken123', 'secretsecret12345', 'shortcodextoken', 'sk-ant-abcdefghijklmnopqrstuvwxyz123456', 'jsonsecretvalueabcdefghijklmnop', 'yamlsecretvalueabcdefghijklmnop']) {
+for (const leaked of ['ghp_abcdefghijklmnopqrstuvwxyz123456', 'verysecretcodexprotoken123', 'secretsecret12345', 'shortcodextoken', 'sk-ant-abcdefghijklmnopqrstuvwxyz123456', 'jsonsecretvalueabcdefghijklmnop', 'yamlsecretvalueabcdefghijklmnop', '2abcDEFghiJKLmnopQRSTuvWXyz_1234567890', 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJjb2RleHBybyJ9.signature1234567890']) {
   if (tokenPayload.includes(leaked)) throw new Error(`read leaked token-like content: ${leaked}`);
+}
+if (!tokenPayload.includes('/Users/rebel/.codexpro/cloudflare-tunnel-token')) {
+  throw new Error('redaction hid a non-secret Cloudflare token-file path');
 }
 await expectToolError('write', { workspace_id: ws, path: 'notes.md', content: 'OPENAI_API_KEY=sk-realSecretValue123\n' }, /Secret-looking content is blocked/);
 await expectToolError('write', { workspace_id: ws, path: 'token.txt', content: 'codexpro_token=shorttok\n' }, /Secret-looking content is blocked/);

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -412,6 +412,72 @@ async function runGlobalSkillStress(root) {
   }
 }
 
+async function runRedactionStress() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-redact-'));
+  const ngrokToken = '2redactDEFghiJKLmnopQRSTuvWXyz_1234567890';
+  const cloudflareToken = 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJzdHJlc3MifQ.signature1234567890';
+  const tokenFile = '/Users/rebel/.codexpro/cloudflare-tunnel-token';
+  await fs.writeFile(path.join(root, 'tokens.txt'), [
+    `ngrok config add-authtoken ${ngrokToken}`,
+    `cloudflared tunnel run --token ${cloudflareToken}`,
+    `cloudflared tunnel run --token-file ${tokenFile}`
+  ].join('\n'), 'utf8');
+
+  const client = await initClient(root);
+  try {
+    const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    for (const request of [
+      { name: 'read', arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'tokens.txt' } },
+      { name: 'codexpro', arguments: { action: 'read', args: { workspace_id: opened.structuredContent.workspace_id, path: 'tokens.txt' } } }
+    ]) {
+      const result = await client.request('tools/call', request);
+      const payload = JSON.stringify(result);
+      assert(!payload.includes(ngrokToken), 'read leaked ngrok authtoken');
+      assert(!payload.includes(cloudflareToken), 'read leaked cloudflared token');
+      assert(payload.includes(tokenFile), 'redaction hid non-secret token-file path');
+    }
+  } finally {
+    client.close();
+  }
+}
+
+async function runMcpInventoryStress() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-mcp-root-'));
+  const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-mcp-home-'));
+  await fs.mkdir(path.join(fakeHome, '.codex'), { recursive: true });
+  await fs.mkdir(path.join(fakeHome, '.cursor'), { recursive: true });
+  const toml = Array.from({ length: 80 }, (_, i) =>
+    `[mcp_servers.codex_${String(i).padStart(3, '0')}]\ncommand = "secret-command"\nargs = ["secret-arg"]\n`
+  ).join('\n');
+  const cursorServers = Object.fromEntries(Array.from({ length: 80 }, (_, i) => [
+    `cursor_${String(i).padStart(3, '0')}`,
+    { command: 'secret-command', args: ['secret-arg'] }
+  ]));
+  await fs.writeFile(path.join(fakeHome, '.codex', 'config.toml'), toml, 'utf8');
+  await fs.writeFile(path.join(fakeHome, '.cursor', 'mcp.json'), JSON.stringify({ mcpServers: cursorServers }), 'utf8');
+
+  const client = await initClient(root, { HOME: fakeHome });
+  try {
+    const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    const inventory = await client.request('tools/call', {
+      name: 'codexpro_inventory',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, include_global_skills: false, include_mcp_servers: true }
+    });
+    const superInventory = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'inventory', args: { workspace_id: opened.structuredContent.workspace_id, include_global_skills: false, include_mcp_servers: true } }
+    });
+    assert(inventory.structuredContent.mcp_server_count === 120, `MCP inventory was not capped: ${inventory.structuredContent.mcp_server_count}`);
+    assert(superInventory.structuredContent.codexpro_tool === 'codexpro_inventory' && superInventory.structuredContent.mcp_server_count === 120, 'supertool MCP inventory was not capped');
+    const payload = JSON.stringify([inventory, superInventory]);
+    for (const leaked of [fakeHome, '~/.codex', '~/.cursor', '.cursor/mcp.json', '.codex/config.toml', 'secret-command', 'secret-arg']) {
+      assert(!payload.includes(leaked), `MCP inventory leaked ${leaked}`);
+    }
+  } finally {
+    client.close();
+  }
+}
+
 async function runSupertoolModeStress(root) {
   const client = await initClient(root, {
     CODEXPRO_TOOL_MODE: 'minimal',
@@ -551,20 +617,42 @@ async function runGuardEdgeStress() {
 async function runShowChangesStatsStress() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-git-'));
   await fs.writeFile(path.join(root, 'demo.txt'), 'alpha\n', 'utf8');
+  await fs.writeFile(path.join(root, 'other.txt'), 'one\n', 'utf8');
+  await fs.writeFile(path.join(root, 'staged file.txt'), 'one\n', 'utf8');
   spawnSync('git', ['init'], { cwd: root, stdio: 'ignore' });
   spawnSync('git', ['config', 'user.email', 'stress@example.com'], { cwd: root, stdio: 'ignore' });
   spawnSync('git', ['config', 'user.name', 'Stress Test'], { cwd: root, stdio: 'ignore' });
   spawnSync('git', ['add', 'demo.txt'], { cwd: root, stdio: 'ignore' });
+  spawnSync('git', ['add', 'other.txt'], { cwd: root, stdio: 'ignore' });
+  spawnSync('git', ['add', 'staged file.txt'], { cwd: root, stdio: 'ignore' });
   spawnSync('git', ['commit', '-m', 'init'], { cwd: root, stdio: 'ignore' });
   await fs.appendFile(path.join(root, 'demo.txt'), 'beta\n', 'utf8');
+  await fs.appendFile(path.join(root, 'other.txt'), 'two\n', 'utf8');
+  await fs.appendFile(path.join(root, 'staged file.txt'), 'two\n', 'utf8');
+  spawnSync('git', ['add', 'staged file.txt'], { cwd: root, stdio: 'ignore' });
   const client = await initClient(root);
   try {
     const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    const scopedStatus = await client.request('tools/call', {
+      name: 'git_status',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'demo.txt' }
+    });
+    assert(scopedStatus.structuredContent.changed_files.length === 1 && scopedStatus.structuredContent.changed_files[0].includes('demo.txt'), `git_status path leaked unrelated files: ${JSON.stringify(scopedStatus.structuredContent.changed_files)}`);
+    const superScopedStatus = await client.request('tools/call', {
+      name: 'codexpro',
+      arguments: { action: 'git_status', args: { workspace_id: opened.structuredContent.workspace_id, path: 'demo.txt' } }
+    });
+    assert(superScopedStatus.structuredContent.codexpro_tool === 'git_status' && superScopedStatus.structuredContent.changed_files.length === 1 && superScopedStatus.structuredContent.changed_files[0].includes('demo.txt'), `supertool git_status path leaked unrelated files: ${JSON.stringify(superScopedStatus.structuredContent.changed_files)}`);
     const changes = await client.request('tools/call', {
       name: 'show_changes',
-      arguments: { workspace_id: opened.structuredContent.workspace_id, include_diff: false }
+      arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'demo.txt', include_diff: false }
     });
     assert(changes.structuredContent.additions === 1 && changes.structuredContent.deletions === 0 && changes.structuredContent.diff === '', `show_changes include_diff=false lost stats: ${JSON.stringify(changes.structuredContent)}`);
+    const stagedDiff = await client.request('tools/call', {
+      name: 'git_diff',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'staged file.txt', staged: true, include_diff: false }
+    });
+    assert(stagedDiff.structuredContent.additions === 1 && stagedDiff.structuredContent.deletions === 0 && stagedDiff.structuredContent.diff === '', `git_diff staged path stats failed: ${JSON.stringify(stagedDiff.structuredContent)}`);
   } finally {
     client.close();
   }
@@ -617,6 +705,8 @@ async function runCardStress(root) {
 const root = await makeFixture();
 await runFullModeStress(root);
 await runGlobalSkillStress(root);
+await runRedactionStress();
+await runMcpInventoryStress();
 await runMaxReadSearchStress();
 await runGuardEdgeStress();
 await runSupertoolModeStress(root);

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -29,6 +29,8 @@ export interface McpServerInventoryItem {
   source: string;
 }
 
+const MAX_MCP_SERVER_INVENTORY = 120;
+
 function unique<T>(items: T[], key: (item: T) => string): T[] {
   const seen = new Set<string>();
   const out: T[] = [];
@@ -297,10 +299,10 @@ function parseJsonMcpServers(text: string, source: string): McpServerInventoryIt
 
 export async function discoverMcpServers(workspace: Workspace): Promise<McpServerInventoryItem[]> {
   const candidates = [
-    { file: path.join(os.homedir(), ".codex", "config.toml"), kind: "toml" },
-    { file: path.join(workspace.root, ".mcp.json"), kind: "json" },
-    { file: path.join(workspace.root, ".cursor", "mcp.json"), kind: "json" },
-    { file: path.join(os.homedir(), ".cursor", "mcp.json"), kind: "json" }
+    { file: path.join(os.homedir(), ".codex", "config.toml"), kind: "toml", source: "user codex config" },
+    { file: path.join(workspace.root, ".mcp.json"), kind: "json", source: "workspace config" },
+    { file: path.join(workspace.root, ".cursor", "mcp.json"), kind: "json", source: "workspace cursor config" },
+    { file: path.join(os.homedir(), ".cursor", "mcp.json"), kind: "json", source: "user cursor config" }
   ];
 
   const servers: McpServerInventoryItem[] = [];
@@ -312,11 +314,12 @@ export async function discoverMcpServers(workspace: Workspace): Promise<McpServe
     } catch {
       continue;
     }
-    const source = displayPath(candidate.file, workspace.root);
-    servers.push(...(candidate.kind === "toml" ? parseTomlMcpServers(text, source) : parseJsonMcpServers(text, source)));
+    servers.push(...(candidate.kind === "toml" ? parseTomlMcpServers(text, candidate.source) : parseJsonMcpServers(text, candidate.source)));
   }
 
-  return unique(servers, (server) => `${server.source}:${server.name}`).sort((a, b) => a.name.localeCompare(b.name));
+  return unique(servers, (server) => `${server.source}:${server.name}`)
+    .sort((a, b) => a.name.localeCompare(b.name) || a.source.localeCompare(b.source))
+    .slice(0, MAX_MCP_SERVER_INVENTORY);
 }
 
 export async function codexproInventory(

--- a/src/http.ts
+++ b/src/http.ts
@@ -18,6 +18,7 @@ import {
   type TunnelMode,
   type WorkspaceProfile
 } from "./profileStore.js";
+import { redactSensitiveText, redactStructured } from "./redact.js";
 import { createCodexProServer } from "./server.js";
 
 function escapeHtml(value: unknown): string {
@@ -215,9 +216,10 @@ function selectOptions(values: readonly string[], current: string): string {
 
 function serverUrlDisplay(endpoint: string | undefined, authEnabled: boolean): string {
   if (!endpoint) return "";
-  if (!authEnabled) return endpoint;
-  const glue = endpoint.includes("?") ? "&" : "?";
-  return `${endpoint}${glue}codexpro_token=<redacted>`;
+  const safeEndpoint = redactSensitiveText(endpoint);
+  if (!authEnabled) return safeEndpoint;
+  const glue = safeEndpoint.includes("?") ? "&" : "?";
+  return `${safeEndpoint}${glue}codexpro_token=<redacted>`;
 }
 
 function currentTunnelMessage(tunnel: TunnelMode, endpoint: string): string {
@@ -256,7 +258,7 @@ function profileForm(config: CodexProConfig): string {
           <code>${escapeHtml(runtimeUrl)}</code>
           <p>${escapeHtml(currentTunnelMessage(runtimeTunnel, runtimeEndpoint))}</p>
         </div>
-        <button type="button" class="copy-mini" data-copy-kind="server-url" data-copy-base="${escapeHtml(runtimeEndpoint)}">Copy</button>
+        <button type="button" class="copy-mini" data-copy-kind="server-url" data-copy-base="${escapeHtml(redactSensitiveText(runtimeEndpoint))}">Copy</button>
       </div>`
     : `<div class="current-url idle">
         <div>
@@ -264,7 +266,7 @@ function profileForm(config: CodexProConfig): string {
           <code>${savedUrl ? escapeHtml(savedUrl) : "No public URL detected for this run"}</code>
           <p>${escapeHtml(savedUrl ? "This is based on the saved hostname. It becomes current after the launcher starts that tunnel." : currentTunnelMessage(values.tunnel, ""))}</p>
         </div>
-        ${savedEndpoint ? `<button type="button" class="copy-mini" data-copy-kind="server-url" data-copy-base="${escapeHtml(savedEndpoint)}">Copy</button>` : ""}
+        ${savedEndpoint ? `<button type="button" class="copy-mini" data-copy-kind="server-url" data-copy-base="${escapeHtml(redactSensitiveText(savedEndpoint))}">Copy</button>` : ""}
       </div>`;
   return `<section class="panel profile-panel" id="profile">
       <div class="section-head">
@@ -375,7 +377,7 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
 function profileResponse(config: CodexProConfig): Record<string, unknown> {
   const profile = readWorkspaceProfile(config.defaultRoot);
   const runtime = readRuntimeConnection(config.defaultRoot);
-  return {
+  return redactStructured({
     ok: true,
     profile_path: profile.profilePath ?? profilePathForRoot(config.defaultRoot),
     exists: Boolean(profile.profilePath),
@@ -394,7 +396,7 @@ function profileResponse(config: CodexProConfig): Record<string, unknown> {
       widgetDomain: config.widgetDomain,
       authEnabled: Boolean(config.authToken)
     }
-  };
+  });
 }
 
 function jsonError(res: Response, status: number, code: string, message: string, issues?: unknown): void {

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,12 +1,13 @@
 const OPENAI_SECRET_PATTERN = /\bsk-[A-Za-z0-9_-]{10,}\b/g;
 const COMMON_TOKEN_PATTERN = /\b(?:sk-ant-[A-Za-z0-9_-]{10,}|gh[opsru]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{20,})\b/g;
 const BEARER_TOKEN_PATTERN = /\b(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi;
+const CLI_TOKEN_PATTERN = /((?:\bngrok\s+config\s+add-authtoken|\bcloudflared\s+service\s+install|--(?:token|access-token|auth-token|api[_-]?key|authtoken))(?:=|\s+))[A-Za-z0-9._~+/=-]{8,}/gi;
 const QUERY_TOKEN_PATTERN = /([?&](?:codexpro_token|token|access_token|auth_token|api[_-]?key)=)[^&\s"'`<>]{8,}/gi;
 const CODEXPRO_TOKEN_ASSIGNMENT_PATTERN = /\b(codexpro_token\s*=\s*)(?:"[^"\r\n]{8,512}"|'[^'\r\n]{8,512}'|`[^`\r\n]{8,512}`|[A-Za-z0-9_./+=-]{8,512})/gi;
 const CODEXPRO_TOKEN_FIELD_PATTERN = /(["']?codexpro_token["']?\s*:\s*)(?:"[^"\r\n]{8,512}"|'[^'\r\n]{8,512}'|`[^`\r\n]{8,512}`|[A-Za-z0-9_./+=-]{8,512})/gi;
 const SECRET_ASSIGNMENT_PATTERN = /\b[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}\s*=\s*(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi;
 const SECRET_FIELD_PATTERN = /(["']?[A-Za-z0-9_]{0,64}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)[A-Za-z0-9_]{0,64}["']?\s*:\s*)(?:"[^"\r\n]{12,512}"|'[^'\r\n]{12,512}'|`[^`\r\n]{12,512}`|[A-Za-z0-9_./+=-]{20,512})/gi;
-const SECRET_PATTERNS = [OPENAI_SECRET_PATTERN, COMMON_TOKEN_PATTERN, BEARER_TOKEN_PATTERN, QUERY_TOKEN_PATTERN, CODEXPRO_TOKEN_ASSIGNMENT_PATTERN, CODEXPRO_TOKEN_FIELD_PATTERN, SECRET_ASSIGNMENT_PATTERN, SECRET_FIELD_PATTERN];
+const SECRET_PATTERNS = [OPENAI_SECRET_PATTERN, COMMON_TOKEN_PATTERN, BEARER_TOKEN_PATTERN, CLI_TOKEN_PATTERN, QUERY_TOKEN_PATTERN, CODEXPRO_TOKEN_ASSIGNMENT_PATTERN, CODEXPRO_TOKEN_FIELD_PATTERN, SECRET_ASSIGNMENT_PATTERN, SECRET_FIELD_PATTERN];
 
 export function hasSecretValue(text: string): boolean {
   for (const pattern of SECRET_PATTERNS) {
@@ -23,6 +24,7 @@ export function redactSensitiveText(text: string): string {
   return text
     .replace(CODEXPRO_TOKEN_ASSIGNMENT_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
     .replace(CODEXPRO_TOKEN_FIELD_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
+    .replace(CLI_TOKEN_PATTERN, (match, prefix) => isPlaceholderSecret(match) ? match : `${prefix}[REDACTED_SECRET]`)
     .replace(SECRET_ASSIGNMENT_PATTERN, (match) => isPlaceholderSecret(match) ? match : redactSecretAssignment(match))
     .replace(SECRET_FIELD_PATTERN, (match, prefix) => isPlaceholderSecret(match) ? match : `${prefix}[REDACTED_SECRET]`)
     .replace(BEARER_TOKEN_PATTERN, (_match, prefix) => `${prefix}[REDACTED_SECRET]`)
@@ -49,6 +51,11 @@ function isPlaceholderSecret(value: string): boolean {
   return (
     normalized.includes("[redacted_secret]") ||
     normalized.includes("replace-me") ||
+    normalized.includes("replace-with-long-random-token") ||
+    normalized.includes("keep-this-codexpro-token-stable") ||
+    normalized.includes("keep-this-stable-token") ||
+    normalized.includes("your-ngrok-token") ||
+    normalized.includes("your-token") ||
     normalized.includes("your-api-key-here") ||
     normalized.includes("<openai_api_key>") ||
     normalized.includes("process.env.") ||

--- a/src/server.ts
+++ b/src/server.ts
@@ -1565,7 +1565,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Git Status",
       description: "Show git branch and changed files for the workspace.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace.")
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
+        path: z.string().optional().describe("Optional file path relative to workspace root.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
@@ -1576,12 +1577,14 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     },
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
-      const status = gitStatus(config, workspace);
+      const scopedPath = typeof args.path === "string" ? args.path : undefined;
+      const status = gitStatus(config, workspace, guard, scopedPath);
       const statusError = looksLikeGitError(status) ? status : "";
       const changedFiles = statusError ? [] : changedStatusLines(status);
       return textResult(status, {
         workspace_id: workspace.id,
         root: workspace.root,
+        path: args.path ?? "workspace status",
         status,
         status_error: statusError || undefined,
         changed_files: changedFiles,


### PR DESCRIPTION
## Summary

- redact ngrok/cloudflared CLI tokens and runtime/profile URL secrets while preserving non-secret token-file paths
- keep MCP server inventory bounded and generic so local config paths, commands, and args are not exposed
- wire `git_status.path` through the same workspace path guard used by diff/change review
- expand smoke/stress coverage, including stable `codexpro` supertool coverage for redacted reads, MCP inventory, and scoped git status

## Truth / impact

This improves CodexPro's local MCP safety and stress coverage. It does not change the OpenAI-side GPT-5.5 Pro limitation: if a selected ChatGPT surface does not expose Apps/MCP tool calls, the request still never reaches CodexPro. The supported fallback remains loading/exporting repo context with a tool-capable model, using Pro for reasoning/review, then returning the plan through a tool-capable model or local handoff flow.

npm registry truth is also unchanged: this repo is `0.28.6`, but `npm latest` is still `0.28.5` until a publish happens.

## Verification

- `node --check scripts/smoke.mjs`
- `node --check scripts/http-smoke.mjs`
- `node --check scripts/stress.mjs`
- `npm run build`
- `node scripts/smoke.mjs`
- `node scripts/http-smoke.mjs`
- `npm run stress`
- `npm run smoke`
- `git diff --check`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- real tarball install probe: bin executability, `codexpro --version`, `doctor`, and `pro-bundle`
