### PR TITLE
Fix Codex session tail pagination

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -104,6 +104,21 @@ await fs.writeFile(path.join(codexSessionDir, `rollout-2026-06-18T01-02-03-${lar
   JSON.stringify({ timestamp: '2026-06-18T01:02:05Z', type: 'response_item', payload: { type: 'function_call_output', output: 'x'.repeat(140000) } }),
   JSON.stringify({ timestamp: '2026-06-18T01:02:06Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: 'Large tail summary' } })
 ].join('\n') + '\n', 'utf8');
+const oversizedCodexSessionId = '019cc365-cccc-7555-8666-123456789aaa';
+const oversizedCodexSessionPath = path.join(codexSessionDir, `rollout-2026-06-16T01-02-03-${oversizedCodexSessionId}.jsonl`);
+await fs.writeFile(oversizedCodexSessionPath, [
+  JSON.stringify({ timestamp: '2026-06-16T01:02:03Z', type: 'session_meta', payload: { id: oversizedCodexSessionId, cwd: tmp } }),
+  JSON.stringify({ timestamp: '2026-06-16T01:02:04Z', type: 'response_item', payload: { type: 'message', role: 'user', content: 'Oversized session first request' } }),
+  JSON.stringify({ timestamp: '2026-06-16T01:02:05Z', type: 'response_item', payload: { type: 'function_call_output', output: 'x'.repeat(20_100_000) } }),
+  JSON.stringify({ timestamp: '2026-06-16T01:02:06Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: 'Oversized session tail answer' } }),
+  JSON.stringify({ timestamp: '2026-06-16T01:02:07Z', type: 'response_item', payload: { type: 'message', role: 'user', content: 'Oversized session latest request' } })
+].join('\n') + '\n', 'utf8');
+const oversizedSourceBeforeRead = await fs.stat(oversizedCodexSessionPath);
+const byteBoundaryCodexSessionId = '019cc364-dddd-7666-8777-123456789aaa';
+await fs.writeFile(path.join(codexSessionDir, `rollout-2026-06-15T01-02-03-${byteBoundaryCodexSessionId}.jsonl`), [
+  JSON.stringify({ timestamp: '2026-06-15T01:02:03Z', type: 'session_meta', payload: { id: byteBoundaryCodexSessionId, cwd: tmp } }),
+  JSON.stringify({ timestamp: '2026-06-15T01:02:04Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: `${'a'.repeat(3999)}😀` } })
+].join('\n') + '\n', 'utf8');
 const unreadableCodexSessionPath = path.join(codexSessionDir, 'rollout-2026-06-17T01-02-03-019cc366-bbbb-7444-8555-123456789aaa.jsonl');
 await fs.writeFile(unreadableCodexSessionPath, [
   JSON.stringify({ timestamp: '2026-06-17T01:02:03Z', type: 'session_meta', payload: { id: '019cc366-bbbb-7444-8555-123456789aaa', cwd: tmp } })
@@ -1095,6 +1110,166 @@ const sourcePathTranscript = await codexSessionsClient.request('tools/call', {
 });
 if (!sourcePathTranscript.content?.[0]?.text?.includes('Fix the smoke session browser')) {
   throw new Error(`read_codex_session rejected source_path returned by codex_sessions: ${sourcePathTranscript.content?.[0]?.text}`);
+}
+const oversizedTailPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: { session_id: oversizedCodexSessionId, max_messages: 2 }
+});
+if (
+  oversizedTailPage.structuredContent.direction !== 'tail' ||
+  !oversizedTailPage.content?.[0]?.text?.includes('Oversized session tail answer') ||
+  !oversizedTailPage.content?.[0]?.text?.includes('Oversized session latest request') ||
+  !oversizedTailPage.structuredContent.has_more ||
+  !Number.isInteger(oversizedTailPage.structuredContent.next_cursor) ||
+  oversizedTailPage.structuredContent.resume_cursor !== oversizedTailPage.structuredContent.next_cursor ||
+  oversizedTailPage.structuredContent.source_size_bytes <= 20_000_000
+) {
+  throw new Error(`read_codex_session did not tail-page an oversized session: ${JSON.stringify(oversizedTailPage.structuredContent)}`);
+}
+const boundedToolOutputPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    cursor: oversizedTailPage.structuredContent.next_cursor,
+    max_messages: 1,
+    max_tool_output_bytes: 128
+  }
+});
+const boundedToolOutput = boundedToolOutputPage.structuredContent.messages?.[0]?.content ?? '';
+if (
+  boundedToolOutputPage.structuredContent.messages?.[0]?.role !== 'tool' ||
+  Buffer.byteLength(boundedToolOutput, 'utf8') > 128 ||
+  !boundedToolOutput.includes('[Tool output truncated]')
+) {
+  throw new Error(`read_codex_session did not bound a large tool output: ${JSON.stringify(boundedToolOutputPage.structuredContent)}`);
+}
+const tinyToolOutputPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    cursor: oversizedTailPage.structuredContent.next_cursor,
+    max_messages: 1,
+    max_tool_output_bytes: 1
+  }
+});
+const tinyToolOutput = tinyToolOutputPage.structuredContent.messages?.[0]?.content ?? '';
+if (
+  tinyToolOutputPage.structuredContent.messages?.[0]?.role !== 'tool' ||
+  Buffer.byteLength(tinyToolOutput, 'utf8') > 1
+) {
+  throw new Error(`read_codex_session exceeded a tiny tool-output cap: ${JSON.stringify(tinyToolOutputPage.structuredContent)}`);
+}
+const zeroToolOutputPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    cursor: oversizedTailPage.structuredContent.next_cursor,
+    max_messages: 1,
+    max_tool_output_bytes: 0
+  }
+});
+if (!zeroToolOutputPage.content?.[0]?.text?.includes('Oversized session first request')) {
+  throw new Error(`read_codex_session did not omit zero-byte tool output: ${zeroToolOutputPage.content?.[0]?.text}`);
+}
+const excludedToolOutputPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    cursor: oversizedTailPage.structuredContent.next_cursor,
+    max_messages: 1,
+    exclude_tool_outputs: true
+  }
+});
+if (!excludedToolOutputPage.content?.[0]?.text?.includes('Oversized session first request')) {
+  throw new Error(`read_codex_session did not skip tool outputs: ${excludedToolOutputPage.content?.[0]?.text}`);
+}
+const oversizedHeadPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: { session_id: oversizedCodexSessionId, direction: 'head', max_messages: 1 }
+});
+if (
+  oversizedHeadPage.structuredContent.direction !== 'head' ||
+  !oversizedHeadPage.content?.[0]?.text?.includes('Oversized session first request') ||
+  !Number.isInteger(oversizedHeadPage.structuredContent.next_cursor)
+) {
+  throw new Error(`read_codex_session did not head-page an oversized session: ${JSON.stringify(oversizedHeadPage.structuredContent)}`);
+}
+const oversizedHeadSecondPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    direction: 'head',
+    cursor: oversizedHeadPage.structuredContent.next_cursor,
+    max_messages: 1,
+    exclude_tool_outputs: true
+  }
+});
+const oversizedHeadThirdPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    direction: 'head',
+    cursor: oversizedHeadSecondPage.structuredContent.next_cursor,
+    max_messages: 1,
+    exclude_tool_outputs: true
+  }
+});
+const headPageContents = [
+  oversizedHeadPage.structuredContent.messages?.[0]?.content,
+  oversizedHeadSecondPage.structuredContent.messages?.[0]?.content,
+  oversizedHeadThirdPage.structuredContent.messages?.[0]?.content
+];
+if (
+  JSON.stringify(headPageContents) !== JSON.stringify([
+    'Oversized session first request',
+    'Oversized session tail answer',
+    'Oversized session latest request'
+  ]) ||
+  oversizedHeadThirdPage.structuredContent.has_more ||
+  !Number.isInteger(oversizedHeadThirdPage.structuredContent.resume_cursor)
+) {
+  throw new Error(`read_codex_session head pagination skipped or duplicated messages: ${JSON.stringify(headPageContents)}`);
+}
+await expectToolError(
+  'read_codex_session',
+  {
+    session_id: oversizedCodexSessionId,
+    cursor: oversizedTailPage.structuredContent.source_size_bytes + 1
+  },
+  /cursor is beyond the current Codex session file/i,
+  codexSessionsClient
+);
+const oversizedSourceAfterRead = await fs.stat(oversizedCodexSessionPath);
+if (
+  oversizedSourceAfterRead.size !== oversizedSourceBeforeRead.size ||
+  oversizedSourceAfterRead.mtimeMs !== oversizedSourceBeforeRead.mtimeMs
+) {
+  throw new Error('read_codex_session modified the source JSONL');
+}
+await fs.appendFile(oversizedCodexSessionPath, JSON.stringify({
+  timestamp: '2026-06-16T01:02:08Z',
+  type: 'response_item',
+  payload: { type: 'message', role: 'assistant', content: 'Oversized session appended answer' }
+}) + '\n', 'utf8');
+const appendedHeadPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: {
+    session_id: oversizedCodexSessionId,
+    direction: 'head',
+    cursor: oversizedHeadThirdPage.structuredContent.resume_cursor,
+    max_messages: 1
+  }
+});
+if (!appendedHeadPage.content?.[0]?.text?.includes('Oversized session appended answer')) {
+  throw new Error(`read_codex_session could not resume after an append: ${appendedHeadPage.content?.[0]?.text}`);
+}
+const byteBoundaryPage = await codexSessionsClient.request('tools/call', {
+  name: 'read_codex_session',
+  arguments: { session_id: byteBoundaryCodexSessionId, max_messages: 1, max_total_bytes: 4000 }
+});
+const byteBoundaryContent = byteBoundaryPage.structuredContent.messages?.[0]?.content ?? '';
+if (Buffer.byteLength(byteBoundaryContent, 'utf8') > 4000) {
+  throw new Error(`read_codex_session exceeded max_total_bytes at a UTF-8 boundary: ${Buffer.byteLength(byteBoundaryContent, 'utf8')}`);
 }
 const largeTailSessions = await codexSessionsClient.request('tools/call', { name: 'codex_sessions', arguments: { query: 'Large tail summary', max_sessions: 5 } });
 if (largeTailSessions.structuredContent.total_found !== 0 || JSON.stringify(largeTailSessions.structuredContent).includes('Large tail summary')) {

--- a/src/codexSessions.ts
+++ b/src/codexSessions.ts
@@ -1,8 +1,7 @@
-import { createReadStream, statSync, type Dirent } from "node:fs";
+import { type Dirent } from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createInterface } from "node:readline";
 import type { CodexProConfig } from "./config.js";
 import { CodexProError } from "./guard.js";
 
@@ -41,8 +40,29 @@ export interface CodexSessionReadResult {
   session: CodexSessionMeta;
   messages: CodexSessionMessage[];
   truncated: boolean;
+  direction: "head" | "tail";
+  cursor: number;
+  resume_cursor: number;
+  next_cursor?: number;
+  has_more: boolean;
+  source_size_bytes: number;
   text: string;
 }
+
+interface JsonlLine {
+  line: string;
+  start: number;
+  end: number;
+}
+
+interface SessionMessageRecord {
+  message: CodexSessionMessage;
+  start: number;
+  end: number;
+}
+
+const SESSION_READ_BLOCK_BYTES = 64 * 1024;
+const DEFAULT_TOOL_OUTPUT_BYTES = 20_000;
 
 function codexDir(config: CodexProConfig): string {
   return path.resolve(config.codexDir || path.join(os.homedir(), ".codex"));
@@ -330,57 +350,240 @@ async function resolveSessionSource(config: CodexProConfig, sessionId?: string, 
   return match;
 }
 
-async function loadSessionMessages(filePath: string, maxMessages: number, maxTotalBytes: number): Promise<{ messages: CodexSessionMessage[]; truncated: boolean }> {
-  const size = statSync(filePath).size;
-  if (size > 20_000_000) {
-    throw new CodexProError(`Codex session file is too large (${size} bytes).`);
+function clampCursor(value: number | undefined, size: number, direction: "head" | "tail"): number {
+  if (value === undefined) return direction === "tail" ? size : 0;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new CodexProError("cursor must be a non-negative integer byte offset returned by a previous read_codex_session call.");
   }
+  if (value > size) {
+    throw new CodexProError("cursor is beyond the current Codex session file. The source may have been truncated or replaced; restart pagination without a cursor.");
+  }
+  return value;
+}
 
-  const messages: CodexSessionMessage[] = [];
+async function* readJsonlLinesFromHead(filePath: string, startOffset: number, endOffset: number): AsyncGenerator<JsonlLine> {
+  const handle = await fsp.open(filePath, "r");
+  try {
+    let position = startOffset;
+    let pending: Buffer[] = [];
+    let pendingStart = startOffset;
+    while (position < endOffset) {
+      const length = Math.min(SESSION_READ_BLOCK_BYTES, endOffset - position);
+      const chunk = Buffer.alloc(length);
+      const { bytesRead } = await handle.read(chunk, 0, length, position);
+      if (!bytesRead) break;
+      const current = chunk.subarray(0, bytesRead);
+      let lineStart = 0;
+      while (true) {
+        const newline = current.indexOf(0x0a, lineStart);
+        if (newline === -1) break;
+        const segment = current.subarray(lineStart, newline);
+        const line = pending.length ? Buffer.concat([...pending, segment]) : segment;
+        yield {
+          line: line.toString("utf8"),
+          start: pendingStart,
+          end: position + newline + 1
+        };
+        pending = [];
+        lineStart = newline + 1;
+        pendingStart = position + lineStart;
+      }
+      const remainder = current.subarray(lineStart);
+      if (remainder.length) pending.push(remainder);
+      position += bytesRead;
+    }
+    if (pending.length) {
+      const line = Buffer.concat(pending);
+      yield { line: line.toString("utf8"), start: pendingStart, end: pendingStart + line.length };
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+async function* readJsonlLinesFromTail(filePath: string, endOffset: number): AsyncGenerator<JsonlLine> {
+  const handle = await fsp.open(filePath, "r");
+  try {
+    let position = endOffset;
+    let pending: Buffer[] = [];
+    let pendingEnd = endOffset;
+    while (position > 0) {
+      const start = Math.max(0, position - SESSION_READ_BLOCK_BYTES);
+      const length = position - start;
+      const chunk = Buffer.alloc(length);
+      const { bytesRead } = await handle.read(chunk, 0, length, start);
+      if (!bytesRead) break;
+      const current = chunk.subarray(0, bytesRead);
+      let lineEnd = current.length;
+      while (true) {
+        const newline = current.lastIndexOf(0x0a, lineEnd - 1);
+        if (newline === -1) break;
+        const lineStart = newline + 1;
+        const segment = current.subarray(lineStart, lineEnd);
+        const line = pending.length
+          ? Buffer.concat([segment, ...pending.slice().reverse()])
+          : segment;
+        if (line.length) {
+          yield { line: line.toString("utf8"), start: start + lineStart, end: pendingEnd };
+        }
+        pending = [];
+        pendingEnd = start + newline;
+        lineEnd = newline;
+      }
+      const remainder = current.subarray(0, lineEnd);
+      if (remainder.length) pending.push(remainder);
+      position = start;
+    }
+    if (pending.length) {
+      const line = Buffer.concat(pending.slice().reverse());
+      yield { line: line.toString("utf8"), start: 0, end: pendingEnd };
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+function truncateUtf8(text: string, maxBytes: number, suffix = "…"): string {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  const fittedSuffix = suffixBytes <= maxBytes ? suffix : "";
+  const bodyBudget = maxBytes - Buffer.byteLength(fittedSuffix, "utf8");
+  let usedBytes = 0;
+  let body = "";
+  for (const character of text) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (usedBytes + characterBytes > bodyBudget) break;
+    body += character;
+    usedBytes += characterBytes;
+  }
+  return `${body}${fittedSuffix}`;
+}
+
+function boundedToolOutput(output: unknown, maxBytes: number): string {
+  const content = String(output || "");
+  if (Buffer.byteLength(content, "utf8") <= maxBytes) return content;
+  if (maxBytes <= 0) return "";
+  const marker = "\n[Tool output truncated]";
+  const markerBytes = Buffer.byteLength(marker, "utf8");
+  if (markerBytes >= maxBytes) return truncateUtf8(content, maxBytes, "");
+  return `${truncateUtf8(content, maxBytes - markerBytes, "")}${marker}`;
+}
+
+function messageFromJsonlLine(
+  line: string,
+  options: { excludeToolOutputs: boolean; maxToolOutputBytes: number }
+): CodexSessionMessage | undefined {
+  const value = parseJsonLine(line);
+  if (value?.type !== "response_item" || !value.payload) return undefined;
+  const payload = value.payload;
+  let role = "";
+  let content = "";
+  if (payload.type === "message") {
+    role = String(payload.role || "unknown");
+    content = extractText(payload.content);
+  } else if (payload.type === "function_call") {
+    role = "assistant";
+    content = `[Tool: ${payload.name || "unknown"}]`;
+  } else if (payload.type === "function_call_output") {
+    if (options.excludeToolOutputs) return undefined;
+    role = "tool";
+    content = boundedToolOutput(payload.output, options.maxToolOutputBytes);
+  } else {
+    return undefined;
+  }
+  if (!content.trim()) return undefined;
+  const ts = parseTimestamp(value.timestamp);
+  return { role, content, ...(ts !== undefined ? { ts } : {}) };
+}
+
+async function loadSessionMessages(
+  filePath: string,
+  options: {
+    direction: "head" | "tail";
+    cursor?: number;
+    maxMessages: number;
+    maxTotalBytes: number;
+    excludeToolOutputs: boolean;
+    maxToolOutputBytes: number;
+  }
+): Promise<{ messages: CodexSessionMessage[]; truncated: boolean; cursor: number; resumeCursor: number; nextCursor?: number; hasMore: boolean; sourceSizeBytes: number }> {
+  const sourceSizeBytes = (await fsp.stat(filePath)).size;
+  const cursor = clampCursor(options.cursor, sourceSizeBytes, options.direction);
+  const lines = options.direction === "tail"
+    ? readJsonlLinesFromTail(filePath, cursor)
+    : readJsonlLinesFromHead(filePath, cursor, sourceSizeBytes);
+  const records: SessionMessageRecord[] = [];
   let usedBytes = 0;
   let truncated = false;
-  const rl = createInterface({ input: createReadStream(filePath, { encoding: "utf8" }), crlfDelay: Infinity });
+  let hasMore = false;
 
-  for await (const line of rl) {
-    const value = parseJsonLine(line);
-    if (value?.type !== "response_item" || !value.payload) continue;
-    const payload = value.payload;
-    let role = "";
-    let content = "";
-    if (payload.type === "message") {
-      role = String(payload.role || "unknown");
-      content = extractText(payload.content);
-    } else if (payload.type === "function_call") {
-      role = "assistant";
-      content = `[Tool: ${payload.name || "unknown"}]`;
-    } else if (payload.type === "function_call_output") {
-      role = "tool";
-      content = String(payload.output || "");
-    } else {
-      continue;
-    }
-    if (!content.trim()) continue;
-    const nextBytes = Buffer.byteLength(content, "utf8");
-    if (messages.length >= maxMessages || usedBytes + nextBytes > maxTotalBytes) {
+  for await (const line of lines) {
+    const parsed = messageFromJsonlLine(line.line, options);
+    if (!parsed) continue;
+    if (records.length >= options.maxMessages || usedBytes >= options.maxTotalBytes) {
       truncated = true;
+      hasMore = true;
       break;
     }
-    usedBytes += nextBytes;
-    const ts = parseTimestamp(value.timestamp);
-    messages.push({ role, content, ...(ts !== undefined ? { ts } : {}) });
+    const remainingBytes = options.maxTotalBytes - usedBytes;
+    const contentBytes = Buffer.byteLength(parsed.content, "utf8");
+    const message = contentBytes > remainingBytes
+      ? { ...parsed, content: truncateUtf8(parsed.content, remainingBytes) }
+      : parsed;
+    if (!message.content) {
+      truncated = true;
+      hasMore = true;
+      break;
+    }
+    if (contentBytes > remainingBytes) truncated = true;
+    usedBytes += Buffer.byteLength(message.content, "utf8");
+    records.push({ message, start: line.start, end: line.end });
   }
 
-  return { messages, truncated };
+  const ordered = options.direction === "tail" ? records.reverse() : records;
+  const resumeCursor = records.length
+    ? options.direction === "tail"
+      ? Math.min(...records.map((record) => record.start))
+      : Math.max(...records.map((record) => record.end))
+    : cursor;
+  return {
+    messages: ordered.map((record) => record.message),
+    truncated,
+    cursor,
+    resumeCursor,
+    ...(hasMore ? { nextCursor: resumeCursor } : {}),
+    hasMore,
+    sourceSizeBytes
+  };
 }
 
 export async function readCodexSession(
   config: CodexProConfig,
-  options: { sessionId?: string; sourcePath?: string; maxMessages?: number; maxTotalBytes?: number } = {}
+  options: {
+    sessionId?: string;
+    sourcePath?: string;
+    direction?: "head" | "tail";
+    cursor?: number;
+    maxMessages?: number;
+    maxTotalBytes?: number;
+    excludeToolOutputs?: boolean;
+    maxToolOutputBytes?: number;
+  } = {}
 ): Promise<CodexSessionReadResult> {
   const session = await resolveSessionSource(config, options.sessionId, options.sourcePath);
+  const direction = options.direction === "head" ? "head" : "tail";
   const maxMessages = Math.max(1, Math.min(Number(options.maxMessages ?? 80), 400));
   const maxTotalBytes = Math.max(4_000, Math.min(Number(options.maxTotalBytes ?? 80_000), 400_000));
-  const { messages, truncated } = await loadSessionMessages(session.source_path, maxMessages, maxTotalBytes);
+  const maxToolOutputBytes = Math.max(0, Math.min(Number(options.maxToolOutputBytes ?? DEFAULT_TOOL_OUTPUT_BYTES), 400_000));
+  const { messages, truncated, cursor, resumeCursor, nextCursor, hasMore, sourceSizeBytes } = await loadSessionMessages(session.source_path, {
+    direction,
+    cursor: options.cursor,
+    maxMessages,
+    maxTotalBytes,
+    excludeToolOutputs: options.excludeToolOutputs === true,
+    maxToolOutputBytes
+  });
   const transcript = messages.map((message) => {
     const when = message.ts ? ` ${new Date(message.ts).toISOString()}` : "";
     return `### ${message.role}${when}\n\n${message.content}`;
@@ -392,6 +595,10 @@ export async function readCodexSession(
     session.title ? `Title: ${session.title}` : "",
     session.project_dir ? `CWD: ${session.project_dir}` : "",
     `Source: ${session.source_path}`,
+    `Direction: ${direction}`,
+    `Cursor: ${cursor}`,
+    `Resume cursor: ${resumeCursor}`,
+    hasMore && nextCursor !== undefined ? `Next cursor: ${nextCursor}` : "",
     `Resume: ${session.resume_command}`,
     truncated ? "Transcript truncated by configured limits." : "",
     "",
@@ -399,5 +606,16 @@ export async function readCodexSession(
     "",
     transcript || "No readable transcript messages found."
   ].filter((line) => line !== "").join("\n");
-  return { session, messages, truncated, text };
+  return {
+    session,
+    messages,
+    truncated,
+    direction,
+    cursor,
+    resume_cursor: resumeCursor,
+    ...(nextCursor !== undefined ? { next_cursor: nextCursor } : {}),
+    has_more: hasMore,
+    source_size_bytes: sourceSizeBytes,
+    text
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2499,12 +2499,16 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         {
           title: "Read Codex Session",
           description:
-            "Opt-in, read-only local Codex transcript reader. Requires --codex-sessions read and returns a bounded transcript from a local Codex session JSONL file.",
+            "Opt-in, read-only local Codex transcript reader. Requires --codex-sessions read. It selects the newest page by default, returns that page chronologically, and reads the file in blocks instead of loading the full JSONL. Memory use still scales with the largest individual JSONL record scanned.",
           inputSchema: {
             session_id: z.string().optional().describe("Codex session id from codex_sessions."),
             source_path: z.string().optional().describe("Source path from codex_sessions. Must be inside the configured Codex session roots."),
+            direction: z.enum(["head", "tail"]).optional().describe("Page direction. tail selects the newest page and is the default; head reads from the start. Messages inside each page are returned chronologically."),
+            cursor: z.number().int().min(0).optional().describe("Opaque byte cursor returned as next_cursor or resume_cursor by a previous page. Reuse it only with the same session and direction. Omit for the newest tail page or the first head page."),
             max_messages: z.number().int().min(1).max(400).optional().describe("Maximum transcript messages. Default: 80."),
-            max_total_bytes: z.number().int().min(4000).max(400000).optional().describe("Maximum transcript content bytes. Default: 80000.")
+            max_total_bytes: z.number().int().min(4000).max(400000).optional().describe("Maximum returned transcript content bytes. Default: 80000."),
+            exclude_tool_outputs: z.boolean().optional().describe("Exclude function_call_output messages. Default: false."),
+            max_tool_output_bytes: z.number().int().min(0).max(400000).optional().describe("Maximum bytes retained per tool output before it is truncated. Default: 20000.")
           },
           annotations: READ_ONLY_ANNOTATIONS,
           _meta: {
@@ -2517,14 +2521,24 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
           const result = await readCodexSession(config, {
             sessionId: args.session_id,
             sourcePath: args.source_path,
+            direction: args.direction,
+            cursor: args.cursor,
             maxMessages: args.max_messages,
-            maxTotalBytes: args.max_total_bytes
+            maxTotalBytes: args.max_total_bytes,
+            excludeToolOutputs: args.exclude_tool_outputs,
+            maxToolOutputBytes: args.max_tool_output_bytes
           });
           return textResult(result.text, {
             session: result.session,
             messages: result.messages,
             message_count: result.messages.length,
             truncated: result.truncated,
+            direction: result.direction,
+            cursor: result.cursor,
+            resume_cursor: result.resume_cursor,
+            next_cursor: result.next_cursor ?? null,
+            has_more: result.has_more,
+            source_size_bytes: result.source_size_bytes,
             codex_sessions_mode: config.codexSessions
           });
         }


### PR DESCRIPTION
Fixes #75.

## What changed

- default `read_codex_session` to the newest transcript page while preserving chronological order within the page
- scan JSONL from the head or tail in 64 KiB blocks instead of rejecting files over 20 MB
- add byte-cursor pagination with `next_cursor`, `resume_cursor`, `has_more`, and source-size metadata
- add `exclude_tool_outputs` and strict UTF-8-aware `max_tool_output_bytes` handling
- apply message and byte limits to returned transcript content
- reject cursors beyond a truncated or replaced source file

## Root cause

The previous reader rejected any session JSONL over 20,000,000 bytes and always streamed from the beginning, so long-running sessions could not recover their newest messages.

## Validation

- `npm run build`
- `npm run smoke`
- `npm run stress`
- `git diff --check`

Regression coverage includes a 20.1 MB session, head and tail pagination, append-resume behavior, stale-cursor rejection, UTF-8 byte boundaries, tool-output filtering and caps, and source-file preservation.