### PR TITLE
Fix Windows stability and plugin lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "start:http": "node dist/http.js",
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
-    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
+    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/lifecycle-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
     "stress": "npm run build && node scripts/stress.mjs",
     "analysis:smoke": "npm run build && node scripts/analysis-smoke.mjs",
     "analysis:cli-smoke": "npm run build && node scripts/analysis-cli-smoke.mjs",

--- a/scripts/analysis-smoke.mjs
+++ b/scripts/analysis-smoke.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const projectRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const importBuilt = (relativePath) => import(pathToFileURL(path.join(projectRoot, 'dist', relativePath)).href);
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-'));
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-outside-'));

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -870,7 +870,7 @@ async function downloadFile(url, destination) {
 }
 
 function verifyCloudflared(binaryPath) {
-  const result = spawnSync(binaryPath, ['--version'], {
+  const result = spawnSyncExternal(binaryPath, ['--version'], {
     stdio: 'ignore',
     shell: false,
     timeout: 15000
@@ -959,7 +959,7 @@ async function resolveCloudflared(args) {
 }
 
 function verifyNgrok(binaryPath) {
-  const result = spawnSync(binaryPath, ['version'], {
+  const result = spawnSyncExternal(binaryPath, ['version'], {
     stdio: 'ignore',
     shell: false,
     timeout: 15000
@@ -989,7 +989,7 @@ function resolveNgrok(args) {
 }
 
 function verifyTailscale(binaryPath) {
-  const result = spawnSync(binaryPath, ['version'], {
+  const result = spawnSyncExternal(binaryPath, ['version'], {
     stdio: 'ignore',
     shell: false,
     timeout: 15000
@@ -1101,7 +1101,12 @@ const spawnedChildren = new Set();
 
 function spawnLogged(name, command, args, options = {}) {
   const { verbose = false, ...spawnOptions } = options;
-  const child = spawn(command, args, { ...spawnOptions, stdio: ['ignore', 'pipe', 'pipe'] });
+  const invocation = processInvocation(command, args);
+  const child = spawn(invocation.command, invocation.args, {
+    ...spawnOptions,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments
+  });
   const logLines = [];
   const record = (stream, chunk) => {
     const text = redactForLog(String(chunk));
@@ -1192,7 +1197,7 @@ function requestQuickTunnelViaCurl(proxyUrl) {
   const args = ['--silent', '--show-error', '--fail', '--max-time', '30'];
   if (proxyUrl) args.push('--proxy', proxyUrl);
   args.push('-X', 'POST', 'https://api.trycloudflare.com/tunnel');
-  const result = spawnSync('curl', args, {
+  const result = spawnSyncExternal(process.env.CODEXPRO_CURL_BIN || 'curl', args, {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: false
@@ -1225,6 +1230,7 @@ function requestQuickTunnelViaCurl(proxyUrl) {
 function writeQuickTunnelCredentials(tunnel) {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codexpro-cloudflare-quick-'));
   const credentialsPath = path.join(tmpRoot, 'credentials.json');
+  fs.writeFileSync(path.join(tmpRoot, 'owner.json'), JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }), { mode: 0o600 });
   fs.writeFileSync(credentialsPath, JSON.stringify({
     AccountTag: tunnel.accountTag,
     TunnelSecret: tunnel.secret,
@@ -1233,11 +1239,39 @@ function writeQuickTunnelCredentials(tunnel) {
   return { tmpRoot, credentialsPath };
 }
 
+function cleanupStaleQuickTunnelCredentials() {
+  const prefix = 'codexpro-cloudflare-quick-';
+  for (const entry of fs.readdirSync(os.tmpdir(), { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+    const tmpRoot = path.join(os.tmpdir(), entry.name);
+    let remove = false;
+    try {
+      const owner = readJsonFile(path.join(tmpRoot, 'owner.json'));
+      if (Number.isInteger(owner?.pid) && owner.pid > 0) {
+        try { process.kill(owner.pid, 0); } catch { remove = true; }
+      } else {
+        remove = Date.now() - fs.statSync(tmpRoot).mtimeMs > 86_400_000;
+      }
+    } catch {
+      remove = Date.now() - fs.statSync(tmpRoot).mtimeMs > 86_400_000;
+    }
+    if (remove) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
 function killProcess(child) {
-  if (!child || child.killed) return;
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  if (process.platform === 'win32' && child.pid) {
+    spawnSync('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'ignore', 'ignore'],
+      shell: false
+    });
+    return;
+  }
   try { child.kill('SIGTERM'); } catch {}
   setTimeout(() => {
-    if (!child.killed) {
+    if (child.exitCode === null && child.signalCode === null) {
       try { child.kill('SIGKILL'); } catch {}
     }
   }, 1500).unref();
@@ -1326,18 +1360,36 @@ function openUrl(url) {
   return result.status === 0;
 }
 
-function waitForProcessExit(child) {
-  return new Promise((resolve) => {
-    child.once('exit', (code, signal) => resolve({ code, signal }));
-  });
-}
-
 async function waitForPublicHealth(publicBase, token, tunnelChild, tunnelLabel = 'tunnel') {
   const health = waitForHealth(`${publicBase}/healthz`, token, 60000);
-  const exit = waitForProcessExit(tunnelChild).then(({ code, signal }) => {
-    throw new Error(`${tunnelLabel} exited before ${publicBase}/healthz was reachable, code=${code} signal=${signal}`);
+  let onExit;
+  let onError;
+  const exit = new Promise((_resolve, reject) => {
+    onExit = (code, signal) => {
+      reject(new Error(`${tunnelLabel} exited before ${publicBase}/healthz was reachable, code=${code} signal=${signal}`));
+    };
+    onError = (error) => {
+      reject(new Error(`${tunnelLabel} failed before ${publicBase}/healthz was reachable: ${error instanceof Error ? error.message : String(error)}`));
+    };
+    tunnelChild.once('exit', onExit);
+    tunnelChild.once('error', onError);
   });
-  return Promise.race([health, exit]);
+  try {
+    return await Promise.race([health, exit]);
+  } finally {
+    tunnelChild.off('exit', onExit);
+    tunnelChild.off('error', onError);
+  }
+}
+
+function refreshRuntimeConnection(root) {
+  try {
+    const filePath = runtimeStatusPathForRoot(root);
+    const runtime = readJsonFile(filePath);
+    if (runtime?.pid !== process.pid) return;
+    const now = new Date();
+    fs.utimesSync(filePath, now, now);
+  } catch {}
 }
 
 function isSubpath(child, parent) {
@@ -1465,6 +1517,17 @@ function splitCommandTemplate(input) {
   return tokens;
 }
 
+function coalesceExecutablePath(parts) {
+  if (parts.length < 2) return parts;
+  const first = expandHome(parts[0]);
+  if (!path.isAbsolute(first) && !path.win32.isAbsolute(first)) return parts;
+  for (let index = 1; index < parts.length; index += 1) {
+    const candidate = parts.slice(0, index + 1).join(' ');
+    if (executableFileExists(candidate)) return [candidate, ...parts.slice(index + 1)];
+  }
+  return parts;
+}
+
 function applyCommandTemplate(value, replacements) {
   return String(value).replace(/\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g, (_, key) => replacements[key] ?? '');
 }
@@ -1484,8 +1547,8 @@ function buildExecutorCommand(args, root, planPath, planText) {
     if (!/\{\{\s*(plan_file|plan_text)\s*\}\}/.test(template)) {
       throw new Error('Custom --command must include {{plan_file}} or {{plan_text}} so the agent receives the handoff.');
     }
-    const parts = splitCommandTemplate(template).map((part) => applyCommandTemplate(part, replacements));
-    const displayParts = splitCommandTemplate(template).map((part) => applyCommandTemplate(part, { ...replacements, plan_text: '<plan_text>' }));
+    const parts = coalesceExecutablePath(splitCommandTemplate(template).map((part) => applyCommandTemplate(part, replacements)));
+    const displayParts = coalesceExecutablePath(splitCommandTemplate(template).map((part) => applyCommandTemplate(part, { ...replacements, plan_text: '<plan_text>' })));
     if (!parts.length) throw new Error('Custom --command is empty.');
     return { agent, model, command: parts[0], args: parts.slice(1), displayArgs: displayParts.slice(1), custom: true };
   }
@@ -1567,6 +1630,9 @@ function quoteWindowsCmdArg(value) {
 }
 
 function processInvocation(command, args) {
+  if (/\.(?:cjs|mjs|js)$/i.test(command)) {
+    return { command: process.execPath, args: [command, ...args] };
+  }
   if (!isWindowsBatchFile(command)) return { command, args };
   const commandLine = ['call', quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(' ');
   return {
@@ -1574,6 +1640,14 @@ function processInvocation(command, args) {
     args: ['/d', '/s', '/c', commandLine],
     windowsVerbatimArguments: true
   };
+}
+
+function spawnSyncExternal(command, args, options) {
+  const invocation = processInvocation(command, args);
+  return spawnSync(invocation.command, invocation.args, {
+    ...options,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments
+  });
 }
 
 function runProcessCaptured(command, args, options) {
@@ -2077,8 +2151,8 @@ function loopArtifactPaths(root, contextDir) {
 }
 
 function buildTemplateCommand(template, replacements, displayReplacements, label) {
-  const parts = splitCommandTemplate(template).map((part) => applyCommandTemplate(part, replacements));
-  const displayParts = splitCommandTemplate(template).map((part) => applyCommandTemplate(part, displayReplacements ?? replacements));
+  const parts = coalesceExecutablePath(splitCommandTemplate(template).map((part) => applyCommandTemplate(part, replacements)));
+  const displayParts = coalesceExecutablePath(splitCommandTemplate(template).map((part) => applyCommandTemplate(part, displayReplacements ?? replacements)));
   if (!parts.length) throw new Error(`${label} command is empty.`);
   return {
     command: parts[0],
@@ -3631,7 +3705,17 @@ function writeControlPrompt() {
 }
 
 function runControlPanel(details, cleanup = cleanupChildren) {
-  if (!process.stdin.isTTY) return new Promise(() => {});
+  if (!process.stdin.isTTY) {
+    process.stdin.setEncoding('utf8');
+    process.stdin.resume();
+    process.stdin.on('data', (input) => {
+      if (String(input).trim().toLowerCase() !== 'q') return;
+      console.log('\nStopping CodexPro...');
+      cleanup();
+      process.exit(0);
+    });
+    return new Promise(() => {});
+  }
 
   writeControlPrompt();
 
@@ -3861,6 +3945,7 @@ async function main() {
     CODEXPRO_CONNECTION_TEST: connectionTest ? '1' : '0',
     CODEXPRO_MODE: mode,
     CODEXPRO_TUNNEL_MODE: tunnel === 'none' ? '0' : '1',
+    CODEXPRO_SUPERVISOR_PID: String(process.pid),
     CODEXPRO_ALLOW_NO_HTTP_TOKEN: args.noAuth ? '1' : '0'
   };
   if (codexDir) serverEnv.CODEXPRO_CODEX_DIR = codexDir;
@@ -3906,11 +3991,47 @@ async function main() {
   const server = spawnLogged('codexpro', process.execPath, [httpPath], { cwd: projectRoot, env: serverEnv, verbose: verboseLogs });
   let cloudflared;
   let cleanupTunnelCredentials = () => {};
+  let runtimeHeartbeat;
+  let shuttingDown = false;
   const cleanup = () => {
+    shuttingDown = true;
+    if (runtimeHeartbeat) clearInterval(runtimeHeartbeat);
     cleanupTunnelCredentials();
     cleanupChildren();
     clearRuntimeConnection(root);
   };
+  const failClosedOnServerExit = (code, signal) => {
+    if (shuttingDown) return;
+    console.error(`[codexpro] local MCP server exited unexpectedly (code=${code ?? 'null'} signal=${signal ?? 'none'}). Closing the tunnel.`);
+    cleanup();
+    process.exit(1);
+  };
+  const failClosedOnTunnelExit = (label) => {
+    const onError = (error) => {
+      if (shuttingDown) return;
+      console.error(`[codexpro] ${label} failed unexpectedly: ${error instanceof Error ? error.message : String(error)}. Closing the local MCP server.`);
+      cleanup();
+      process.exit(1);
+    };
+    const onExit = (code, signal) => {
+      if (shuttingDown) return;
+      console.error(`[codexpro] ${label} exited unexpectedly (code=${code ?? 'null'} signal=${signal ?? 'none'}). Closing the local MCP server.`);
+      cleanup();
+      process.exit(1);
+    };
+    cloudflared.once('error', onError);
+    cloudflared.once('exit', onExit);
+    if (cloudflared.exitCode !== null || cloudflared.signalCode !== null) {
+      onExit(cloudflared.exitCode, cloudflared.signalCode);
+    }
+  };
+  server.once('error', (error) => {
+    if (shuttingDown) return;
+    console.error(`[codexpro] local MCP server failed to start: ${error instanceof Error ? error.message : String(error)}`);
+    cleanup();
+    process.exit(1);
+  });
+  server.once('exit', failClosedOnServerExit);
   process.on('SIGINT', () => { cleanup(); process.exit(130); });
   process.on('SIGTERM', () => { cleanup(); process.exit(143); });
 
@@ -3930,6 +4051,12 @@ async function main() {
     requireBashSession,
     toolCards,
     connectionTest
+  };
+  const publishRuntimeConnection = (details) => {
+    saveRuntimeConnection(root, details, runtimeOptions);
+    if (runtimeHeartbeat) clearInterval(runtimeHeartbeat);
+    runtimeHeartbeat = setInterval(() => refreshRuntimeConnection(root), 500);
+    runtimeHeartbeat.unref();
   };
 
   if (tunnel === 'none') {
@@ -3952,7 +4079,7 @@ async function main() {
       requireBashSession,
       connectionTest
     });
-    saveRuntimeConnection(root, details, runtimeOptions);
+    publishRuntimeConnection(details);
     await runControlPanel(details, cleanup);
     return;
   }
@@ -3981,6 +4108,7 @@ async function main() {
       ].join('\n');
       throw new Error(`${error instanceof Error ? error.message : String(error)}${tail ? `\n\nRecent ngrok output:\n${tail}` : ''}${hint}`);
     }
+    failClosedOnTunnelExit('ngrok tunnel');
     const details = printConnectorBlock(`${publicBase}/mcp`, token, {
       localBase,
       copyUrl: args.noCopyUrl ? false : true,
@@ -3996,7 +4124,7 @@ async function main() {
       requireBashSession,
       connectionTest
     });
-    saveRuntimeConnection(root, details, runtimeOptions);
+    publishRuntimeConnection(details);
     await runControlPanel(details, cleanup);
     return;
   }
@@ -4026,6 +4154,7 @@ async function main() {
       ].join('\n');
       throw new Error(`${error instanceof Error ? error.message : String(error)}${tail ? `\n\nRecent tailscale output:\n${tail}` : ''}${hint}`);
     }
+    failClosedOnTunnelExit('Tailscale Funnel');
     const details = printConnectorBlock(`${publicBase}/mcp`, token, {
       localBase,
       copyUrl: args.noCopyUrl ? false : true,
@@ -4041,7 +4170,7 @@ async function main() {
       requireBashSession,
       connectionTest
     });
-    saveRuntimeConnection(root, details, runtimeOptions);
+    publishRuntimeConnection(details);
     await runControlPanel(details, cleanup);
     return;
   }
@@ -4066,12 +4195,13 @@ async function main() {
       requireBashSession,
       connectionTest
     });
-    saveRuntimeConnection(root, details, runtimeOptions);
+    publishRuntimeConnection(details);
     await runControlPanel(details, cleanup);
     return;
   }
 
   if (tunnel === 'cloudflare') {
+    cleanupStaleQuickTunnelCredentials();
     statusLine('wait', 'Opening Cloudflare quick tunnel');
     const proxyUrl = outboundProxyFromEnv(process.env);
     let publicBase = '';
@@ -4094,6 +4224,8 @@ async function main() {
       cloudflared = spawnLogged('cloudflared', cloudflaredPath, ['tunnel', '--url', localBase], { cwd: root, env: process.env, verbose: verboseLogs });
       publicBase = await waitForCloudflareUrl(cloudflared);
     }
+    await waitForPublicHealth(publicBase, token, cloudflared, 'Cloudflare quick tunnel');
+    failClosedOnTunnelExit('Cloudflare quick tunnel');
     const details = printConnectorBlock(`${publicBase}/mcp`, token, {
       localBase,
       copyUrl: args.noCopyUrl ? false : true,
@@ -4109,7 +4241,7 @@ async function main() {
       requireBashSession,
       connectionTest
     });
-    saveRuntimeConnection(root, details, runtimeOptions);
+    publishRuntimeConnection(details);
     await runControlPanel(details, cleanup);
     return;
   }
@@ -4163,6 +4295,7 @@ async function main() {
     ].join('\n');
     throw new Error(`${error instanceof Error ? error.message : String(error)}${tail ? `\n\nRecent cloudflared output:\n${tail}` : ''}${hint}`);
   }
+  failClosedOnTunnelExit('Cloudflare named tunnel');
   const details = printConnectorBlock(`${publicBase}/mcp`, token, {
     localBase,
     copyUrl: args.noCopyUrl ? false : true,
@@ -4178,7 +4311,7 @@ async function main() {
     requireBashSession,
     connectionTest
   });
-  saveRuntimeConnection(root, details, runtimeOptions);
+  publishRuntimeConnection(details);
   await runControlPanel(details, cleanup);
 }
 

--- a/scripts/lifecycle-smoke.mjs
+++ b/scripts/lifecycle-smoke.mjs
@@ -1,0 +1,110 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codexpro-lifecycle-'));
+
+function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitFor(predicate, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+function directChildPids(parentPid) {
+  const result = process.platform === 'win32'
+    ? spawnSync('powershell.exe', [
+        '-NoProfile',
+        '-Command',
+        `Get-CimInstance Win32_Process -Filter \"ParentProcessId = ${parentPid}\" | Select-Object -ExpandProperty ProcessId`
+      ], { encoding: 'utf8' })
+    : spawnSync('ps', ['-o', 'pid=', '--ppid', String(parentPid)], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`Could not inspect the launcher process tree: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+  return result.stdout.trim().split(/\s+/).filter(Boolean).map(Number);
+}
+
+function killPid(pid, tree = false) {
+  if (process.platform === 'win32') {
+    const args = ['/PID', String(pid)];
+    if (tree) args.push('/T');
+    args.push('/F');
+    return spawnSync('taskkill.exe', args, { encoding: 'utf8', stdio: tree ? 'ignore' : 'pipe' });
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+    return { status: 0, stdout: '', stderr: '' };
+  } catch (error) {
+    return { status: 1, stdout: '', stderr: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+let launcher;
+try {
+  const port = await availablePort();
+  launcher = spawn(process.execPath, [
+    'scripts/codexpro.mjs',
+    'start',
+    '--root', workspaceRoot,
+    '--tunnel', 'none',
+    '--port', String(port),
+    '--no-copy-url'
+  ], {
+    cwd: projectRoot,
+    env: { ...process.env, NO_COLOR: '1' },
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  let output = '';
+  launcher.stdout.on('data', (chunk) => { output += String(chunk); });
+  launcher.stderr.on('data', (chunk) => { output += String(chunk); });
+  await waitFor(() => output.includes('Local MCP ready'), 20_000, 'local MCP readiness');
+
+  const pids = directChildPids(launcher.pid);
+  if (pids.length !== 1) throw new Error(`Expected one local MCP child, found ${JSON.stringify(pids)}.`);
+  const killed = killPid(pids[0]);
+  if (killed.status !== 0) {
+    throw new Error(`Could not fault-inject the local MCP child: ${killed.stderr || killed.stdout || `exit ${killed.status}`}`);
+  }
+
+  const exit = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Launcher did not fail closed after local MCP child death.')), 10_000);
+    launcher.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+  if (exit.code !== 1) throw new Error(`Expected launcher exit 1, got ${JSON.stringify(exit)}.`);
+  if (!output.includes('local MCP server exited unexpectedly')) {
+    throw new Error(`Launcher omitted the failure diagnostic. Output:\n${output}`);
+  }
+
+  const portOpen = await new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port });
+    socket.once('connect', () => { socket.destroy(); resolve(true); });
+    socket.once('error', () => resolve(false));
+  });
+  if (portOpen) throw new Error(`Port ${port} remained open after launcher failure.`);
+  console.log('✓ lifecycle smoke passed');
+} finally {
+  if (launcher && launcher.exitCode === null && launcher.signalCode === null) killPid(launcher.pid, true);
+  fs.rmSync(workspaceRoot, { recursive: true, force: true });
+}

--- a/scripts/release-guard-smoke.mjs
+++ b/scripts/release-guard-smoke.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCli = process.env.npm_execpath ?? join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
 const manifest = JSON.parse(await (await import("node:fs/promises")).readFile(join(root, "package.json"), "utf8"));
 
 assert.equal(manifest.scripts.prepublishOnly, "node scripts/release-guard.mjs");
@@ -37,7 +38,9 @@ try {
   assert.notEqual(wrongDirectory.status, 0, wrongDirectory.output);
   assert.match(wrongDirectory.output, /Release commands must run from the CodexPro root/);
 
-  const prefixInvocation = run(npm, ["--prefix", root, "run", "release:guard", "--silent"], { cwd: wrongCwd });
+  const prefixInvocation = process.platform === "win32" && npmCli
+    ? run(process.execPath, [npmCli, "--prefix", root, "run", "release:guard", "--silent"], { cwd: wrongCwd })
+    : run(npm, ["--prefix", root, "run", "release:guard", "--silent"], { cwd: wrongCwd });
   assert.notEqual(prefixInvocation.status, 0, prefixInvocation.output);
   assert.match(prefixInvocation.output, /Release commands must run from the CodexPro root/);
 

--- a/scripts/release-pack.mjs
+++ b/scripts/release-pack.mjs
@@ -1,7 +1,10 @@
 import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
 import { CODEXPRO_PACKAGE, assertCodexProReleaseEnvironment } from "./release-guard.mjs";
 
-const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCli = process.env.npm_execpath ?? join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+const npmCommand = process.platform === "win32" ? process.execPath : "npm";
+const npmArgs = (args) => process.platform === "win32" ? [npmCli, ...args] : args;
 
 function fail(message) {
   throw new Error(message);
@@ -9,7 +12,7 @@ function fail(message) {
 
 try {
   const release = assertCodexProReleaseEnvironment();
-  const packed = spawnSync(npm, ["pack", "--dry-run", "--ignore-scripts", "--json"], {
+  const packed = spawnSync(npmCommand, npmArgs(["pack", "--dry-run", "--ignore-scripts", "--json"]), {
     cwd: release.root,
     encoding: "utf8",
     env: { ...process.env, INIT_CWD: release.root }

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -1,10 +1,13 @@
 import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
 import { assertCodexProReleaseEnvironment } from "./release-guard.mjs";
 
-const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCli = process.env.npm_execpath ?? join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+const npmCommand = process.platform === "win32" ? process.execPath : "npm";
+const npmArgs = (args) => process.platform === "win32" ? [npmCli, ...args] : args;
 
 function runNpm(args, root) {
-  const result = spawnSync(npm, args, {
+  const result = spawnSync(npmCommand, npmArgs(args), {
     cwd: root,
     stdio: "inherit",
     env: { ...process.env, INIT_CWD: root }

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 function run(args, env) {
   const result = spawnSync(process.execPath, ['scripts/codexpro.mjs', ...args], {
@@ -72,11 +73,25 @@ async function waitForJson(filePath, predicate, label) {
   throw new Error(`timed out waiting for ${label}: ${lastError?.message ?? 'predicate not met'}`);
 }
 
+async function waitForMissing(filePath, label) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(filePath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for ${label} to be removed`);
+}
+
 async function withStartedCodexPro(args, env, fn) {
   const child = spawn(process.execPath, ['scripts/codexpro.mjs', 'start', ...args], {
     cwd: path.resolve('.'),
     env,
-    stdio: ['ignore', 'pipe', 'pipe']
+    stdio: ['pipe', 'pipe', 'pipe']
   });
   let output = '';
   let closed = false;
@@ -91,7 +106,15 @@ async function withStartedCodexPro(args, env, fn) {
   } catch (error) {
     throw new Error(`${error.message}\nstart output:\n${output}`);
   } finally {
-    if (!closed) child.kill('SIGTERM');
+    if (!closed) {
+      child.stdin.write('q\n');
+      child.stdin.end();
+      const graceful = await Promise.race([
+        closedPromise.then(() => true),
+        new Promise((resolve) => setTimeout(() => resolve(false), 5_000))
+      ]);
+      if (!graceful) child.kill('SIGTERM');
+    }
     await closedPromise;
   }
 }
@@ -189,7 +212,20 @@ const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-r
 const staleRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-stale-'));
 const ngrokRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-ngrok-'));
 const home = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-home-'));
-const env = { ...process.env, CODEXPRO_HOME: home };
+const healthPreload = path.join(home, 'fake-public-health.mjs');
+await fs.writeFile(healthPreload, [
+  'const realFetch = globalThis.fetch;',
+  'globalThis.fetch = async (input, init) => {',
+  '  const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);',
+  '  if (url.hostname.endsWith(".trycloudflare.com") && url.pathname === "/healthz") {',
+  '    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });',
+  '  }',
+  '  return realFetch(input, init);',
+  '};',
+  ''
+].join('\n'));
+const nodeOptions = [process.env.NODE_OPTIONS, `--import=${pathToFileURL(healthPreload).href}`].filter(Boolean).join(' ');
+const env = { ...process.env, CODEXPRO_HOME: home, NODE_OPTIONS: nodeOptions };
 function withoutProxyEnv(input) {
   const next = { ...input };
   for (const key of ['HTTPS_PROXY', 'https_proxy', 'ALL_PROXY', 'all_proxy', 'HTTP_PROXY', 'http_proxy']) delete next[key];
@@ -438,12 +474,7 @@ await withStartedCodexPro([
     throw new Error(`runtime status did not persist toolCards: ${JSON.stringify(runtime)}`);
   }
 });
-try {
-  await fs.access(runtimePath);
-  throw new Error('runtime status was not cleared after launcher SIGTERM');
-} catch (error) {
-  if (error?.code !== 'ENOENT') throw error;
-}
+await waitForMissing(runtimePath, 'runtime status after launcher shutdown');
 
 const quitRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-quit-'));
 const quitPort = await getFreePort();
@@ -500,13 +531,13 @@ const proxyCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-se
 const proxyCloudflarePort = await getFreePort();
 const proxyCloudflarePath = await runtimeStatusPath(proxyCloudflareRoot, home);
 const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-fake-bin-'));
-const fakeCurl = path.join(fakeBin, 'curl');
+const fakeCurl = path.join(fakeBin, 'curl.mjs');
 const curlArgsPath = path.join(home, 'fake-curl-args.json');
 const cloudflaredArgsPath = path.join(home, 'fake-cloudflared-proxy-args.json');
 const fakeProxyCloudflared = path.join(home, 'fake-cloudflared-proxy.mjs');
 await fs.writeFile(fakeCurl, [
   '#!/usr/bin/env node',
-  "const fs = require('node:fs');",
+  "import fs from 'node:fs';",
   "fs.writeFileSync(process.env.CODEXPRO_FAKE_CURL_ARGS, JSON.stringify(process.argv.slice(2)));",
   "console.log(JSON.stringify({ success: true, result: { id: 'proxy-tunnel-id', hostname: 'proxy-codexpro.trycloudflare.com', account_tag: 'account-tag', secret: 'proxy-secret-1234567890' } }));",
   ''
@@ -539,6 +570,7 @@ await withStartedCodexPro([
   ...env,
   PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
   HTTPS_PROXY: 'http://proxy.example.test:8080',
+  CODEXPRO_CURL_BIN: fakeCurl,
   CODEXPRO_FAKE_CURL_ARGS: curlArgsPath,
   CODEXPRO_FAKE_CLOUDFLARED_ARGS: cloudflaredArgsPath
 }, async () => {
@@ -590,6 +622,7 @@ const proxyFailure = runFail([
   ...env,
   PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
   HTTPS_PROXY: 'http://proxy.example.test:8080',
+  CODEXPRO_CURL_BIN: fakeCurl,
   CODEXPRO_FAKE_CURL_ARGS: path.join(home, 'fake-curl-fail-args.json')
 }, /exited before startup completed/);
 if (!proxyFailure.includes('proxy tunnel startup failed')) {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -673,10 +673,21 @@ if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwd
 if (!pwdBash.structuredContent.stdout?.includes(tmp)) {
   throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
 }
+if (process.platform === 'win32' && pwdBash.structuredContent.backend !== 'native_windows_direct') {
+  throw new Error(`Windows selected an unexpected executor backend: ${JSON.stringify(pwdBash.structuredContent)}`);
+}
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'find . -fprint leaked.txt' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'git show HEAD:.env' }, /blocked/i);
 await expectToolError('bash', { workspace_id: ws, command: 'ls $HOME' }, /blocked/i);
+await expectToolError('bash', { workspace_id: ws, command: 'python -c "print(1)"' }, /allowlist/i);
+const quotedPathProbe = await client.request('tools/call', {
+  name: 'bash',
+  arguments: { workspace_id: ws, command: 'git rev-parse --sq-quote "C:\\folder with space\\file.txt"' }
+});
+if (quotedPathProbe.structuredContent.exitCode !== 0 || !quotedPathProbe.structuredContent.stdout?.includes('C:\\folder with space\\file.txt')) {
+  throw new Error(`quoted Windows-style path was not preserved: ${JSON.stringify(quotedPathProbe.structuredContent)}`);
+}
 const clientBuild = await client.request('tools/call', { name: 'bash', arguments: { workspace_id: ws, command: 'npm run build:clients', timeout_ms: 60000 } });
 if (!clientBuild.structuredContent.stdout?.includes('clients ok')) {
   throw new Error('safe bash did not run npm run build:clients');

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -102,12 +102,14 @@ async function expectToolError(client, name, args, pattern) {
   return result;
 }
 
+const COLON_FIXTURE = process.platform === 'win32' ? 'visible-123-file.txt' : 'visible:123:file.txt';
+
 async function makeFixture() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-'));
   await fs.writeFile(path.join(root, 'AGENTS.md'), '# Stress Agents\n\nKeep checks local.\n', 'utf8');
   await fs.writeFile(path.join(root, 'demo.txt'), 'alpha\n--flag root\narrow -> value\n', 'utf8');
   await fs.writeFile(path.join(root, '.hidden.txt'), 'needle hidden\n', 'utf8');
-  await fs.writeFile(path.join(root, 'visible:123:file.txt'), 'needle colon path\n', 'utf8');
+  await fs.writeFile(path.join(root, COLON_FIXTURE), 'needle colon path\n', 'utf8');
   await fs.mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
   await fs.writeFile(path.join(root, '.github', 'workflows', 'ci.yml'), 'name: ci\n', 'utf8');
   await fs.mkdir(path.join(root, 'many'), { recursive: true });
@@ -211,7 +213,7 @@ async function runFullModeStress(root) {
       name: 'search',
       arguments: { workspace_id: ws, query: 'needle colon path', max_results: 10 }
     });
-    assert(colonSearch.structuredContent.matches.some((match) => match.path === 'visible:123:file.txt' && match.line === 1), `colon path search parsed incorrectly: ${JSON.stringify(colonSearch.structuredContent.matches)}`);
+    assert(colonSearch.structuredContent.matches.some((match) => match.path === COLON_FIXTURE && match.line === 1), `search result path parsed incorrectly: ${JSON.stringify(colonSearch.structuredContent.matches)}`);
 
     const superRead = await client.request('tools/call', {
       name: 'codexpro',
@@ -456,7 +458,7 @@ async function runMcpInventoryStress() {
   await fs.writeFile(path.join(fakeHome, '.codex', 'config.toml'), toml, 'utf8');
   await fs.writeFile(path.join(fakeHome, '.cursor', 'mcp.json'), JSON.stringify({ mcpServers: cursorServers }), 'utf8');
 
-  const client = await initClient(root, { HOME: fakeHome });
+  const client = await initClient(root, { HOME: fakeHome, USERPROFILE: fakeHome });
   try {
     const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
     const inventory = await client.request('tools/call', {

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
@@ -15,134 +17,66 @@ export interface BashResult {
   stdout: string;
   stderr: string;
   truncated: boolean;
+  backend: string;
+  spawnError?: string;
   bashSessionId?: string;
 }
 
 const SAFE_ALLOWED_PREFIXES = [
-  "pwd",
-  "ls",
-  "find",
-  "git status",
-  "git diff",
-  "git log",
-  "git show",
-  "git branch",
-  "git rev-parse",
-  "git ls-files",
-  "npm test",
-  "npm run test",
-  "npm run typecheck",
-  "npm run lint",
-  "npm run build",
-  "npm run check",
-  "pnpm test",
-  "pnpm run test",
-  "pnpm run typecheck",
-  "pnpm run lint",
-  "pnpm run build",
-  "pnpm run check",
-  "yarn test",
-  "yarn run test",
-  "yarn run typecheck",
-  "yarn run lint",
-  "yarn run build",
-  "yarn run check",
-  "bun test",
-  "bun run test",
-  "bun run typecheck",
-  "bun run lint",
-  "bun run build",
-  "pytest",
-  "python -m pytest",
-  "python3 -m pytest",
-  "uv run pytest",
-  "go test",
-  "cargo test",
-  "cargo check",
-  "cargo clippy",
-  "tsc",
-  "npx tsc",
-  "eslint",
-  "npx eslint",
-  "biome check",
-  "npx biome check"
+  "pwd", "ls", "find", "git status", "git diff", "git log", "git show", "git branch", "git rev-parse", "git ls-files",
+  "npm test", "npm run test", "npm run typecheck", "npm run lint", "npm run build", "npm run check",
+  "pnpm test", "pnpm run test", "pnpm run typecheck", "pnpm run lint", "pnpm run build", "pnpm run check",
+  "yarn test", "yarn run test", "yarn run typecheck", "yarn run lint", "yarn run build", "yarn run check",
+  "bun test", "bun run test", "bun run typecheck", "bun run lint", "bun run build", "bun run check",
+  "pytest", "python -m pytest", "python3 -m pytest", "uv run pytest", "go test", "cargo test", "cargo check", "cargo clippy",
+  "tsc", "npx tsc", "eslint", "npx eslint", "biome check", "npx biome check"
 ];
 
 const SAFE_BLOCKED_PATTERNS = [
-  /(^|\s)rm\s+/,
-  /(^|\s)mv\s+/,
-  /(^|\s)cp\s+/,
-  /(^|\s)dd\s+/,
-  /(^|\s)sudo\s+/,
-  /(^|\s)chmod\s+/,
-  /(^|\s)chown\s+/,
-  /(^|\s)kill\s+/,
-  /(^|\s)pkill\s+/,
-  /(^|\s)curl\s+/,
-  /(^|\s)wget\s+/,
-  /(^|\s)ssh\s+/,
-  /(^|\s)scp\s+/,
-  /(^|\s)rsync\s+/,
-  /(^|\s)docker\s+/,
-  /(^|\s)podman\s+/,
-  /(^|\s)git\s+push\b/,
-  /(^|\s)git\s+reset\b/,
-  /(^|\s)git\s+clean\b/,
-  /(^|\s)git\s+checkout\b/,
-  /(^|\s)git\s+switch\b/,
-  /(^|\s)git\s+restore\b/,
-  /(^|\s)(npm|pnpm|yarn)\s+publish\b/,
-  /(^|\s)--no-index\b/,
-  /(^|\s)--fix\b/,
-  /(^|\s)(\/|~(?:\/|\s|$))/,
-  /(^|\s)\.\.(?:\/|\s|$)/,
-  /\$/,
-  /(^|[\s:])(?:\.env(?:[./\s:]|$)|\.git(?:[\/\s:]|$)|node_modules(?:[\/\s:]|$)|\.ssh(?:[\/\s:]|$)|id_rsa(?:[.\s:]|$)|id_ed25519(?:[.\s:]|$)|[^\s:]*\.(?:pem|key)(?:[\s:]|$))/,
-  /(^|\s)['"]?-exec(?:['"]|\s|$)/,
-  /(^|\s)['"]?-execdir(?:['"]|\s|$)/,
-  /(^|\s)['"]?-delete(?:['"]|\s|$)/,
-  /(^|\s)['"]?-ok(?:['"]|\s|$)/,
-  /(^|\s)['"]?-okdir(?:['"]|\s|$)/,
-  /(^|\s)['"]?-fprint0?(?:['"]|\s|$)/,
-  /(^|\s)['"]?-fprintf(?:['"]|\s|$)/,
-  /(^|\s)['"]?-fls(?:['"]|\s|$)/,
-  /(^|\s)['"]?--output(?:=|['"]|\s|$)/,
-  /(^|\s)(sed|perl)\s+.*(^|\s)-i(\s|$)/,
-  /(^|\s)(cat|grep|rg|head|tail|wc)\s+/,
-  /[;&|<>`]/,
-  /[\r\n]/
+  /(^|\s)rm\s+/, /(^|\s)mv\s+/, /(^|\s)cp\s+/, /(^|\s)dd\s+/, /(^|\s)sudo\s+/, /(^|\s)chmod\s+/, /(^|\s)chown\s+/,
+  /(^|\s)kill\s+/, /(^|\s)pkill\s+/, /(^|\s)curl\s+/, /(^|\s)wget\s+/, /(^|\s)ssh\s+/, /(^|\s)scp\s+/, /(^|\s)rsync\s+/,
+  /(^|\s)docker\s+/, /(^|\s)podman\s+/, /(^|\s)git\s+push\b/, /(^|\s)git\s+reset\b/, /(^|\s)git\s+clean\b/,
+  /(^|\s)git\s+checkout\b/, /(^|\s)git\s+switch\b/, /(^|\s)git\s+restore\b/, /(^|\s)(npm|pnpm|yarn)\s+publish\b/,
+  /(^|\s)--no-index\b/, /(^|\s)--fix\b/, /(^|\s)(\/|~(?:\/|\s|$))/, /(^|\s)\.\.(?:\/|\s|$)/, /\$/,
+  /(^|[\s:])(?:\.env(?:[./\s:]|$)|\.git(?:[\/\s:]|$)|node_modules(?:[\/\s:]|$)|\.ssh(?:[\/\s:]|$)|id_rsa(?:[.\s:]|$)|id_ed25519(?:[.\s:]|$)|[^\s:]*(?:\.pem|\.key)(?:[\s:]|$))/,
+  /(^|\s)['"]?-exec(?:['"]|\s|$)/, /(^|\s)['"]?-execdir(?:['"]|\s|$)/, /(^|\s)['"]?-delete(?:['"]|\s|$)/,
+  /(^|\s)['"]?-ok(?:['"]|\s|$)/, /(^|\s)['"]?-okdir(?:['"]|\s|$)/, /(^|\s)['"]?-fprint0?(?:['"]|\s|$)/,
+  /(^|\s)['"]?-fprintf(?:['"]|\s|$)/, /(^|\s)['"]?-fls(?:['"]|\s|$)/, /(^|\s)['"]?--output(?:=|['"]|\s|$)/,
+  /(^|\s)(sed|perl)\s+.*(^|\s)-i(\s|$)/, /(^|\s)(cat|grep|rg|head|tail|wc)\s+/, /[\r\n]/
 ];
 
-function compact(command: string): string {
-  return command.trim().replace(/\s+/g, " ");
-}
-
+function compact(command: string): string { return command.trim().replace(/\s+/g, " "); }
 function startsWithAllowedPrefix(command: string): boolean {
   const normalized = compact(command);
   return isAllowedPackageScript(normalized) || SAFE_ALLOWED_PREFIXES.some((prefix) => normalized === prefix || normalized.startsWith(`${prefix} `));
 }
-
 function isAllowedPackageScript(command: string): boolean {
-  const packageScriptPattern =
-    /^(?:npm|pnpm|yarn|bun)\s+run\s+(?:test|typecheck|lint|build|check)(?::[A-Za-z0-9._-]+)*(?:\s+--\s+[A-Za-z0-9._:= -]+)?$/;
-  return packageScriptPattern.test(command);
+  return /^(?:npm|pnpm|yarn|bun)\s+(?:test|run\s+(?:test|typecheck|lint|build|check)(?::[A-Za-z0-9._-]+)*)(?:\s+--\s+[A-Za-z0-9._:= -]+)?$/.test(command);
 }
-
+function hasUnquotedShellOperator(command: string): boolean {
+  let quote: "'" | '"' | undefined;
+  let escaping = false;
+  for (const char of command) {
+    if (escaping) { escaping = false; continue; }
+    if (char === "\\" && quote !== "'") { escaping = true; continue; }
+    if (quote) { if (char === quote) quote = undefined; continue; }
+    if (char === "'" || char === '"') { quote = char; continue; }
+    if (";&|<>`".includes(char)) return true;
+  }
+  return false;
+}
 function assertSafeCommand(config: CodexProConfig, command: string): void {
   if (config.bashMode === "off") {
     throw new CodexProError("bash tool is disabled. Start with CODEXPRO_BASH_MODE=safe or CODEXPRO_BASH_MODE=full to enable it.");
   }
   if (config.bashMode === "full") return;
-
   const raw = command.trim();
   const normalized = compact(command);
-  for (const pattern of SAFE_BLOCKED_PATTERNS) {
-    if (pattern.test(raw) || pattern.test(normalized)) {
-      throw new CodexProError(
-        `Command is blocked in CODEXPRO_BASH_MODE=safe: ${normalized}\n` +
-          "Use separate read/search/git tools, or restart with CODEXPRO_BASH_MODE=full only for trusted repos."
-      );
-    }
+  if (hasUnquotedShellOperator(raw)) {
+    throw new CodexProError(`Command is blocked in CODEXPRO_BASH_MODE=safe: ${normalized}`);
+  }
+  for (const pattern of SAFE_BLOCKED_PATTERNS) if (pattern.test(raw) || pattern.test(normalized)) {
+    throw new CodexProError(`Command is blocked in CODEXPRO_BASH_MODE=safe: ${normalized}`);
   }
   if (!startsWithAllowedPrefix(normalized)) {
     throw new CodexProError(
@@ -152,103 +86,216 @@ function assertSafeCommand(config: CodexProConfig, command: string): void {
     );
   }
 }
-
 function assertBashSession(config: CodexProConfig, sessionId?: string): string | undefined {
   const requested = sessionId?.trim();
   if (!config.bashSessionId) {
-    if (config.requireBashSession) {
-      throw new CodexProError("bash session guard is enabled but no server bash session id is configured.");
-    }
+    if (config.requireBashSession) throw new CodexProError("bash session guard is enabled but no server bash session id is configured.");
     return undefined;
   }
-  if (!requested) {
-    if (config.requireBashSession) {
-      throw new CodexProError(`bash session id is required. Retry with session_id="${config.bashSessionId}".`);
-    }
-    return config.bashSessionId;
-  }
-  if (requested !== config.bashSessionId) {
-    throw new CodexProError(`bash session id mismatch. This CodexPro server accepts session_id="${config.bashSessionId}".`);
-  }
+  if (!requested && config.requireBashSession) throw new CodexProError(`bash session id is required. Retry with session_id="${config.bashSessionId}".`);
+  if (requested && requested !== config.bashSessionId) throw new CodexProError(`bash session id mismatch. This CodexPro server accepts session_id="${config.bashSessionId}".`);
   return config.bashSessionId;
 }
 
+export function executionBackend(): string { return process.platform === "win32" ? "native_windows_direct" : "unix_bash"; }
 function makeEnv(config: CodexProConfig): NodeJS.ProcessEnv {
-  if (config.inheritEnv) {
-    return { ...process.env, NO_COLOR: "1", CI: process.env.CI ?? "1" };
+  if (config.inheritEnv) return { ...process.env, NO_COLOR: "1", CI: process.env.CI ?? "1" };
+  if (process.platform === "win32") {
+    const root = process.env.SystemRoot ?? "C:\\Windows";
+    return {
+      PATH: process.env.PATH ?? `${root}\\System32;${root}`,
+      PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+      SystemRoot: root, WINDIR: process.env.WINDIR ?? root,
+      ComSpec: process.env.ComSpec ?? `${root}\\System32\\cmd.exe`,
+      TEMP: process.env.TEMP ?? os.tmpdir(), TMP: process.env.TMP ?? os.tmpdir(),
+      USERPROFILE: process.env.USERPROFILE ?? os.homedir(), HOME: process.env.USERPROFILE ?? os.homedir(), PYTHONUTF8: "1",
+      TERM: "dumb", NO_COLOR: "1", CI: "1"
+    };
   }
-  return {
-    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-    HOME: process.env.HOME ?? "",
-    USER: process.env.USER ?? "",
-    SHELL: process.env.SHELL ?? "/bin/bash",
-    TMPDIR: process.env.TMPDIR ?? "/tmp",
-    TERM: "dumb",
-    NO_COLOR: "1",
-    CI: "1"
-  };
+  return { PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin", HOME: process.env.HOME ?? "", USER: process.env.USER ?? "", SHELL: process.env.SHELL ?? "/bin/bash", TMPDIR: process.env.TMPDIR ?? "/tmp", TERM: "dumb", NO_COLOR: "1", CI: "1" };
+}
+function parseCommand(command: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  const input = command.trim();
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    if (quote === "'") {
+      if (char === quote) quote = undefined;
+      else current += char;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === quote) {
+        quote = undefined;
+      } else if (char === "\\" && (input[index + 1] === '"' || input[index + 1] === "\\")) {
+        current += input[index + 1];
+        index += 1;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+    } else if (/\s/.test(char)) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (quote) throw new CodexProError("Command contains an unterminated quote.");
+  if (current) args.push(current);
+  if (!args.length) throw new CodexProError("command is required.");
+  return args;
 }
 
-function bashExecutable(): string {
-  return fs.existsSync("/bin/bash") ? "/bin/bash" : "bash";
+function windowsShellCommandAllowed(command: string): boolean {
+  const normalized = compact(command);
+  if (isAllowedPackageScript(normalized)) return true;
+  return /^(?:npx\s+(?:tsc|eslint|biome\s+check))(?:\s+[A-Za-z0-9._:=\\/ -]+)*$/.test(normalized);
 }
-
+function resolveExecutable(command: string, env: NodeJS.ProcessEnv): string {
+  if (path.isAbsolute(command) || command.includes(path.sep) || (process.platform === "win32" && command.includes("/"))) {
+    if (fs.existsSync(command)) return command;
+    throw new CodexProError(`process_spawn_failed: executable not found: ${path.basename(command)}`);
+  }
+  const extensions = process.platform === "win32" ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";") : [""];
+  for (const entry of (env.PATH ?? "").split(path.delimiter).filter(Boolean)) for (const extension of extensions) {
+    const candidate = path.join(entry, process.platform === "win32" && !path.extname(command) ? `${command}${extension.toLowerCase()}` : command);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new CodexProError(`process_spawn_failed: executable not found: ${command}`);
+}
+function terminateProcessTree(child: ReturnType<typeof spawn>): void {
+  if (!child.pid) return;
+  if (process.platform === "win32") { const killer = spawn("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], { windowsHide: true, stdio: "ignore" }); killer.unref(); }
+  else { try { process.kill(-child.pid, "SIGTERM"); } catch { child.kill("SIGTERM"); } setTimeout(() => { try { process.kill(-child.pid!, "SIGKILL"); } catch {} }, 1_500).unref(); }
+}
 function trimOutput(value: string, maxBytes: number): { value: string; truncated: boolean } {
-  const buffer = Buffer.from(value, "utf8");
-  if (buffer.byteLength <= maxBytes) return { value, truncated: false };
-  const sliced = buffer.subarray(0, maxBytes).toString("utf8");
-  return { value: `${sliced}\n...[output truncated to ${maxBytes} bytes]`, truncated: true };
+  const buffer = Buffer.from(value, "utf8"); if (buffer.byteLength <= maxBytes) return { value, truncated: false };
+  return { value: `${buffer.subarray(0, maxBytes).toString("utf8")}\n...[output truncated to ${maxBytes} bytes]`, truncated: true };
 }
 
-export async function runBash(
-  config: CodexProConfig,
-  guard: PathGuard,
-  workspace: Workspace,
-  command: string,
-  options: { cwd?: string; timeoutMs?: number; sessionId?: string } = {}
-): Promise<BashResult> {
+export async function runBash(config: CodexProConfig, guard: PathGuard, workspace: Workspace, command: string, options: { cwd?: string; timeoutMs?: number; sessionId?: string } = {}): Promise<BashResult> {
   if (!command?.trim()) throw new CodexProError("command is required.");
   const bashSessionId = assertBashSession(config, options.sessionId);
   assertSafeCommand(config, command);
-  const cwdResolved = guard.resolve(workspace, options.cwd ?? ".");
-  const cwd = cwdResolved.absPath;
+  const cwd = guard.resolve(workspace, options.cwd ?? ".").absPath;
   const timeoutMs = Math.max(1_000, Math.min(options.timeoutMs ?? 30_000, 180_000));
   const start = Date.now();
+  const backend = executionBackend();
+  const env = makeEnv(config);
 
-  return new Promise((resolve, reject) => {
-    const child = spawn(bashExecutable(), ["-lc", command], {
+  if (process.platform === "win32" && compact(command).toLowerCase() === "pwd") {
+    return {
+      command,
+      cwd: path.relative(workspace.root, cwd) || ".",
+      exitCode: 0,
+      signal: null,
+      durationMs: Date.now() - start,
+      stdout: `${cwd}\n`,
+      stderr: "",
+      truncated: false,
+      backend,
+      ...(bashSessionId ? { bashSessionId } : {})
+    };
+  }
+
+  let executable: string;
+  let childArgs: string[];
+  let shell: string | false = false;
+  if (process.platform === "win32" && config.bashMode === "full") {
+    executable = command;
+    childArgs = [];
+    shell = env.ComSpec ?? "cmd.exe";
+  } else if (process.platform === "win32") {
+    const argv = parseCommand(command);
+    const resolvedExecutable = resolveExecutable(argv[0], env);
+    if (/\.(?:cmd|bat)$/i.test(resolvedExecutable)) {
+      if (!windowsShellCommandAllowed(command)) {
+        throw new CodexProError(
+          "Windows command shims are allowed in safe mode only for validated package-manager verification commands."
+        );
+      }
+      executable = command;
+      childArgs = [];
+      shell = env.ComSpec ?? "cmd.exe";
+    } else {
+      executable = resolvedExecutable;
+      childArgs = argv.slice(1);
+    }
+  } else {
+    executable = fs.existsSync("/bin/bash") ? "/bin/bash" : "bash";
+    childArgs = ["-lc", command];
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(executable, childArgs, {
       cwd,
-      env: makeEnv(config),
+      env,
+      shell,
+      windowsHide: true,
+      detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"]
     });
-
     let stdout = "";
     let stderr = "";
     let killedByTimeout = false;
-
+    let outputLimitReached = false;
+    let settled = false;
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     const timer = setTimeout(() => {
       killedByTimeout = true;
-      child.kill("SIGTERM");
-      setTimeout(() => {
-        if (!child.killed) child.kill("SIGKILL");
-      }, 1_500).unref();
+      terminateProcessTree(child);
     }, timeoutMs);
     timer.unref();
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-      if (Buffer.byteLength(stdout, "utf8") > config.maxOutputBytes * 2) child.kill("SIGTERM");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-      if (Buffer.byteLength(stderr, "utf8") > config.maxOutputBytes * 2) child.kill("SIGTERM");
-    });
-    child.on("error", reject);
-    child.on("close", (exitCode, signal) => {
-      clearTimeout(timer);
-      if (killedByTimeout) {
-        stderr += `\n[codexpro] Command timed out after ${timeoutMs} ms.`;
+    child.stdout!.on("data", (chunk) => {
+      stdout += stdoutDecoder.write(chunk);
+      if (Buffer.byteLength(stdout, "utf8") > config.maxOutputBytes * 2 && !outputLimitReached) {
+        outputLimitReached = true;
+        terminateProcessTree(child);
       }
+    });
+    child.stderr!.on("data", (chunk) => {
+      stderr += stderrDecoder.write(chunk);
+      if (Buffer.byteLength(stderr, "utf8") > config.maxOutputBytes * 2 && !outputLimitReached) {
+        outputLimitReached = true;
+        terminateProcessTree(child);
+      }
+    });
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const message = error instanceof Error ? error.message : String(error);
+      resolve({
+        command,
+        cwd: path.relative(workspace.root, cwd) || ".",
+        exitCode: null,
+        signal: null,
+        durationMs: Date.now() - start,
+        stdout: redactSensitiveText(stdout),
+        stderr: redactSensitiveText(`${stderr}\n[codexpro] process_spawn_failed: ${message}`),
+        truncated: false,
+        backend,
+        spawnError: message,
+        ...(bashSessionId ? { bashSessionId } : {})
+      });
+    });
+    child.once("close", (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
+      if (killedByTimeout) stderr += `\n[codexpro] Command timed out after ${timeoutMs} ms.`;
+      if (outputLimitReached) stderr += "\n[codexpro] Output limit reached; process tree terminated.";
       const out = trimOutput(redactSensitiveText(stdout), config.maxOutputBytes);
       const err = trimOutput(redactSensitiveText(stderr), config.maxOutputBytes);
       resolve({
@@ -260,6 +307,7 @@ export async function runBash(
         stdout: out.value,
         stderr: err.value,
         truncated: out.truncated || err.truncated,
+        backend,
         ...(bashSessionId ? { bashSessionId } : {})
       });
     });

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import { timingSafeEqual } from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
 import express, { type NextFunction, type Request, type Response } from "express";
 import cors from "cors";
@@ -14,6 +15,7 @@ import {
   readWorkspaceProfile,
   sanitizeWorkspaceProfile,
   saveWorkspaceProfile,
+  runtimeStatusPathForRoot,
   type ConnectorMode,
   type TunnelMode,
   type WorkspaceProfile
@@ -1440,6 +1442,42 @@ async function main(): Promise<void> {
   }
 
   const config = loadConfig();
+  const supervisorPid = Number(process.env.CODEXPRO_SUPERVISOR_PID ?? 0);
+  if (Number.isInteger(supervisorPid) && supervisorPid > 0 && supervisorPid !== process.pid) {
+    const runtimePath = runtimeStatusPathForRoot(config.defaultRoot);
+    const shutdownOrphan = () => {
+      try {
+        const runtime = JSON.parse(fs.readFileSync(runtimePath, "utf8")) as { pid?: unknown };
+        if (runtime?.pid === supervisorPid) fs.rmSync(runtimePath, { force: true });
+      } catch {
+        // The runtime lease is absent, unreadable, or already owned by a newer launcher.
+      }
+      console.error(`[CodexPro] launcher process ${supervisorPid} is no longer running; shutting down orphaned HTTP MCP server.`);
+      clearInterval(supervisorTimer);
+      process.exit(1);
+    };
+    const supervisorTimer = setInterval(() => {
+      let processAlive = true;
+      try {
+        process.kill(supervisorPid, 0);
+      } catch {
+        processAlive = false;
+      }
+      let leaseExpired = false;
+      try {
+        const runtime = JSON.parse(fs.readFileSync(runtimePath, "utf8")) as { pid?: unknown };
+        if (runtime?.pid !== supervisorPid) {
+          leaseExpired = true;
+        } else {
+          leaseExpired = Date.now() - fs.statSync(runtimePath).mtimeMs > 5_000;
+        }
+      } catch {
+        // The launcher publishes the runtime lease only after its endpoint is ready.
+      }
+      if (!processAlive || leaseExpired) shutdownOrphan();
+    }, 250);
+    supervisorTimer.unref();
+  }
   if (config.requireHttpToken && !config.authToken) {
     throw new Error(
       "CODEXPRO_HTTP_TOKEN is required for this HTTP binding. " +

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -39,6 +39,7 @@ export interface WorkspaceProfile {
 export interface RuntimeConnection {
   version?: number;
   root?: string;
+  pid?: number;
   updatedAt?: string;
   endpoint?: string;
   localBase?: string;
@@ -136,5 +137,20 @@ export function readRuntimeConnection(root: string): RuntimeConnection {
   if (!runtime || typeof runtime !== "object" || Array.isArray(runtime)) return {};
   const typed = runtime as RuntimeConnection;
   if (typed.root && typed.root !== root) return {};
+  if (!Number.isInteger(typed.pid) || typed.pid! <= 0) {
+    fs.rmSync(runtimePath, { force: true });
+    return {};
+  }
+  const leaseExpired = Date.now() - fs.statSync(runtimePath).mtimeMs > 5_000;
+  try {
+    process.kill(typed.pid!, 0);
+  } catch {
+    fs.rmSync(runtimePath, { force: true });
+    return {};
+  }
+  if (leaseExpired) {
+    fs.rmSync(runtimePath, { force: true });
+    return {};
+  }
   return typed;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import type { CodexProConfig } from "./config.js";
 import { WorkspaceManager, PathGuard, CodexProError, type Workspace } from "./guard.js";
 import { repoTree, readTextFile, writeTextFile, editTextFile, ensureAiBridge } from "./fsOps.js";
 import { searchWorkspace } from "./searchOps.js";
-import { runBash } from "./bashOps.js";
+import { executionBackend, runBash } from "./bashOps.js";
 import { gitDiff, gitDiffStatus, gitLog, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./workspaceOps.js";
 import { buildProContext, exportProContext } from "./proContext.js";
@@ -1058,6 +1058,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         connectionTest: config.connectionTest,
         analysisEnabled: config.analysisEnabled,
         analysisLimits: config.analysisLimits,
+        executionBackend: executionBackend(),
         inheritEnv: config.inheritEnv,
         contextDir: config.contextDir,
         maxReadBytes: config.maxReadBytes,
@@ -1220,17 +1221,14 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
             check("bash policy", "warn", "bash disabled");
           } else {
             const bashProbeOptions = { timeoutMs: 10_000, sessionId: config.bashSessionId };
-            const pwd = await runBash(config, guard, workspace, "pwd", bashProbeOptions);
-            if (config.bashMode === "safe") {
-              try {
-                await runBash(config, guard, workspace, "ls $HOME", bashProbeOptions);
-                check("bash policy", "fail", "safe bash allowed environment expansion unexpectedly");
-              } catch {
-                check("bash policy", pwd.exitCode === 0 ? "pass" : "warn", "safe bash allowed pwd and blocked environment expansion");
-              }
-            } else {
-              check("bash policy", pwd.exitCode === 0 ? "warn" : "fail", "full bash is enabled; use only for trusted local repos");
-            }
+            const probe = await runBash(config, guard, workspace, "pwd", bashProbeOptions);
+            const expectedCwd = path.resolve(workspace.root);
+            const actualCwd = probe.stdout.split(/\r?\n/).map((line) => line.trim()).find((line) => path.isAbsolute(line));
+            const cwdOk = actualCwd ? path.resolve(actualCwd) === expectedCwd : false;
+            const executionOk = probe.exitCode === 0 && !probe.spawnError && cwdOk;
+            check("bash execution backend", executionOk ? "pass" : "fail", `${probe.backend}; exit=${probe.exitCode}; cwd=${cwdOk ? "honored" : "not honored"}${probe.spawnError ? "; process spawn failed" : ""}`);
+            if (config.bashMode === "safe") check("bash policy", executionOk ? "pass" : "fail", "safe policy and production executor probe completed");
+            else check("bash policy", executionOk ? "warn" : "fail", "full bash is enabled; use only for trusted local repos");
           }
         } catch (error) {
           check("bash policy", "fail", errorText(error));


### PR DESCRIPTION
## Summary

- make CodexPro command execution native and reliable on Windows
- fail closed when the local MCP server or public tunnel exits
- add runtime leases, stale-state cleanup, public health verification, and credential cleanup
- repair Windows release, handoff, settings, and stress paths
- add lifecycle fault-injection coverage

## Root cause

The Windows integration mixed Unix shell assumptions, direct `.cmd` spawning, unstable quick-tunnel state, and one-way process supervision. That produced path corruption, deprecated shell behavior, orphaned processes, stale success state, and broken release commands.

## Validation

Completed before publication:

- `NODE_OPTIONS=--throw-deprecation npm run release:check`
- all 11 smoke lanes passed
- lifecycle fault injection passed
- stress suite passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- release package dry-run passed for `codexpro-0.29.0.tgz`
- `git diff --cached --check` passed before commit

CI is intentionally skipped for this publication at the request of the operator; the commit includes `[skip ci]`.