### PR TITLE
Fix large-file range reads and search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Hardened Codex handoff execution on Windows by resolving spawnable Codex shims, asking Codex to read the plan file instead of argv-passing the whole plan, and recording git status in handoff artifacts.
 - Added concise connector-creation troubleshooting to the English and Chinese FAQs.
 - Bounded browser-facing tool-card structured payloads and binary-file text checks so CodexPro emits less data without reducing normal tool-result or binary-detection quality.
+- Allowed targeted line-range reads and search matches in text files slightly above `maxReadBytes`, while keeping full-file reads and very large scans bounded.
 - Replaced the overlong README with a shorter install, tunnel, safety, RAM-boundary, and development guide.
 - Added a guarded `apply_patch` MCP tool for unified-diff edits inside workspace write mode, with blocked-path and secret-content checks before patches are applied.
 - Added last-shown review checkpoints to `show_changes`, so repeated unchanged reviews collapse while new workspace changes still produce a fresh diff.

--- a/FAQ.md
+++ b/FAQ.md
@@ -273,11 +273,21 @@ Use it with repos you trust. Keep token auth enabled for public tunnels. Keep sa
 
 ## Where are saved settings stored?
 
-Workspace profiles are saved under:
+CodexPro stores local state under `~/.codexpro` by default. On Windows that is usually `C:\Users\<you>\.codexpro`.
+
+Workspace profiles are JSON files saved under:
 
 ```text
 ~/.codexpro/profiles/
 ```
+
+Current runtime connection files are saved under:
+
+```text
+~/.codexpro/runtime/
+```
+
+Set `CODEXPRO_HOME` to move this directory.
 
 Use:
 

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -537,15 +537,33 @@ async function runSupertoolModeStress(root) {
 
 async function runMaxReadSearchStress() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-max-read-'));
-  await fs.writeFile(path.join(root, 'large.txt'), `needle in large file\n${'x'.repeat(5000)}\n`, 'utf8');
+  await fs.writeFile(path.join(root, 'many-lines.txt'), `${Array.from({ length: 1200 }, (_, i) => `x${i % 10}`).join('\n')}\n`, 'utf8');
+  await fs.writeFile(path.join(root, 'large.txt'), `intro\n${'x'.repeat(4500)}\nneedle in large file\n`, 'utf8');
+  await fs.writeFile(path.join(root, 'huge.txt'), `needle in huge file\n${'x'.repeat(20000)}\n`, 'utf8');
   const client = await initClient(root, { CODEXPRO_MAX_READ_BYTES: '1000' });
   try {
     const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+    const manyLinesRead = await client.request('tools/call', {
+      name: 'read',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'many-lines.txt' }
+    });
+    assert(manyLinesRead.isError !== true && manyLinesRead.structuredContent.endLine === 1201, `full read under maxReadBytes failed after line numbering: ${JSON.stringify(manyLinesRead.structuredContent)}`);
+    const fullRead = await client.request('tools/call', {
+      name: 'read',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'large.txt' }
+    });
+    assert(fullRead.isError === true && String(fullRead.structuredContent.error).includes('too large'), 'full read ignored maxReadBytes');
+    const rangedRead = await client.request('tools/call', {
+      name: 'read',
+      arguments: { workspace_id: opened.structuredContent.workspace_id, path: 'large.txt', start_line: 3, end_line: 3 }
+    });
+    assert(rangedRead.isError !== true && rangedRead.structuredContent.text.includes('needle in large file'), `ranged read failed above maxReadBytes: ${JSON.stringify(rangedRead.structuredContent)}`);
     const search = await client.request('tools/call', {
       name: 'search',
-      arguments: { workspace_id: opened.structuredContent.workspace_id, query: 'needle in large file', max_results: 10 }
+      arguments: { workspace_id: opened.structuredContent.workspace_id, query: 'needle', max_results: 10 }
     });
-    assert(search.structuredContent.matches.length === 0, `search ignored maxReadBytes: ${JSON.stringify(search.structuredContent.matches)}`);
+    assert(search.structuredContent.matches.some((match) => match.path === 'large.txt'), `search skipped slightly large file: ${JSON.stringify(search.structuredContent.matches)}`);
+    assert(!search.structuredContent.matches.some((match) => match.path === 'huge.txt'), `search scanned file beyond text scan cap: ${JSON.stringify(search.structuredContent.matches)}`);
   } finally {
     client.close();
   }

