### PR TITLE
docs: update ChatGPT plugin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ CodexPro prints and copies the Server URL. In ChatGPT, open:
 
 ```text
 Settings -> Security and login -> Developer mode: on
-Settings -> Plugins -> Create
+Settings -> Plugins -> Plugins tab -> + (beside Search plugins)
 ```
 
-Paste the Server URL and choose `Authentication: No Authentication / None`.
-CodexPro uses its own URL token.
+This opens **New Plugin**. Give it a name such as `CodexPro`, paste the Server URL in the **Server URL** connection option, then choose `Authentication: No Authentication / None`. The form may initially show OAuth; change it before creating the plugin. CodexPro uses its own URL token.
 
 Daily use from the same repo:
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -50,7 +50,7 @@ cd /path/to/your/repo
 codexpro setup
 ```
 
-CodexPro 会自动复制 ChatGPT Server URL。先到 `Settings -> Security and login` 打开 Developer mode，再到 `Settings -> Plugins` 创建连接，粘贴这个 URL，并选择 `Authentication: No Authentication / None`。
+CodexPro 会自动复制 ChatGPT Server URL。先到 `Settings -> Security and login` 打开 Developer mode，再到 `Settings -> Plugins -> Plugins` 标签页，点击搜索框旁的圆形 `+` 图标。打开 **New Plugin** 后，粘贴这个 URL，连接方式选择 `Server URL`，并选择 `Authentication: No Authentication / None`。表单可能默认显示 OAuth，请在创建前改为 No Authentication / None。
 
 以后同一个仓库日常启动只需要：
 
@@ -128,12 +128,13 @@ ChatGPT Settings
 
 ChatGPT Settings
 -> Plugins
--> Create
+-> Plugins 标签页
+-> 点击搜索框旁的 +
 ```
 
 保留 CSP 开启。CodexPro 的卡片和小组件就是按 CSP 开启的路径设计的，不需要远程脚本、外部字体、iframe 或第三方图片。
 
-在创建 Plugin 页面填写：
+在打开的 New Plugin 页面填写：
 
 ```text
 Name: CodexPro
@@ -143,7 +144,7 @@ Server URL: 粘贴 CodexPro 自动复制的 URL
 Authentication: No Authentication / None
 ```
 
-复制的 Server URL 已经包含私有 `codexpro_token`。不要单独粘贴 token，除非你的 ChatGPT UI 明确支持自定义 header。
+表单可能默认显示 OAuth；请改为 `No Authentication / None`。复制的 Server URL 已经包含私有 `codexpro_token`。不要单独粘贴 token，除非你的 ChatGPT UI 明确支持自定义 header。
 
 保持终端里的 CodexPro 进程运行。你停止它之后，ChatGPT 就无法继续连接本地仓库。Cloudflare quick tunnel 的 URL 也会失效。
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,14 +246,14 @@ codexpro setup</code>
             <span>3</span>
             <div>
               <strong>Turn on Developer Mode</strong>
-              <p>In ChatGPT, open Settings -> Security and login. Turn on Developer mode and keep Enforce CSP in developer mode enabled, then go to Settings -> Plugins and create the connection.</p>
+              <p>In ChatGPT, open Settings -> Security and login. Turn on Developer mode and keep Enforce CSP in developer mode enabled. Then open Settings -> Plugins, stay on the Plugins tab, and click the circular + beside Search plugins.</p>
             </div>
           </div>
           <div class="step">
             <span>4</span>
             <div>
               <strong>Create a ChatGPT plugin</strong>
-              <p>Name it CodexPro. Use Connection: Server URL. Paste the copied URL. Set Authentication to No Authentication / None.</p>
+              <p>In New Plugin, name it CodexPro. Use Connection: Server URL and paste the copied URL. The form may default to OAuth; set Authentication to No Authentication / None before creating the plugin.</p>
             </div>
           </div>
           <div class="step">
@@ -412,7 +412,7 @@ cloudflared tunnel route dns codexpro codexpro.example.com</code></pre>
               <div><dt>Go to</dt><dd>Security and login</dd></div>
               <div><dt>Enable</dt><dd>Developer mode</dd></div>
               <div><dt>Keep on</dt><dd>Enforce CSP in developer mode</dd></div>
-              <div><dt>Then</dt><dd>Plugins -> Create</dd></div>
+              <div><dt>Then</dt><dd>Plugins -> Plugins tab -> + beside Search plugins</dd></div>
             </dl>
             <p>This is a one-time ChatGPT setting. CodexPro widgets work with CSP enabled.</p>
           </article>
@@ -426,7 +426,7 @@ cloudflared tunnel route dns codexpro codexpro.example.com</code></pre>
               <div><dt>Server URL</dt><dd>Paste copied CodexPro URL</dd></div>
               <div><dt>Authentication</dt><dd>No Authentication / None</dd></div>
             </dl>
-            <p>The copied Server URL already includes the private CodexPro token. Do not paste the token separately unless your ChatGPT UI supports custom headers.</p>
+            <p>The form may initially show OAuth; select No Authentication / None. The copied Server URL already includes the private CodexPro token. Do not paste the token separately unless your ChatGPT UI supports custom headers.</p>
           </article>
           <article>
             <small>Doctor</small>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -206,7 +206,8 @@ codexpro setup</code></pre>
 
 Settings
 -> Plugins
--> Create</code></pre>
+-> Plugins 标签页
+-> 点击搜索框旁的 +</code></pre>
           </div>
           <div>
             <small>创建 Plugin 字段</small>
@@ -217,13 +218,13 @@ Authentication: No Authentication / None</code></pre>
           </div>
         </div>
         <div>
-          <p class="eyebrow">ChatGPT App 设置</p>
-          <h2>创建 Plugin 时粘贴 CodexPro 复制的 URL。</h2>
+          <p class="eyebrow">ChatGPT Plugin 设置</p>
+          <h2>在 Plugins 标签页点击 +，再在 New Plugin 中粘贴 CodexPro URL。</h2>
           <p>
             保持 Enforce CSP in developer mode 开启。CodexPro 的小组件按 CSP 开启路径设计，不依赖远程脚本、外部字体、iframe 或第三方图片。
           </p>
           <p>
-            复制的 Server URL 已包含私有 CodexPro token。Authentication 选择 No Authentication / None，不需要单独粘贴 token。
+            复制的 Server URL 已包含私有 CodexPro token。连接方式选择 Server URL。表单可能默认显示 OAuth；请将 Authentication 改为 No Authentication / None，不需要单独粘贴 token。
           </p>
         </div>
       </section>


### PR DESCRIPTION
## What changed

Updates the ChatGPT plugin setup documentation for the current UI:

- Plugins → Plugins tab → the + button beside Search plugins
- New Plugin fields: Server URL and No Authentication / None
- OAuth-default warning
- English and Chinese README and site documentation

## Why

The previous Plugins → Create path is outdated and caused confusion in issue #65.

## Validation

- `git diff --check`
- `npm run build`