### PR TITLE
[codex] harden runtime profile and search edge cases

### DIFF
--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -3240,7 +3240,7 @@ function writeControlPrompt() {
   process.stdout.write('codexpro> ');
 }
 
-function runControlPanel(details) {
+function runControlPanel(details, cleanup = cleanupChildren) {
   if (!process.stdin.isTTY) return new Promise(() => {});
 
   writeControlPrompt();
@@ -3253,7 +3253,7 @@ function runControlPanel(details) {
     process.stdin.on('data', (key) => {
       if (key === '\u0003') {
         console.log('\nStopping CodexPro...');
-        cleanupChildren();
+        cleanup();
         process.exit(130);
       }
       const normalized = key.toLowerCase();
@@ -3290,7 +3290,7 @@ function runControlPanel(details) {
         writeControlPrompt();
       } else if (normalized === 'q') {
         console.log('\nStopping CodexPro...');
-        cleanupChildren();
+        cleanup();
         process.exit(0);
       }
     });
@@ -3532,7 +3532,7 @@ async function main() {
       requireBashSession
     });
     saveRuntimeConnection(root, details, runtimeOptions);
-    await runControlPanel(details);
+    await runControlPanel(details, cleanup);
     return;
   }
 
@@ -3575,7 +3575,7 @@ async function main() {
       requireBashSession
     });
     saveRuntimeConnection(root, details, runtimeOptions);
-    await runControlPanel(details);
+    await runControlPanel(details, cleanup);
     return;
   }
 
@@ -3599,7 +3599,7 @@ async function main() {
       requireBashSession
     });
     saveRuntimeConnection(root, details, runtimeOptions);
-    await runControlPanel(details);
+    await runControlPanel(details, cleanup);
     return;
   }
 
@@ -3622,7 +3622,7 @@ async function main() {
       requireBashSession
     });
     saveRuntimeConnection(root, details, runtimeOptions);
-    await runControlPanel(details);
+    await runControlPanel(details, cleanup);
     return;
   }
 
@@ -3690,7 +3690,7 @@ async function main() {
     requireBashSession
   });
   saveRuntimeConnection(root, details, runtimeOptions);