--- a/src/fsOps.ts
+++ b/src/fsOps.ts
@@ -43,6 +43,11 @@ export function sha256(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
 
+// ponytail: bounded scan window covers normal source files over the read cap; add a separate knob only if real repos need larger files.
+export function textScanByteLimit(config: CodexProConfig): number {
+  return Math.min(2_000_000, config.maxReadBytes * 4);
+}
+
 function splitLines(text: string): string[] {
   return text.replace(/\r\n/g, "\n").split("\n");
 }
@@ -204,7 +209,8 @@ export async function readTextFile(
 ): Promise<ReadFileResult> {
   const resolved = guard.resolve(workspace, filePath);
   const maxBytes = Math.min(options.maxBytes ?? config.maxReadBytes, config.maxReadBytes);
-  await guard.assertTextFile(resolved.absPath, maxBytes);
+  const hasRange = options.startLine !== undefined || options.endLine !== undefined;
+  await guard.assertTextFile(resolved.absPath, hasRange ? textScanByteLimit(config) : maxBytes);
   const buffer = await fsp.readFile(resolved.absPath);
   const text = buffer.toString("utf8");
   const allLines = splitLines(text);
@@ -216,6 +222,9 @@ export async function readTextFile(
   }
   const selected = allLines.slice(startLine - 1, endLine);
   const numbered = withLineNumbers(selected, startLine);
+  if (hasRange && Buffer.byteLength(numbered, "utf8") > maxBytes) {
+    throw new CodexProError(`Selected line range is too large. Limit: ${maxBytes} bytes.`);
+  }
   const truncated = startLine > 1 || endLine < totalLines;
   return {
     path: resolved.relPath,

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
-import { listFiles } from "./fsOps.js";
+import { listFiles, textScanByteLimit } from "./fsOps.js";
 import { redactSensitiveText } from "./redact.js";
 
 export interface SearchOptions {
@@ -40,7 +40,7 @@ function truncateLine(line: string, max = 400): string {
 
 async function runRipgrep(config: CodexProConfig, guard: PathGuard, workspace: Workspace, options: SearchOptions): Promise<SearchResult> {
   const target = guard.resolve(workspace, options.root ?? ".");
-  const args = ["--json", "--line-number", "--with-filename", "--no-heading", "--color=never", "--max-columns", "500", "--max-count", "50", "--max-filesize", String(config.maxReadBytes)];
+  const args = ["--json", "--line-number", "--with-filename", "--no-heading", "--color=never", "--max-columns", "500", "--max-count", "50", "--max-filesize", String(textScanByteLimit(config))];
   if (!options.regex) args.push("--fixed-strings");
   if (options.includeHidden) args.push("--hidden");
   for (const glob of config.blockedGlobs) args.push("-g", `!${glob}`);
@@ -96,13 +96,14 @@ async function runNodeSearch(config: CodexProConfig, guard: PathGuard, workspace
   });
   const matches: Array<{ path: string; line: number; text: string }> = [];
   let visibleMatches = 0;
+  const scanBytes = textScanByteLimit(config);
   const matcher = options.regex ? new RegExp(options.query) : undefined;
   for (const rel of files) {
     if (visibleMatches > options.maxResults) break;
     const resolved = guard.resolve(workspace, rel);
     try {
       const stat = await fsp.stat(resolved.absPath);
-      if (stat.size > config.maxReadBytes) continue;
+      if (stat.size > scanBytes) continue;
       const buffer = await fsp.readFile(resolved.absPath);
       if (buffer.includes(0)) continue;
       const lines = buffer.toString("utf8").split(/\r?\n/);


### PR DESCRIPTION
## Summary

- allow `read` line ranges in text files slightly above `maxReadBytes` while keeping full-file reads capped
- let `search` scan the same bounded larger text window instead of skipping ordinary source files just over the read cap
- clarify where CodexPro stores local profile and runtime settings

Fixes #62
Answers #61

## Verification

- `npm run build`
- `npm run stress`
- `npm run smoke`
- `git diff --check`
- GitHub CI