### PR TITLE
Prefer workspace skills over global duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Made skill inventory and name-only `load_skill` use one deterministic winner per skill name, with workspace skills taking precedence over user-global and plugin skills.
+- Kept explicit `source` and `path` overrides available for diagnostics or intentionally loading a suppressed duplicate.
+
 ## 0.29.0 (2026-07-13)
 
 - Replaced the heavy v9 Apps widget with a compact, host-theme-aware v10 card for selected user-visible results: workspace, analysis, changes, Git status, handoff, and terminal verification.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "start:http": "node dist/http.js",
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
-    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
+    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
     "stress": "npm run build && node scripts/stress.mjs",
     "analysis:smoke": "npm run build && node scripts/analysis-smoke.mjs",
     "analysis:cli-smoke": "npm run build && node scripts/analysis-cli-smoke.mjs",

--- a/scripts/analysis-smoke.mjs
+++ b/scripts/analysis-smoke.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const projectRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const importBuilt = (relativePath) => import(pathToFileURL(path.join(projectRoot, 'dist', relativePath)).href);
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-'));
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-outside-'));

--- a/scripts/skill-precedence-smoke.mjs
+++ b/scripts/skill-precedence-smoke.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { discoverSkillInventory, loadSkill } from '../dist/capabilitiesOps.js';
+
+async function writeSkill(root, relativeDir, name, description, heading) {
+  const dir = path.join(root, relativeDir);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'SKILL.md'), [
+    '---',
+    `name: ${name}`,
+    `description: ${description}`,
+    '---',
+    '',
+    `# ${heading}`,
+    ''
+  ].join('\n'), 'utf8');
+}
+
+function onlySkill(inventory, name) {
+  const matches = inventory.filter((skill) => skill.name === name);
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one active ${name}, found ${matches.length}: ${JSON.stringify(matches)}`);
+  }
+  return matches[0];
+}
+
+const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-workspace-'));
+const homeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-home-'));
+
+try {
+  await writeSkill(workspaceRoot, path.join('.codex', 'skills', 'smoke-skill'), 'smoke-skill', 'Preferred workspace skill.', 'Workspace Codex Skill');
+  await writeSkill(workspaceRoot, path.join('.agents', 'skills', 'smoke-skill'), 'smoke-skill', 'Suppressed workspace duplicate.', 'Workspace Agents Duplicate');
+  await writeSkill(homeRoot, path.join('.codex', 'skills', 'smoke-skill'), 'smoke-skill', 'Suppressed user duplicate.', 'User Duplicate');
+  await writeSkill(homeRoot, path.join('.agents', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Preferred user-global skill.', 'User Global Preferred Skill');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'smoke-skill'), 'smoke-skill', 'Suppressed plugin duplicate.', 'Plugin Smoke Duplicate');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Suppressed plugin global duplicate.', 'Plugin Global Duplicate');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'First plugin copy.', 'Plugin First Copy');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-b', '2.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'Second plugin copy.', 'Plugin Second Copy');
+
+  const workspace = {
+    id: 'skill-precedence-smoke',
+    root: workspaceRoot,
+    openedAt: new Date().toISOString()
+  };
+  const discoveryOptions = { includeGlobal: true, maxSkills: 50, homeDir: homeRoot };
+  const inventory = await discoverSkillInventory(workspace, discoveryOptions);
+
+  const workspaceWinner = onlySkill(inventory, 'smoke-skill');
+  if (workspaceWinner.source !== 'workspace' || workspaceWinner.path !== '$WORKSPACE/.codex/skills/smoke-skill/SKILL.md') {
+    throw new Error(`workspace precedence winner was wrong: ${JSON.stringify(workspaceWinner)}`);
+  }
+
+  const userWinner = onlySkill(inventory, 'global-smoke-skill');
+  if (userWinner.source !== 'user' || userWinner.path !== '~/.agents/skills/global-smoke-skill/SKILL.md') {
+    throw new Error(`user precedence winner was wrong: ${JSON.stringify(userWinner)}`);
+  }
+
+  const pluginWinner = onlySkill(inventory, 'plugin-only-skill');
+  if (pluginWinner.source !== 'plugin') {
+    throw new Error(`plugin duplicate was not reduced to one plugin winner: ${JSON.stringify(pluginWinner)}`);
+  }
+
+  const loadedWorkspace = await loadSkill(workspace, { name: 'smoke-skill', maxSkills: 50, homeDir: homeRoot });
+  if (!loadedWorkspace.text.includes('# Workspace Codex Skill')) {
+    throw new Error(`name-only load did not choose the workspace winner: ${loadedWorkspace.skill.path}`);
+  }
+
+  const loadedUser = await loadSkill(workspace, { name: 'global-smoke-skill', maxSkills: 50, homeDir: homeRoot });
+  if (!loadedUser.text.includes('# User Global Preferred Skill')) {
+    throw new Error(`name-only load did not choose the user winner: ${loadedUser.skill.path}`);
+  }
+
+  const loadedPluginOverride = await loadSkill(workspace, {
+    name: 'global-smoke-skill',
+    source: 'plugin',
+    maxSkills: 50,
+    homeDir: homeRoot
+  });
+  if (!loadedPluginOverride.text.includes('# Plugin Global Duplicate')) {
+    throw new Error(`source override did not load the suppressed plugin copy: ${loadedPluginOverride.skill.path}`);
+  }
+
+  const loadedPathOverride = await loadSkill(workspace, {
+    name: 'smoke-skill',
+    path: '$WORKSPACE/.agents/skills/smoke-skill/SKILL.md',
+    maxSkills: 50,
+    homeDir: homeRoot
+  });
+  if (!loadedPathOverride.text.includes('# Workspace Agents Duplicate')) {
+    throw new Error(`path override did not load the suppressed workspace copy: ${loadedPathOverride.skill.path}`);
+  }
+
+  console.log('✓ skill precedence smoke test passed');
+} finally {
+  await fs.rm(workspaceRoot, { recursive: true, force: true });
+  await fs.rm(homeRoot, { recursive: true, force: true });
+}

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -342,15 +342,17 @@ for (const legacyToolCardUri of legacyToolCardUris) {
 }
 const current = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
 const realTmp = await fs.realpath(tmp);
-if (current.structuredContent.root !== realTmp) throw new Error(`open_current_workspace opened ${current.structuredContent.root}, expected ${realTmp}`);
+const realOpenedRoot = await fs.realpath(current.structuredContent.root);
+if (realOpenedRoot.toLowerCase() !== realTmp.toLowerCase()) throw new Error(`open_current_workspace opened ${current.structuredContent.root}, expected ${realTmp}`);
 if (current.structuredContent.codexpro_tool !== 'open_current_workspace') throw new Error('tool result was not tagged for widget rendering');
 if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_current_workspace did not expose tool_mode: ${current.structuredContent.tool_mode}`);
 if (current.structuredContent.skill_inventory?.length) {
   throw new Error('open_current_workspace discovered skills by default');
 }
 const currentWithSkills = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false, include_skills: true } });