-  await runControlPanel(details);
+  await runControlPanel(details, cleanup);
 }
 
 main().catch((error) => {

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -183,7 +183,6 @@ function postToolsListWithSession(baseUrl, token, sessionId) {
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-smoke-'));
-const realRoot = await fs.realpath(root);
 const profileHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-profile-home-'));
 await fs.mkdir(path.join(root, '.codex', 'skills', 'http-smoke-skill'), { recursive: true });
 await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKILL.md'), [
@@ -201,6 +200,7 @@ const token = 'codexpro-http-smoke-token';
 const runtimeQuerySecret = 'runtimequerysecret1234567890';
 const runtimeAccessSecret = 'runtimeaccesssecret1234567890';
 const runtimeCloudflareSecret = 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJodHRwLXNtb2tlIn0.signature1234567890';
+const staleCloudflareToken = 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJzdGFsZS1odHRwLXNtb2tlIn0.signature1234567890';
 const runtimeId = createHash('sha256').update(root).digest('hex').slice(0, 24);
 await fs.mkdir(path.join(profileHome, 'runtime'), { recursive: true });
 await fs.writeFile(path.join(profileHome, 'runtime', `${runtimeId}.json`), JSON.stringify({
@@ -348,6 +348,15 @@ try {
   if (invalidProfile.status !== 400) {
     throw new Error(`expected invalid guarded profile to return 400, got ${invalidProfile.status}`);
   }
+  await fs.mkdir(path.join(profileHome, 'profiles'), { recursive: true });
+  await fs.writeFile(path.join(profileHome, 'profiles', `${runtimeId}.json`), JSON.stringify({
+    version: 1,
+    root,
+    tunnel: 'cloudflare-named',
+    hostname: 'stale.example.com',
+    cloudflareToken: staleCloudflareToken,
+    cloudflareTokenFile: path.join(root, 'stale-cloudflare-token')
+  }, null, 2), 'utf8');
 
   const profileSave = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
     method: 'POST',
@@ -389,11 +398,13 @@ try {
     savedProfile.requireBashSession !== true ||
     savedProfile.toolCards !== true ||
     savedProfile.ngrokConfig !== path.join(root, 'ngrok.yml') ||
-    savedProfile.cloudflareTokenFile !== path.join(realRoot, 'cloudflare-token') ||
     savedProfile.noInstallCloudflared !== true ||
     savedProfile.token !== token
   ) {
     throw new Error(`admin profile save wrote unexpected profile: ${JSON.stringify(savedProfile)}`);
+  }
+  if (savedProfile.cloudflareToken || savedProfile.cloudflareTokenFile) {
+    throw new Error(`admin profile save kept cloudflare token config on ngrok profile: ${JSON.stringify(savedProfile)}`);
   }
 
   const localProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
@@ -403,8 +414,24 @@ try {
   });
   const localProfileJson = await localProfile.json();
   const localSavedProfile = JSON.parse(await fs.readFile(localProfileJson.profile_path, 'utf8'));
-  if (localProfile.status !== 200 || localSavedProfile.hostname || localProfileJson.profile?.hostname || localProfileJson.effective?.hostname) {
-    throw new Error(`admin profile local-only save kept a stale hostname: ${JSON.stringify(localProfileJson)} ${JSON.stringify(localSavedProfile)}`);
+  if (
+    localProfile.status !== 200 ||
+    localSavedProfile.hostname ||
+    localSavedProfile.ngrokConfig ||
+    localSavedProfile.tunnelName ||
+    localSavedProfile.cloudflareConfig ||
+    localSavedProfile.cloudflareToken ||
+    localSavedProfile.cloudflareTokenFile ||
+    localProfileJson.profile?.hostname ||
+    localProfileJson.profile?.ngrokConfig ||
+    localProfileJson.profile?.cloudflareToken ||
+    localProfileJson.profile?.cloudflareTokenFile ||
+    localProfileJson.effective?.hostname ||
+    localProfileJson.effective?.ngrokConfig ||
+    localProfileJson.effective?.cloudflareToken ||
+    localProfileJson.effective?.cloudflareTokenFile
+  ) {
+    throw new Error(`admin profile local-only save kept stale tunnel config: ${JSON.stringify(localProfileJson)} ${JSON.stringify(localSavedProfile)}`);
   }
 
   const queryTools = await listTools(`${baseUrl}/mcp?codexpro_token=${encodeURIComponent(token)}`);

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -96,6 +96,92 @@ async function withStartedCodexPro(args, env, fn) {
   }
 }
 
+function findPythonForPty() {
+  if (process.platform === 'win32') return '';
+  for (const command of ['python3', 'python']) {
+    const result = spawnSync(command, ['-c', 'import pty, select, subprocess'], { stdio: 'ignore' });
+    if (result.status === 0) return command;
+  }
+  return '';
+}
+
+function runInteractiveQuit(args, env) {
+  const python = findPythonForPty();
+  if (!python) return false;
+  const payload = JSON.stringify({
+    cmd: process.execPath,
+    args: ['scripts/codexpro.mjs', 'start', ...args],
+    cwd: path.resolve('.')
+  });
+  const code = `
+import json, os, pty, select, subprocess, sys, time
+payload = json.loads(sys.argv[1])
+master, slave = pty.openpty()
+proc = subprocess.Popen([payload["cmd"]] + payload["args"], cwd=payload["cwd"], env=os.environ.copy(), stdin=slave, stdout=slave, stderr=slave, close_fds=True)
+os.close(slave)
+out = bytearray()
+sent = False
+deadline = time.time() + 20
+while time.time() < deadline:
+    if proc.poll() is not None:
+        break
+    ready, _, _ = select.select([master], [], [], 0.1)
+    if not ready:
+        continue
+    try:
+        chunk = os.read(master, 4096)
+    except OSError:
+        break
+    if not chunk:
+        break
+    out.extend(chunk)
+    if not sent and b"codexpro> " in out:
+        os.write(master, b"q")
+        sent = True
+if proc.poll() is None:
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        pass
+if proc.poll() is None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    sys.stderr.write(out.decode(errors="replace"))
+    raise SystemExit(124)
+while True:
+    ready, _, _ = select.select([master], [], [], 0)
+    if not ready:
+        break
+    try:
+        chunk = os.read(master, 4096)
+    except OSError:
+        break
+    if not chunk:
+        break
+    out.extend(chunk)
+os.close(master)
+sys.stdout.write(out.decode(errors="replace"))
+if not sent:
+    sys.stderr.write("control prompt was not reached\\n")
+    raise SystemExit(125)
+raise SystemExit(proc.returncode or 0)
+`;
+  const result = spawnSync(python, ['-c', code, payload], {
+    cwd: path.resolve('.'),
+    env: { ...env, NO_COLOR: '1' },
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024
+  });
+  if (result.status !== 0) {
+    throw new Error(`interactive quit failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  return true;
+}
+
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-root-'));
 const reuseRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-reuse-'));
 const policyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-policy-'));
@@ -337,6 +423,26 @@ try {
   throw new Error('runtime status was not cleared after launcher SIGTERM');
 } catch (error) {
   if (error?.code !== 'ENOENT') throw error;
+}
+
+const quitRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-quit-'));
+const quitPort = await getFreePort();
+const quitRuntimePath = await runtimeStatusPath(quitRoot, home);
+if (runInteractiveQuit([
+  '--root',
+  quitRoot,
+  '--tunnel',
+  'none',
+  '--port',
+  String(quitPort),
+  '--no-copy-url'
+], env)) {
+  try {
+    await fs.access(quitRuntimePath);
+    throw new Error('runtime status was not cleared after interactive q exit');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
 }
 
 const cloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-'));

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -18,7 +18,7 @@ async function pathExists(file) {
 
 class McpStdioClient {
   constructor(root, env = {}) {
-    this.child = spawn('node', ['dist/stdio.js'], {
+    this.child = spawn(process.execPath, ['dist/stdio.js'], {
       cwd: path.resolve('.'),
       env: {
         ...process.env,
@@ -551,6 +551,31 @@ async function runMaxReadSearchStress() {
   }
 }
 
+async function runNodeFallbackSearchLimitStress() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-node-search-'));
+  await fs.writeFile(path.join(root, 'exact.txt'), 'needle one\nneedle two\n', 'utf8');
+  await fs.writeFile(path.join(root, 'overflow.txt'), 'needle one\nneedle two\nneedle three\n', 'utf8');
+  const client = await initClient(root, { PATH: '/usr/bin:/bin' });
+  try {
+    const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    const exact = await client.request('tools/call', {
+      name: 'search',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, query: 'needle', path: 'exact.txt', max_results: 2 }
+    });
+    assert(exact.structuredContent.used === 'node', `expected node fallback, got ${exact.structuredContent.used}`);
+    assert(exact.structuredContent.matches.length === 2, `node fallback exact-limit search returned ${exact.structuredContent.matches.length} matches`);
+    assert(exact.structuredContent.truncated === false, `node fallback exact-limit search was incorrectly truncated: ${JSON.stringify(exact.structuredContent)}`);
+
+    const overflow = await client.request('tools/call', {
+      name: 'search',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, query: 'needle', path: 'overflow.txt', max_results: 2 }
+    });
+    assert(overflow.structuredContent.matches.length === 2 && overflow.structuredContent.truncated === true, `node fallback overflow search did not report truncation: ${JSON.stringify(overflow.structuredContent)}`);
+  } finally {
+    client.close();
+  }
+}
+
 async function runGuardEdgeStress() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-guard-'));
   const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-outside-'));
@@ -708,6 +733,7 @@ await runGlobalSkillStress(root);
 await runRedactionStress();
 await runMcpInventoryStress();
 await runMaxReadSearchStress();
+await runNodeFallbackSearchLimitStress();
 await runGuardEdgeStress();
 await runSupertoolModeStress(root);
 await runShowChangesStatsStress();

--- a/src/http.ts
+++ b/src/http.ts
@@ -344,17 +344,18 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
   }
 
   const token = typeof existing.token === "string" && existing.token ? existing.token : config.authToken ?? "";
-  const cloudflareToken = typeof existing.cloudflareToken === "string" && existing.cloudflareToken ? existing.cloudflareToken : "";
+  const cloudflareToken = next.tunnel === "cloudflare-named" && typeof existing.cloudflareToken === "string" && existing.cloudflareToken ? existing.cloudflareToken : "";
   const write = effectiveWriteMode(next.mode, next.write);
-  const ngrokConfig = normalizeProfilePath(config.defaultRoot, next.ngrokConfig);
-  const cloudflareConfig = normalizeProfilePath(config.defaultRoot, next.cloudflareConfig);
-  const cloudflareTokenFile = normalizeProfilePath(config.defaultRoot, next.cloudflareTokenFile);
+  const tunnelName = next.tunnel === "cloudflare-named" ? next.tunnelName : "";
+  const ngrokConfig = next.tunnel === "ngrok" ? normalizeProfilePath(config.defaultRoot, next.ngrokConfig) : "";
+  const cloudflareConfig = next.tunnel === "cloudflare-named" ? normalizeProfilePath(config.defaultRoot, next.cloudflareConfig) : "";
+  const cloudflareTokenFile = next.tunnel === "cloudflare-named" ? normalizeProfilePath(config.defaultRoot, next.cloudflareTokenFile) : "";
   return {
     port: next.port,
     mode: next.mode,
     tunnel: next.tunnel,
     ...(next.hostname ? { hostname: next.hostname } : {}),
-    ...(next.tunnelName ? { tunnelName: next.tunnelName } : {}),
+    ...(tunnelName ? { tunnelName } : {}),
     ...(ngrokConfig ? { ngrokConfig } : {}),
     ...(cloudflareConfig ? { cloudflareConfig } : {}),
     ...(cloudflareTokenFile ? { cloudflareTokenFile } : {}),

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -95,9 +95,10 @@ async function runNodeSearch(config: CodexProConfig, guard: PathGuard, workspace
     maxFiles: 20_000
   });
   const matches: Array<{ path: string; line: number; text: string }> = [];
+  let visibleMatches = 0;
   const matcher = options.regex ? new RegExp(options.query) : undefined;
   for (const rel of files) {
-    if (matches.length >= options.maxResults) break;
+    if (visibleMatches > options.maxResults) break;
     const resolved = guard.resolve(workspace, rel);
     try {
       const stat = await fsp.stat(resolved.absPath);
@@ -109,8 +110,11 @@ async function runNodeSearch(config: CodexProConfig, guard: PathGuard, workspace
         const line = lines[i];
         const hit = matcher ? matcher.test(line) : line.includes(options.query);
         if (hit) {
-          matches.push({ path: rel, line: i + 1, text: redactSensitiveText(truncateLine(line)) });
-          if (matches.length >= options.maxResults) break;
+          visibleMatches += 1;
+          if (matches.length < options.maxResults) {
+            matches.push({ path: rel, line: i + 1, text: redactSensitiveText(truncateLine(line)) });
+          }
+          if (visibleMatches > options.maxResults) break;
         }
       }
     } catch {
@@ -118,7 +122,7 @@ async function runNodeSearch(config: CodexProConfig, guard: PathGuard, workspace
     }
   }
   const text = matches.map((m) => `${m.path}:${m.line}: ${m.text}`).join("\n") || "No matches.";
-  return { text, matches, truncated: matches.length >= options.maxResults, used: "node" };
+  return { text, matches, truncated: visibleMatches > matches.length, used: "node" };
 }
 
 export async function searchWorkspace(config: CodexProConfig, guard: PathGuard, workspace: Workspace, rawOptions: Partial<SearchOptions>): Promise<SearchResult> {


### PR DESCRIPTION
## Summary

- clear runtime status when the interactive launcher exits through `q` or Ctrl-C
- stop admin profile saves from carrying stale tunnel-specific config or hidden Cloudflare tokens across tunnel mode changes
- fix Node search fallback truncation so exact-limit results are not reported as truncated
- add focused smoke/stress coverage for all three regressions

## Root causes

- the interactive control panel called `cleanupChildren()` directly, bypassing the launcher cleanup wrapper that also clears runtime status
- admin profile saves merged old profile values, then persisted tunnel-specific fields even when the new tunnel mode did not use them
- Node fallback search stopped at the visible result limit and used `matches.length >= max_results` as truncation, so exact-limit results were falsely marked truncated

## Verification

- `node --check scripts/http-smoke.mjs`
- `node --check scripts/stress.mjs`
- `node --check scripts/settings-smoke.mjs`
- `npm run build`
- `node scripts/http-smoke.mjs`
- `node scripts/stress.mjs`
- `node scripts/settings-smoke.mjs`
- `npm run stress`
- `npm run smoke`
- `git diff --check`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- real tarball install probe: bin executability, `codexpro --version`, `doctor`, and `pro-bundle`

## Current truth

Repo version remains `0.28.6`; npm `latest` remains `0.28.5` until publish.
