### PR TITLE
Add Windows CI and harden runtime lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -28,6 +35,9 @@ jobs:
 
       - name: Smoke Test
         run: npm run smoke
+
+      - name: Stress Test
+        run: npm run stress
 
       - name: Check Package Contents
         run: npm pack --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added Windows CI coverage and made smoke, stress, tunnel-shim, and runtime-status checks portable across Windows and Unix hosts.
+
 ## 0.29.0-beta.1 (npm beta, 2026-07-11)
 
 - Added bounded multi-language repository analysis, grouped search results, change-impact and test recommendations, `codexpro inspect` / `codexpro review` CLI commands, and compact opt-in tool cards.

--- a/scripts/analysis-smoke.mjs
+++ b/scripts/analysis-smoke.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const projectRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const importBuilt = (relativePath) => import(pathToFileURL(path.join(projectRoot, 'dist', relativePath)).href);
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-'));
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-outside-'));

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -870,9 +870,8 @@ async function downloadFile(url, destination) {
 }
 
 function verifyCloudflared(binaryPath) {
-  const result = spawnSync(binaryPath, ['--version'], {
+  const result = spawnSyncPortable(binaryPath, ['--version'], {
     stdio: 'ignore',
-    shell: false,
     timeout: 15000
   });
   if (result.status !== 0) {
@@ -959,9 +958,8 @@ async function resolveCloudflared(args) {
 }
 
 function verifyNgrok(binaryPath) {
-  const result = spawnSync(binaryPath, ['version'], {
+  const result = spawnSyncPortable(binaryPath, ['version'], {
     stdio: 'ignore',
-    shell: false,
     timeout: 15000
   });
   if (result.status !== 0) {
@@ -989,9 +987,8 @@ function resolveNgrok(args) {
 }
 
 function verifyTailscale(binaryPath) {
-  const result = spawnSync(binaryPath, ['version'], {
+  const result = spawnSyncPortable(binaryPath, ['version'], {
     stdio: 'ignore',
-    shell: false,
     timeout: 15000
   });
   if (result.status !== 0) {
@@ -1101,7 +1098,12 @@ const spawnedChildren = new Set();
 
 function spawnLogged(name, command, args, options = {}) {
   const { verbose = false, ...spawnOptions } = options;
-  const child = spawn(command, args, { ...spawnOptions, stdio: ['ignore', 'pipe', 'pipe'] });
+  const invocation = processInvocation(command, args);
+  const child = spawn(invocation.command, invocation.args, {
+    ...spawnOptions,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments
+  });
   const logLines = [];
   const record = (stream, chunk) => {
     const text = redactForLog(String(chunk));
@@ -1192,10 +1194,12 @@ function requestQuickTunnelViaCurl(proxyUrl) {
   const args = ['--silent', '--show-error', '--fail', '--max-time', '30'];
   if (proxyUrl) args.push('--proxy', proxyUrl);
   args.push('-X', 'POST', 'https://api.trycloudflare.com/tunnel');
-  const result = spawnSync('curl', args, {
+  const curlCommand = process.platform === 'win32'
+    ? commandPaths('curl').find(isWindowsCommandCandidate) || 'curl'
+    : 'curl';
+  const result = spawnSyncPortable(curlCommand, args, {
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    shell: false
+    stdio: ['ignore', 'pipe', 'pipe']
   });
   if (result.status !== 0) {
     throw new Error(redactForLog(`Failed to request Cloudflare quick tunnel via curl: ${result.stderr || result.stdout || `exit ${result.status}`}`));
@@ -1574,6 +1578,15 @@ function processInvocation(command, args) {
     args: ['/d', '/s', '/c', commandLine],
     windowsVerbatimArguments: true
   };
+}
+
+function spawnSyncPortable(command, args, options = {}) {
+  const invocation = processInvocation(command, args);
+  return spawnSync(invocation.command, invocation.args, {
+    ...options,
+    shell: false,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments
+  });
 }
 
 function runProcessCaptured(command, args, options) {
@@ -3631,7 +3644,19 @@ function writeControlPrompt() {
 }
 
 function runControlPanel(details, cleanup = cleanupChildren) {
-  if (!process.stdin.isTTY) return new Promise(() => {});
+  if (!process.stdin.isTTY) {
+    process.stdin.setEncoding('utf8');
+    process.stdin.resume();
+    return new Promise(() => {
+      process.stdin.on('data', (input) => {
+        const normalized = String(input).trim().toLowerCase();
+        if (normalized === 'q') {
+          cleanup();
+          process.exit(0);
+        }
+      });
+    });
+  }
 
   writeControlPrompt();
 

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1104,6 +1104,7 @@ function spawnLogged(name, command, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsVerbatimArguments: invocation.windowsVerbatimArguments
   });
+  child.codexproKillTree = Boolean(invocation.killTree);
   const logLines = [];
   const record = (stream, chunk) => {
     const text = redactForLog(String(chunk));
@@ -1239,6 +1240,13 @@ function writeQuickTunnelCredentials(tunnel) {
 
 function killProcess(child) {
   if (!child || child.killed) return;
+  if (child.codexproKillTree && child.pid) {
+    const result = spawnSync('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true
+    });
+    if (!result.error && result.status === 0) return;
+  }
   try { child.kill('SIGTERM'); } catch {}
   setTimeout(() => {
     if (!child.killed) {
@@ -1576,7 +1584,8 @@ function processInvocation(command, args) {
   return {
     command: process.env.ComSpec || 'cmd.exe',
     args: ['/d', '/s', '/c', commandLine],
-    windowsVerbatimArguments: true
+    windowsVerbatimArguments: true,
+    killTree: true
   };
 }
 

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -669,14 +669,16 @@ await fs.writeFile(path.join(boundedUntrackedRoot, 'app.txt'), 'start\n', 'utf8'
 await fs.writeFile(path.join(boundedUntrackedRoot, 'bounded-agent.mjs'), `
 import fs from 'node:fs';
 fs.writeFileSync('large-artifact.bin', Buffer.alloc(96 * 1024, 'a'));
-fs.symlinkSync('app.txt', 'app-link.txt');
+if (process.platform !== 'win32') fs.symlinkSync('app.txt', 'app-link.txt');
 `, 'utf8');
 await fs.writeFile(path.join(boundedUntrackedRoot, 'reviewer.mjs'), `
 import fs from 'node:fs';
 const diffPath = process.argv[process.argv.indexOf('--diff') + 1];
 const diff = fs.readFileSync(diffPath, 'utf8');
-const linkLine = diff.split(/\\r?\\n/).find((line) => line.includes('app-link.txt'));
-if (!linkLine || !linkLine.includes('(symlink, target=app.txt') || linkLine.includes('sha256')) process.exit(6);
+if (process.platform !== 'win32') {
+  const linkLine = diff.split(/\\r?\\n/).find((line) => line.includes('app-link.txt'));
+  if (!linkLine || !linkLine.includes('(symlink, target=app.txt') || linkLine.includes('sha256')) process.exit(6);
+}
 if (!diff.includes('large-artifact.bin') || !diff.includes('sha256_first_65536=') || !diff.includes('fingerprint_truncated=true')) process.exit(7);
 if (Buffer.byteLength(diff, 'utf8') > 4500) process.exit(8);
 console.log('CODEXPRO_REVIEW=PASS');

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -83,6 +83,20 @@ async function waitForJson(filePath, predicate, label) {
   throw new Error(`timed out waiting for ${label}: ${lastError?.message ?? 'predicate not met'}`);
 }
 
+async function waitForProcessExit(pid, label) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === 'ESRCH') return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for ${label} process ${pid} to exit`);
+}
+
 async function withStartedCodexPro(args, env, fn, options = {}) {
   const child = spawn(process.execPath, ['scripts/codexpro.mjs', 'start', ...args], {
     cwd: path.resolve('.'),
@@ -494,9 +508,12 @@ if (runInteractiveQuit([
 const cloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-'));
 const cloudflarePort = await getFreePort();
 const cloudflarePath = await runtimeStatusPath(cloudflareRoot, home);
+const fakeCloudflaredPidPath = path.join(home, 'fake-cloudflared.pid');
 const fakeCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared.mjs'), [
   '#!/usr/bin/env node',
+  "import fs from 'node:fs';",
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
+  'fs.writeFileSync(process.env.CODEXPRO_FAKE_CLOUDFLARED_PID, String(process.pid));',
   "console.error('https://api.trycloudflare.com/tunnel');",
   "setTimeout(() => console.error('https://real-codexpro.trycloudflare.com'), 100);",
   'setInterval(() => {}, 1000);',
@@ -514,12 +531,21 @@ await withStartedCodexPro([
   '--token',
   'codexpro-cloudflare-token',
   '--no-copy-url'
-], withoutProxyEnv(env), async () => {
+], withoutProxyEnv({ ...env, CODEXPRO_FAKE_CLOUDFLARED_PID: fakeCloudflaredPidPath }), async () => {
   const runtime = await waitForJson(cloudflarePath, (data) => data.endpoint?.includes('trycloudflare.com'), 'cloudflare runtime status');
   if (runtime.endpoint.includes('api.trycloudflare.com') || !runtime.endpoint.startsWith('https://real-codexpro.trycloudflare.com/mcp')) {
     throw new Error(`quick tunnel saved the wrong endpoint: ${JSON.stringify(runtime)}`);
   }
 });
+if (process.platform === 'win32') {
+  const fakeCloudflaredPid = Number(await fs.readFile(fakeCloudflaredPidPath, 'utf8'));
+  try {
+    await waitForProcessExit(fakeCloudflaredPid, 'fake cloudflared shim descendant');
+  } catch (error) {
+    spawnSync('taskkill.exe', ['/pid', String(fakeCloudflaredPid), '/t', '/f'], { stdio: 'ignore' });
+    throw error;
+  }
+}
 
 const proxyCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-proxy-'));
 const proxyCloudflarePort = await getFreePort();

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -45,6 +45,17 @@ async function runtimeStatusPath(root, home) {
   return path.join(home, 'runtime', `${id}.json`);
 }
 
+async function writeNodeExecutable(filePath, lines, windowsCommandPath) {
+  await fs.writeFile(filePath, lines.join('\n'), { mode: 0o700 });
+  if (process.platform !== 'win32') return filePath;
+  const commandPath = windowsCommandPath ?? path.join(
+    path.dirname(filePath),
+    `${path.basename(filePath, path.extname(filePath))}.cmd`
+  );
+  await fs.writeFile(commandPath, `@echo off\r\n"${process.execPath}" "${filePath}" %*\r\n`, 'utf8');
+  return commandPath;
+}
+
 async function getFreePort() {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
@@ -72,11 +83,11 @@ async function waitForJson(filePath, predicate, label) {
   throw new Error(`timed out waiting for ${label}: ${lastError?.message ?? 'predicate not met'}`);
 }
 
-async function withStartedCodexPro(args, env, fn) {
+async function withStartedCodexPro(args, env, fn, options = {}) {
   const child = spawn(process.execPath, ['scripts/codexpro.mjs', 'start', ...args], {
     cwd: path.resolve('.'),
     env,
-    stdio: ['ignore', 'pipe', 'pipe']
+    stdio: ['pipe', 'pipe', 'pipe']
   });
   let output = '';
   let closed = false;
@@ -91,7 +102,10 @@ async function withStartedCodexPro(args, env, fn) {
   } catch (error) {
     throw new Error(`${error.message}\nstart output:\n${output}`);
   } finally {
-    if (!closed) child.kill('SIGTERM');
+    if (!closed) {
+      if (process.platform === 'win32' && !options.forceKill) child.stdin.end('q\n');
+      else child.kill('SIGTERM');
+    }
     await closedPromise;
   }
 }
@@ -437,7 +451,19 @@ await withStartedCodexPro([
   if (runtime.toolCards !== true || runtime.pid !== child.pid) {
     throw new Error(`runtime status did not persist toolCards: ${JSON.stringify(runtime)}`);
   }
-});
+}, { forceKill: true });
+const previousCodexProHome = process.env.CODEXPRO_HOME;
+process.env.CODEXPRO_HOME = home;
+try {
+  const { readRuntimeConnection } = await import('../dist/profileStore.js');
+  const stoppedRuntime = readRuntimeConnection(runtimeRoot);
+  if (Object.keys(stoppedRuntime).length > 0) {
+    throw new Error(`stale runtime status remained visible after launcher exit: ${JSON.stringify(stoppedRuntime)}`);
+  }
+} finally {
+  if (previousCodexProHome === undefined) delete process.env.CODEXPRO_HOME;
+  else process.env.CODEXPRO_HOME = previousCodexProHome;
+}
 try {
   await fs.access(runtimePath);
   throw new Error('runtime status was not cleared after launcher SIGTERM');
@@ -468,15 +494,14 @@ if (runInteractiveQuit([
 const cloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-'));
 const cloudflarePort = await getFreePort();
 const cloudflarePath = await runtimeStatusPath(cloudflareRoot, home);
-const fakeCloudflared = path.join(home, 'fake-cloudflared.mjs');
-await fs.writeFile(fakeCloudflared, [
+const fakeCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
   "console.error('https://api.trycloudflare.com/tunnel');",
   "setTimeout(() => console.error('https://real-codexpro.trycloudflare.com'), 100);",
   'setInterval(() => {}, 1000);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 await withStartedCodexPro([
   '--root',
   cloudflareRoot,
@@ -500,18 +525,17 @@ const proxyCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-se
 const proxyCloudflarePort = await getFreePort();
 const proxyCloudflarePath = await runtimeStatusPath(proxyCloudflareRoot, home);
 const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-fake-bin-'));
-const fakeCurl = path.join(fakeBin, 'curl');
+const fakeCurlScript = path.join(fakeBin, process.platform === 'win32' ? 'curl.cjs' : 'curl');
 const curlArgsPath = path.join(home, 'fake-curl-args.json');
 const cloudflaredArgsPath = path.join(home, 'fake-cloudflared-proxy-args.json');
-const fakeProxyCloudflared = path.join(home, 'fake-cloudflared-proxy.mjs');
-await fs.writeFile(fakeCurl, [
+await writeNodeExecutable(fakeCurlScript, [
   '#!/usr/bin/env node',
   "const fs = require('node:fs');",
   "fs.writeFileSync(process.env.CODEXPRO_FAKE_CURL_ARGS, JSON.stringify(process.argv.slice(2)));",
   "console.log(JSON.stringify({ success: true, result: { id: 'proxy-tunnel-id', hostname: 'proxy-codexpro.trycloudflare.com', account_tag: 'account-tag', secret: 'proxy-secret-1234567890' } }));",
   ''
-].join('\n'), { mode: 0o700 });
-await fs.writeFile(fakeProxyCloudflared, [
+], path.join(fakeBin, 'curl.cmd'));
+const fakeProxyCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared-proxy.mjs'), [
   '#!/usr/bin/env node',
   "import fs from 'node:fs';",
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
@@ -522,7 +546,7 @@ await fs.writeFile(fakeProxyCloudflared, [
   "if (credentials.TunnelID !== 'proxy-tunnel-id' || credentials.AccountTag !== 'account-tag' || credentials.TunnelSecret !== 'proxy-secret-1234567890') process.exit(4);",
   "setInterval(() => {}, 1000);",
   ''
-].join('\n'), { mode: 0o700 });
+]);
 await withStartedCodexPro([
   '--root',
   proxyCloudflareRoot,
@@ -565,14 +589,13 @@ try {
 
 const proxyCloudflareFailRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-proxy-fail-'));
 const proxyCloudflareFailPort = await getFreePort();
-const fakeFailingProxyCloudflared = path.join(home, 'fake-cloudflared-proxy-fail.mjs');
-await fs.writeFile(fakeFailingProxyCloudflared, [
+const fakeFailingProxyCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared-proxy-fail.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
   "console.error('proxy tunnel startup failed');",
   'process.exit(7);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 const proxyFailure = runFail([
   'start',
   '--root',
@@ -598,15 +621,14 @@ if (!proxyFailure.includes('proxy tunnel startup failed')) {
 
 const namedCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-named-'));
 const namedCloudflarePort = await getFreePort();
-const fakeNamedCloudflared = path.join(home, 'fake-cloudflared-named.mjs');
 const cloudflareRawToken = 'cf_audit_secret_1234567890TOKEN';
-await fs.writeFile(fakeNamedCloudflared, [
+const fakeNamedCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared-named.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
   "console.error('fake tunnel saw TUNNEL_TOKEN=' + process.env.TUNNEL_TOKEN);",
   'process.exit(2);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 const namedFailure = runFail([
   'start',
   '--root',
@@ -629,14 +651,13 @@ if (namedFailure.includes(cloudflareRawToken) || !namedFailure.includes('TUNNEL_
   throw new Error(`named tunnel failure leaked or failed to redact Cloudflare token\n${namedFailure}`);
 }
 
-const fakeNgrok = path.join(home, 'fake-ngrok.mjs');
-await fs.writeFile(fakeNgrok, [
+const fakeNgrok = await writeNodeExecutable(path.join(home, 'fake-ngrok.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('version')) { console.log('ngrok version 3.0.0'); process.exit(0); }",
   "console.error('NGROK_ARGS=' + process.argv.slice(2).join('|'));",
   'process.exit(2);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 run([
   'settings',
   'set',
@@ -671,14 +692,13 @@ if (!ngrokFailure.includes(`--config|${path.join(realNgrokRoot, 'new-ngrok.yml')
   throw new Error(`ngrok start did not let env config override saved profile\n${ngrokFailure}`);
 }
 
-const fakeTailscale = path.join(home, 'fake-tailscale.mjs');
-await fs.writeFile(fakeTailscale, [
+const fakeTailscale = await writeNodeExecutable(path.join(home, 'fake-tailscale.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('version')) { console.log('1.80.0'); process.exit(0); }",
   "console.error('TAILSCALE_ARGS=' + process.argv.slice(2).join('|'));",
   'process.exit(2);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 const tailscaleRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-tailscale-'));
 const tailscalePort = await getFreePort();
 const tailscaleFailure = runFail([

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -644,7 +644,7 @@ const pwdBashText = pwdBash.content?.[0]?.text ?? '';
 if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwdBashText.includes('## stderr')) {
   throw new Error(`default bash transcript should be compact: ${pwdBashText}`);
 }
-if (!pwdBash.structuredContent.stdout?.includes(tmp)) {
+if (!pwdBash.structuredContent.stdout?.includes(path.basename(tmp))) {
   throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
 }
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
@@ -977,7 +977,7 @@ await fullTranscriptClient.request('initialize', {
 fullTranscriptClient.notify('notifications/initialized');
 const fullTranscriptBash = await fullTranscriptClient.request('tools/call', { name: 'bash', arguments: { command: 'pwd' } });
 const fullTranscriptText = fullTranscriptBash.content?.[0]?.text ?? '';
-if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(tmp)) {
+if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(path.basename(tmp))) {
   throw new Error(`full bash transcript mode did not preserve raw stdout in chat text: ${fullTranscriptText}`);
 }
 fullTranscriptClient.close();

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -107,7 +107,9 @@ async function makeFixture() {
   await fs.writeFile(path.join(root, 'AGENTS.md'), '# Stress Agents\n\nKeep checks local.\n', 'utf8');
   await fs.writeFile(path.join(root, 'demo.txt'), 'alpha\n--flag root\narrow -> value\n', 'utf8');
   await fs.writeFile(path.join(root, '.hidden.txt'), 'needle hidden\n', 'utf8');
-  await fs.writeFile(path.join(root, 'visible:123:file.txt'), 'needle colon path\n', 'utf8');
+  if (process.platform !== 'win32') {
+    await fs.writeFile(path.join(root, 'visible:123:file.txt'), 'needle colon path\n', 'utf8');
+  }
   await fs.mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
   await fs.writeFile(path.join(root, '.github', 'workflows', 'ci.yml'), 'name: ci\n', 'utf8');
   await fs.mkdir(path.join(root, 'many'), { recursive: true });
@@ -207,11 +209,13 @@ async function runFullModeStress(root) {
     });
     assert(hiddenSearch.structuredContent.matches.some((match) => match.path === '.hidden.txt'), 'include_hidden search missed hidden file');
 
-    const colonSearch = await client.request('tools/call', {
-      name: 'search',
-      arguments: { workspace_id: ws, query: 'needle colon path', max_results: 10 }
-    });
-    assert(colonSearch.structuredContent.matches.some((match) => match.path === 'visible:123:file.txt' && match.line === 1), `colon path search parsed incorrectly: ${JSON.stringify(colonSearch.structuredContent.matches)}`);
+    if (process.platform !== 'win32') {
+      const colonSearch = await client.request('tools/call', {
+        name: 'search',
+        arguments: { workspace_id: ws, query: 'needle colon path', max_results: 10 }
+      });
+      assert(colonSearch.structuredContent.matches.some((match) => match.path === 'visible:123:file.txt' && match.line === 1), `colon path search parsed incorrectly: ${JSON.stringify(colonSearch.structuredContent.matches)}`);
+    }
 
     const superRead = await client.request('tools/call', {
       name: 'codexpro',
@@ -456,7 +460,10 @@ async function runMcpInventoryStress() {
   await fs.writeFile(path.join(fakeHome, '.codex', 'config.toml'), toml, 'utf8');
   await fs.writeFile(path.join(fakeHome, '.cursor', 'mcp.json'), JSON.stringify({ mcpServers: cursorServers }), 'utf8');
 
-  const client = await initClient(root, { HOME: fakeHome });
+  const client = await initClient(root, {
+    HOME: fakeHome,
+    ...(process.platform === 'win32' ? { USERPROFILE: fakeHome } : {})
+  });
   try {
     const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
     const inventory = await client.request('tools/call', {

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -39,6 +39,7 @@ export interface WorkspaceProfile {
 export interface RuntimeConnection {
   version?: number;
   root?: string;
+  pid?: number;
   updatedAt?: string;
   endpoint?: string;
   localBase?: string;
@@ -136,5 +137,23 @@ export function readRuntimeConnection(root: string): RuntimeConnection {
   if (!runtime || typeof runtime !== "object" || Array.isArray(runtime)) return {};
   const typed = runtime as RuntimeConnection;
   if (typed.root && typed.root !== root) return {};
+  if (typeof typed.pid === "number" && !processIsAlive(typed.pid)) {
+    try {
+      fs.rmSync(runtimePath, { force: true });
+    } catch {
+      // Best-effort stale runtime cleanup.
+    }
+    return {};
+  }
   return typed;
+}
+
+function processIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && typeof error === "object" && "code" in error && error.code === "EPERM");
+  }
 }


### PR DESCRIPTION
## Summary

- add an Ubuntu/Windows CI matrix and run both smoke and stress coverage
- reuse the existing safe Windows `.cmd`/`.bat` invocation path for tunnel binaries and proxied `curl`
- support cooperative `q` shutdown for non-TTY launchers so runtime and temporary tunnel credentials are cleaned up
- discard stale runtime status when its recorded launcher PID no longer exists
- make path, home-directory, symlink, colon-filename, and fake-binary fixtures portable without reducing Linux coverage

## Why

CodexPro supports Windows, but CI currently runs only on Ubuntu. On Windows, the documented validation flow failed in several places before reaching the end of the suite:

- `analysis-smoke` built a doubled drive path such as `C:\\C:\\...`
- bash transcript assertions compared native Windows paths with MSYS/WSL-style output
- forced launcher termination left a stale runtime status file
- JavaScript tunnel fixtures could not be executed as Windows binaries
- stress fixtures assumed Unix filename, symlink, and `HOME` behavior

The runtime-status failure is user-visible: the local settings/status page can report a stopped launcher as active after an abrupt Windows termination.

## Impact

- Windows becomes a continuously tested platform instead of a best-effort path.
- Explicit `.cmd`/`.bat` tunnel shims use the same quoted `cmd.exe` wrapper already used by the handoff executor.
- Non-interactive launchers can request graceful shutdown by writing `q` to stdin.
- Stale runtime files self-heal on read when their PID is no longer alive.
- Existing Linux-only edge-case coverage remains enabled on Linux.

This does not change authentication, tunnel exposure, tool permissions, or default write/bash policy.

## Validation

- `npm ci` (0 vulnerabilities)
- `npm run build`
- `npm run smoke`
- `npm run stress`
- `npm pack --dry-run`
- `git diff --check`

All checks passed locally on Windows.

## Contributor attribution

One small attribution request: if this is merged directly or ported into another branch, could you please preserve the author metadata from commit `fb12f76` (or add `Co-authored-by: Zao <zawonyee@163.com>`) so GitHub can credit the contribution? Please use whichever merge strategy best fits the project. Thank you.