-if (!currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
-  throw new Error('open_current_workspace did not discover workspace skill inventory when requested');
+const activeSmokeSkills = currentWithSkills.structuredContent.skill_inventory?.filter?.((skill) => skill.name === 'smoke-skill') ?? [];
+if (activeSmokeSkills.length !== 1 || activeSmokeSkills[0].source !== 'workspace') {
+  throw new Error(`open_current_workspace did not expose exactly one workspace smoke-skill: ${JSON.stringify(activeSmokeSkills)}`);
 }
 if (currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'outside-skill')) {
   throw new Error('open_current_workspace followed a symlinked workspace skill root outside the workspace');
@@ -383,17 +385,22 @@ const snapshotAlias = await client.request('tools/call', {
 if (!snapshotAlias.structuredContent.tree) {
   throw new Error('workspace_snapshot did not accept max_files alias or return a tree');
 }
-await expectToolError('load_skill', { name: 'smoke-skill', source: 'workspace' }, /Multiple skills named smoke-skill/);
 const loadedSkill = await client.request('tools/call', {
+  name: 'load_skill',
+  arguments: { name: 'smoke-skill' }
+});
+if (loadedSkill.structuredContent.skill?.source !== 'workspace' || !loadedSkill.structuredContent.text?.includes('# Smoke Skill')) {
+  throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
+}
+const suppressedSkill = await client.request('tools/call', {
   name: 'load_skill',
   arguments: {
     name: 'smoke-skill',
-    source: 'workspace',
-    path: '$WORKSPACE/.codex/skills/smoke-skill/SKILL.md'
+    path: '$WORKSPACE/.agents/skills/smoke-skill/SKILL.md'
   }
 });
-if (loadedSkill.structuredContent.skill?.name !== 'smoke-skill' || !loadedSkill.structuredContent.text?.includes('# Smoke Skill')) {
-  throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
+if (!suppressedSkill.structuredContent.text?.includes('# Duplicate Smoke Skill')) {
+  throw new Error('load_skill path override did not load the suppressed workspace duplicate');
 }
 await expectToolError('load_skill', { name: 'missing-skill' }, /Skill not found/);
 await expectToolError('load_skill', { name: 'outside-skill', source: 'workspace', include_global_skills: false }, /Skill not found/);
@@ -685,7 +692,9 @@ const pwdBashText = pwdBash.content?.[0]?.text ?? '';
 if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwdBashText.includes('## stderr')) {
   throw new Error(`default bash transcript should be compact: ${pwdBashText}`);
 }
-if (!pwdBash.structuredContent.stdout?.includes(tmp)) {
+const normalizedPwd = (pwdBash.structuredContent.stdout ?? '').trim().replace(/^\/([A-Za-z])\//, '$1:/').replaceAll('/', path.sep).toLowerCase();
+const normalizedTmp = tmp.replaceAll('/', path.sep).toLowerCase();
+if (!normalizedPwd.includes(normalizedTmp)) {
   throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
 }
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
@@ -1018,7 +1027,8 @@ await fullTranscriptClient.request('initialize', {
 fullTranscriptClient.notify('notifications/initialized');
 const fullTranscriptBash = await fullTranscriptClient.request('tools/call', { name: 'bash', arguments: { command: 'pwd' } });
 const fullTranscriptText = fullTranscriptBash.content?.[0]?.text ?? '';
-if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(tmp)) {
+const normalizedFullTranscriptText = fullTranscriptText.replace(/\/([A-Za-z])\//g, '$1:/').replaceAll('/', path.sep).toLowerCase();
+if (!fullTranscriptText.includes('## stdout') || !normalizedFullTranscriptText.includes(normalizedTmp)) {
   throw new Error(`full bash transcript mode did not preserve raw stdout in chat text: ${fullTranscriptText}`);
 }
 fullTranscriptClient.close();

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -14,6 +14,7 @@ export interface SkillInventoryItem {
 
 interface SkillInventoryRecord extends SkillInventoryItem {
   absPath: string;
+  precedence: number;
 }
 
 export interface LoadedSkill {
@@ -89,8 +90,7 @@ function realpathOrUndefined(filePath: string): string | undefined {
   }
 }
 
-function displayPath(absPath: string, workspaceRoot: string): string {
-  const home = os.homedir();
+function displayPath(absPath: string, workspaceRoot: string, home = os.homedir()): string {
   if (absPath === workspaceRoot) return "$WORKSPACE";
   if (absPath.startsWith(`${workspaceRoot}${path.sep}`)) {
     return `$WORKSPACE/${path.relative(workspaceRoot, absPath).split(path.sep).join("/")}`;
@@ -102,10 +102,10 @@ function displayPath(absPath: string, workspaceRoot: string): string {
   return absPath;
 }
 
-function skillSource(skillPath: string, workspaceRoot: string): SkillInventoryItem["source"] {
+function skillSource(skillPath: string, workspaceRoot: string, home = os.homedir()): SkillInventoryItem["source"] {
   if (skillPath.startsWith(`${workspaceRoot}${path.sep}`)) return "workspace";
   if (skillPath.includes(`${path.sep}.codex${path.sep}plugins${path.sep}`)) return "plugin";
-  if (skillPath.startsWith(`${os.homedir()}${path.sep}`)) return "user";
+  if (skillPath.startsWith(`${home}${path.sep}`)) return "user";
   return "other";
 }
 
@@ -124,6 +124,19 @@ function compareSkills(a: SkillInventoryItem, b: SkillInventoryItem): number {
   );
 }
 
+function compareSkillPrecedence(a: SkillInventoryRecord, b: SkillInventoryRecord): number {
+  return (
+    a.precedence - b.precedence ||
+    skillSourceRank(a.source) - skillSourceRank(b.source) ||
+    a.name.localeCompare(b.name) ||
+    a.path.localeCompare(b.path)
+  );
+}
+
+function activeSkillRecords(records: SkillInventoryRecord[]): SkillInventoryRecord[] {
+  return unique([...records].sort(compareSkillPrecedence), (item) => item.name).sort(compareSkills);
+}
+
 function publicSkill(record: SkillInventoryRecord): SkillInventoryItem {
   return {
     name: record.name,
@@ -138,28 +151,35 @@ function frontmatterValue(text: string, key: string): string | undefined {
   return match?.[1]?.trim().replace(/^["']|["']$/g, "");
 }
 
-async function findSkillFiles(root: string, maxDepth: number, out: string[], maxItems: number): Promise<void> {
+async function findSkillFiles(
+  root: string,
+  maxDepth: number,
+  out: Array<{ file: string; precedence: number }>,
+  maxItems: number,
+  precedence: number
+): Promise<void> {
   if (out.length >= maxItems || maxDepth < 0) return;
-  const entries = await safeReaddir(root);
+  const entries = (await safeReaddir(root)).sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {
     if (out.length >= maxItems) return;
     if (entry.name === "node_modules" || entry.name === ".git") continue;
     const abs = path.join(root, entry.name);
     if (entry.isFile() && entry.name === "SKILL.md") {
-      out.push(abs);
+      out.push({ file: abs, precedence });
       continue;
     }
     if (entry.isDirectory()) {
-      await findSkillFiles(abs, maxDepth - 1, out, maxItems);
+      await findSkillFiles(abs, maxDepth - 1, out, maxItems, precedence);
     }
   }
 }
 
 async function discoverSkillRecords(
   workspace: Workspace,
-  options: { includeGlobal?: boolean; maxSkills?: number } = {}
+  options: { includeGlobal?: boolean; maxSkills?: number; homeDir?: string } = {}
 ): Promise<SkillInventoryRecord[]> {
   const maxSkills = Math.max(1, Math.min(options.maxSkills ?? 120, 500));
+  const homeDir = options.homeDir ?? os.homedir();
   const workspaceRoots = [
     path.join(workspace.root, ".codex", "skills"),
     path.join(workspace.root, ".agents", "skills"),
@@ -172,21 +192,28 @@ async function discoverSkillRecords(
     ...workspaceRoots,
     ...(options.includeGlobal
       ? [
-          path.join(os.homedir(), ".codex", "skills"),
-          path.join(os.homedir(), ".agents", "skills"),
-          path.join(os.homedir(), ".codex", "plugins", "cache")
+          path.join(homeDir, ".codex", "skills"),
+          path.join(homeDir, ".agents", "skills"),
+          path.join(homeDir, ".codex", "plugins", "cache")
         ]
       : [])
   ].filter((dir) => fs.existsSync(dir));
 
-  const skillFiles: string[] = [];
-  for (const root of roots) {
-    await findSkillFiles(root, root.includes(`${path.sep}plugins${path.sep}cache`) ? 9 : 3, skillFiles, maxSkills);
+  const skillFiles: Array<{ file: string; precedence: number }> = [];
+  for (const [precedence, root] of roots.entries()) {
+    await findSkillFiles(
+      root,
+      root.includes(`${path.sep}plugins${path.sep}cache`) ? 9 : 3,
+      skillFiles,
+      maxSkills,
+      precedence
+    );
     if (skillFiles.length >= maxSkills) break;
   }
 
   const items: SkillInventoryRecord[] = [];
-  for (const file of skillFiles.slice(0, maxSkills)) {
+  for (const discovered of skillFiles.slice(0, maxSkills)) {
+    const file = discovered.file;
     const realFile = realpathOrUndefined(file) ?? file;
     if (isSubpath(file, workspace.root) && !isSubpath(realFile, workspace.root)) continue;
     let text = "";
@@ -200,20 +227,21 @@ async function discoverSkillRecords(
     items.push({
       name,
       description,
-      source: skillSource(realFile, workspace.root),
-      path: displayPath(realFile, workspace.root),
-      absPath: realFile
+      source: skillSource(realFile, workspace.root, homeDir),
+      path: displayPath(realFile, workspace.root, homeDir),
+      absPath: realFile,
+      precedence: discovered.precedence
     });
   }
 
-  return unique(items, (item) => `${item.source}:${item.name}:${item.path}`).sort(compareSkills);
+  return unique(items, (item) => `${item.source}:${item.name}:${item.path}`).sort(compareSkillPrecedence);
 }
 
 export async function discoverSkillInventory(
   workspace: Workspace,
-  options: { includeGlobal?: boolean; maxSkills?: number } = {}
+  options: { includeGlobal?: boolean; maxSkills?: number; homeDir?: string } = {}
 ): Promise<SkillInventoryItem[]> {
-  return (await discoverSkillRecords(workspace, options)).map(publicSkill);
+  return activeSkillRecords(await discoverSkillRecords(workspace, options)).map(publicSkill);
 }
 
 export async function loadSkill(
@@ -225,6 +253,7 @@ export async function loadSkill(
     includeGlobal?: boolean;
     maxSkills?: number;
     maxBytes?: number;
+    homeDir?: string;
   }
 ): Promise<LoadedSkill> {
   const name = options.name.trim();
@@ -233,16 +262,21 @@ export async function loadSkill(
 
   const records = await discoverSkillRecords(workspace, {
     includeGlobal: options.includeGlobal !== false,
-    maxSkills: options.maxSkills
+    maxSkills: options.maxSkills,
+    homeDir: options.homeDir
   });
-  const matches = records.filter(
+  const activeRecords = activeSkillRecords(records);
+  const candidateRecords = requestedPath
+    ? records
+    : activeSkillRecords(options.source ? records.filter((skill) => skill.source === options.source) : records);
+  const matches = candidateRecords.filter(
     (skill) =>
       skill.name === name &&
       (!options.source || skill.source === options.source) &&
       (!requestedPath || skill.path === requestedPath)
   );
   if (!matches.length) {
-    const near = records
+    const near = activeRecords
       .filter((skill) => skill.name.toLowerCase().includes(name.toLowerCase()))
       .slice(0, 8)
       .map((skill) => `${skill.name} [${skill.source}]`)
@@ -252,7 +286,7 @@ export async function loadSkill(
   }
   if (matches.length > 1) {
     const choices = matches.map((skill) => `${skill.name} [${skill.source}] at ${skill.path}`).join("; ");
-    throw new Error(`Multiple skills named ${name} were found. Pass source and path to choose one: ${choices}`);
+    throw new Error(`Multiple exact skill matches remained for ${name}: ${choices}`);
   }
 
   const [skill] = matches;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1352,8 +1352,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use default workspace."),
         name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
-        source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source when multiple skills share a name."),
-        path: z.string().optional().describe("Exact sanitized path from skill_inventory when name/source are still ambiguous."),
+        source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source override. Without it, the highest-precedence skill is loaded."),
+        path: z.string().optional().describe("Optional exact sanitized path override for diagnostics or an explicitly selected suppressed duplicate."),
         include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: auto when source/path is not workspace."),
         max_skills: z.number().int().min(1).max(500).optional().describe("Maximum skills to scan while resolving the requested skill. Default: 500."),
         max_bytes: z.number().int().min(1000).max(100000).optional().describe("Maximum bytes to return from SKILL.md. Default: 40000.")


### PR DESCRIPTION
## Summary

- expose only one active skill per frontmatter `name` in skill inventory results
- choose duplicates deterministically with workspace roots before user-global and plugin roots
- make name-only `load_skill` use the same winner instead of failing on duplicates
- preserve explicit `source` and `path` overrides for diagnostics and intentional access to suppressed copies
- sort skill directory traversal so same-tier selection is deterministic
- make the relevant smoke assertions path-safe on Windows

## Precedence

1. workspace `.codex/skills`
2. workspace `.agents/skills`
3. workspace `skills`
4. user `.codex/skills`
5. user `.agents/skills`
6. plugin cache

## Verification

- `npm run build` — PASS
- `node scripts/skill-precedence-smoke.mjs` — PASS
- `node scripts/smoke.mjs` — PASS on Windows
- Repo Launch Doctor exact commit scan — PASS_WITH_NOTES, no blocker/high findings
- Repo Launch Doctor outgoing commit history scan — PASS, 0 findings

The full aggregate smoke command reaches the unrelated Windows-only launcher fixtures after all skill, HTTP, widget, Pro, and Doctor smoke paths pass. Those fixtures currently assume Unix executable and signal behavior and were not changed in this PR.

## Compatibility

Existing callers that specify `source` or an exact sanitized `path` continue to work. Callers that only provide a skill name now receive the highest-precedence active skill instead of an ambiguity error.

## Rollback

Revert this commit to restore duplicate inventory entries and ambiguity errors for name-only loads.
