### PR TITLE
Harden Windows runtime and skill precedence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -28,6 +35,9 @@ jobs:
 
       - name: Smoke Test
         run: npm run smoke
+
+      - name: Stress Test
+        run: npm run stress
 
       - name: Check Package Contents
         run: npm pack --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Made bounded ripgrep truncation tolerate an interrupted final JSON record, rejected symlinked `.ai-bridge` handoff paths, and terminated timed-out bash process trees instead of only their direct shell process.
 - Closed the follow-up security findings by rejecting symlinked handoff leaf files, bounding and force-terminating output-heavy bash trees, disabling unbounded regex in the Node search fallback, size-capping verified `cloudflared` downloads, removing `cmd.exe call` re-expansion, excluding internal plans from npm packages, and adding a protected `--token-file` path for stable launches.
 - Added Windows CI coverage and made smoke, stress, tunnel-shim, and runtime-status checks portable across Windows and Unix hosts.
+- Made skill inventory and name-only `load_skill` use one deterministic winner per skill name, with workspace skills taking precedence over user-global and plugin skills.
+- Kept explicit `source` and `path` overrides available for diagnostics or intentionally loading a suppressed duplicate.
 
 ## 0.29.0 (2026-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Closed cross-session and concurrency gaps by isolating `show_changes` checkpoints per MCP session and making `apply_patch` share canonical per-file write locks with `write` and `edit`.
 - Made bounded ripgrep truncation tolerate an interrupted final JSON record, rejected symlinked `.ai-bridge` handoff paths, and terminated timed-out bash process trees instead of only their direct shell process.
 - Closed the follow-up security findings by rejecting symlinked handoff leaf files, bounding and force-terminating output-heavy bash trees, disabling unbounded regex in the Node search fallback, size-capping verified `cloudflared` downloads, removing `cmd.exe call` re-expansion, excluding internal plans from npm packages, and adding a protected `--token-file` path for stable launches.
+- Added Windows CI coverage and made smoke, stress, tunnel-shim, and runtime-status checks portable across Windows and Unix hosts.
 
 ## 0.29.0 (2026-07-13)
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "start:http": "node dist/http.js",
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
-    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
+    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
     "stress": "npm run build && node scripts/stress.mjs",
     "analysis:smoke": "npm run build && node scripts/analysis-smoke.mjs",
     "analysis:cli-smoke": "npm run build && node scripts/analysis-cli-smoke.mjs",

--- a/scripts/analysis-smoke.mjs
+++ b/scripts/analysis-smoke.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const projectRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const importBuilt = (relativePath) => import(pathToFileURL(path.join(projectRoot, 'dist', relativePath)).href);
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-'));
 const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-outside-'));

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -502,7 +502,7 @@ function realDir(input) {
   if (!fs.existsSync(resolved)) throw new Error(`Directory does not exist: ${resolved}`);
   const stat = fs.statSync(resolved);
   if (!stat.isDirectory()) throw new Error(`Not a directory: ${resolved}`);
-  return fs.realpathSync(resolved);
+  return fs.realpathSync.native(resolved);
 }
 
 function configuredProjectRoots(root, args = {}, profile = {}) {

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -879,9 +879,8 @@ async function downloadFile(url, destination, asset) {
 }
 
 function verifyCloudflared(binaryPath) {
-  const result = spawnSync(binaryPath, ['--version'], {
+  const result = spawnSyncPortable(binaryPath, ['--version'], {
     stdio: 'ignore',
-    shell: false,
     timeout: 15000
   });
   if (result.status !== 0) {
@@ -968,9 +967,8 @@ async function resolveCloudflared(args) {
 }
 
 function verifyNgrok(binaryPath) {
-  const result = spawnSync(binaryPath, ['version'], {
+  const result = spawnSyncPortable(binaryPath, ['version'], {
     stdio: 'ignore',
-    shell: false,
     timeout: 15000
   });
   if (result.status !== 0) {
@@ -998,9 +996,8 @@ function resolveNgrok(args) {
 }
 
 function verifyTailscale(binaryPath) {
-  const result = spawnSync(binaryPath, ['version'], {
+  const result = spawnSyncPortable(binaryPath, ['version'], {
     stdio: 'ignore',
-    shell: false,
     timeout: 15000
   });
   if (result.status !== 0) {
@@ -1110,7 +1107,12 @@ const spawnedChildren = new Set();
 
 function spawnLogged(name, command, args, options = {}) {
   const { verbose = false, ...spawnOptions } = options;
-  const child = spawn(command, args, { ...spawnOptions, stdio: ['ignore', 'pipe', 'pipe'] });
+  const invocation = processInvocation(command, args);
+  const child = spawn(invocation.command, invocation.args, {
+    ...spawnOptions,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments
+  });
   const logLines = [];
   const record = (stream, chunk) => {
     const text = redactForLog(String(chunk));
@@ -1201,10 +1203,12 @@ function requestQuickTunnelViaCurl(proxyUrl) {
   const args = ['--silent', '--show-error', '--fail', '--max-time', '30'];
   if (proxyUrl) args.push('--proxy', proxyUrl);
   args.push('-X', 'POST', 'https://api.trycloudflare.com/tunnel');
-  const result = spawnSync('curl', args, {
+  const curlCommand = process.platform === 'win32'
+    ? commandPaths('curl').find(isWindowsCommandCandidate) || 'curl'
+    : 'curl';
+  const result = spawnSyncPortable(curlCommand, args, {
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    shell: false
+    stdio: ['ignore', 'pipe', 'pipe']
   });
   if (result.status !== 0) {
     throw new Error(redactForLog(`Failed to request Cloudflare quick tunnel via curl: ${result.stderr || result.stdout || `exit ${result.status}`}`));
@@ -1608,6 +1612,15 @@ function processInvocation(command, args) {
     args: ['/d', '/q', '/v:off', '/s', '/c', commandLine],
     windowsVerbatimArguments: true
   };
+}
+
+function spawnSyncPortable(command, args, options = {}) {
+  const invocation = processInvocation(command, args);
+  return spawnSync(invocation.command, invocation.args, {
+    ...options,
+    shell: false,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments
+  });
 }
 
 function runProcessCaptured(command, args, options) {
@@ -3678,7 +3691,19 @@ function writeControlPrompt() {
 }
 
 function runControlPanel(details, cleanup = cleanupChildren) {
-  if (!process.stdin.isTTY) return new Promise(() => {});
+  if (!process.stdin.isTTY) {
+    process.stdin.setEncoding('utf8');
+    process.stdin.resume();
+    return new Promise(() => {
+      process.stdin.on('data', (input) => {
+        const normalized = String(input).trim().toLowerCase();
+        if (normalized === 'q') {
+          cleanup();
+          process.exit(0);
+        }
+      });
+    });
+  }
 
   writeControlPrompt();
 

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1113,6 +1113,7 @@ function spawnLogged(name, command, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsVerbatimArguments: invocation.windowsVerbatimArguments
   });
+  child.codexproKillTree = Boolean(invocation.killTree);
   const logLines = [];
   const record = (stream, chunk) => {
     const text = redactForLog(String(chunk));
@@ -1248,6 +1249,13 @@ function writeQuickTunnelCredentials(tunnel) {
 
 function killProcess(child) {
   if (!child || child.killed) return;
+  if (child.codexproKillTree && child.pid) {
+    const result = spawnSync('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true
+    });
+    if (!result.error && result.status === 0) return;
+  }
   try { child.kill('SIGTERM'); } catch {}
   setTimeout(() => {
     if (!child.killed) {
@@ -1610,7 +1618,8 @@ function processInvocation(command, args) {
   return {
     command: process.env.ComSpec || 'cmd.exe',
     args: ['/d', '/q', '/v:off', '/s', '/c', commandLine],
-    windowsVerbatimArguments: true
+    windowsVerbatimArguments: true,
+    killTree: true
   };
 }
 

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -734,14 +734,16 @@ await fs.writeFile(path.join(boundedUntrackedRoot, 'app.txt'), 'start\n', 'utf8'
 await fs.writeFile(path.join(boundedUntrackedRoot, 'bounded-agent.mjs'), `
 import fs from 'node:fs';
 fs.writeFileSync('large-artifact.bin', Buffer.alloc(96 * 1024, 'a'));
-fs.symlinkSync('app.txt', 'app-link.txt');
+if (process.platform !== 'win32') fs.symlinkSync('app.txt', 'app-link.txt');
 `, 'utf8');
 await fs.writeFile(path.join(boundedUntrackedRoot, 'reviewer.mjs'), `
 import fs from 'node:fs';
 const diffPath = process.argv[process.argv.indexOf('--diff') + 1];
 const diff = fs.readFileSync(diffPath, 'utf8');
-const linkLine = diff.split(/\\r?\\n/).find((line) => line.includes('app-link.txt'));
-if (!linkLine || !linkLine.includes('(symlink, target=app.txt') || linkLine.includes('sha256')) process.exit(6);
+if (process.platform !== 'win32') {
+  const linkLine = diff.split(/\\r?\\n/).find((line) => line.includes('app-link.txt'));
+  if (!linkLine || !linkLine.includes('(symlink, target=app.txt') || linkLine.includes('sha256')) process.exit(6);
+}
 if (!diff.includes('large-artifact.bin') || !diff.includes('sha256_first_65536=') || !diff.includes('fingerprint_truncated=true')) process.exit(7);
 if (Buffer.byteLength(diff, 'utf8') > 4500) process.exit(8);
 console.log('CODEXPRO_REVIEW=PASS');

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -828,10 +828,13 @@ const cliChild = spawn(process.execPath, [
 });
 try {
   await waitForHealthJson(`http://127.0.0.1:${cliPort}/healthz`);
-  const expectedCliCodexDir = path.join(await fs.realpath(cliRoot), '.codex');
+  const expectedCliCodexDir = await fs.realpath(path.join(cliRoot, '.codex'));
   await withClient(`http://127.0.0.1:${cliPort}/mcp`, async (client) => {
     const config = await callTool(client, 'server_config');
-    if (config.structuredContent.codexDir !== expectedCliCodexDir) {
+    const actualCliCodexDir = await fs.realpath(config.structuredContent.codexDir);
+    const comparableActual = process.platform === 'win32' ? actualCliCodexDir.toLowerCase() : actualCliCodexDir;
+    const comparableExpected = process.platform === 'win32' ? expectedCliCodexDir.toLowerCase() : expectedCliCodexDir;
+    if (comparableActual !== comparableExpected) {
       throw new Error(`relative --codex-dir resolved to ${config.structuredContent.codexDir}, expected ${expectedCliCodexDir}`);
     }
   });

--- a/scripts/release-guard-smoke.mjs
+++ b/scripts/release-guard-smoke.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCli = process.env.npm_execpath;
 const manifest = JSON.parse(await (await import("node:fs/promises")).readFile(join(root, "package.json"), "utf8"));
 
 assert.equal(manifest.scripts.prepublishOnly, "node scripts/release-guard.mjs");
@@ -37,7 +38,10 @@ try {
   assert.notEqual(wrongDirectory.status, 0, wrongDirectory.output);
   assert.match(wrongDirectory.output, /Release commands must run from the CodexPro root/);
 
-  const prefixInvocation = run(npm, ["--prefix", root, "run", "release:guard", "--silent"], { cwd: wrongCwd });
+  const prefixArgs = ["--prefix", root, "run", "release:guard", "--silent"];
+  const prefixInvocation = npmCli
+    ? run(process.execPath, [npmCli, ...prefixArgs], { cwd: wrongCwd })
+    : run(npm, prefixArgs, { cwd: wrongCwd });
   assert.notEqual(prefixInvocation.status, 0, prefixInvocation.output);
   assert.match(prefixInvocation.output, /Release commands must run from the CodexPro root/);
 

--- a/scripts/release-pack.mjs
+++ b/scripts/release-pack.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { CODEXPRO_PACKAGE, assertCodexProReleaseEnvironment } from "./release-guard.mjs";
 
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCli = process.env.npm_execpath;
 
 function fail(message) {
   throw new Error(message);
@@ -9,7 +10,8 @@ function fail(message) {
 
 try {
   const release = assertCodexProReleaseEnvironment();
-  const packed = spawnSync(npm, ["pack", "--dry-run", "--ignore-scripts", "--json"], {
+  const packArgs = ["pack", "--dry-run", "--ignore-scripts", "--json"];
+  const packed = spawnSync(npmCli ? process.execPath : npm, npmCli ? [npmCli, ...packArgs] : packArgs, {
     cwd: release.root,
     encoding: "utf8",
     env: { ...process.env, INIT_CWD: release.root }

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -2,9 +2,10 @@ import { spawnSync } from "node:child_process";
 import { assertCodexProReleaseEnvironment } from "./release-guard.mjs";
 
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCli = process.env.npm_execpath;
 
 function runNpm(args, root) {
-  const result = spawnSync(npm, args, {
+  const result = spawnSync(npmCli ? process.execPath : npm, npmCli ? [npmCli, ...args] : args, {
     cwd: root,
     stdio: "inherit",
     env: { ...process.env, INIT_CWD: root }

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -79,6 +79,17 @@ async function runtimeStatusPath(root, home) {
   return path.join(home, 'runtime', `${id}.json`);
 }
 
+async function writeNodeExecutable(filePath, lines, windowsCommandPath) {
+  await fs.writeFile(filePath, lines.join('\n'), { mode: 0o700 });
+  if (process.platform !== 'win32') return filePath;
+  const commandPath = windowsCommandPath ?? path.join(
+    path.dirname(filePath),
+    `${path.basename(filePath, path.extname(filePath))}.cmd`
+  );
+  await fs.writeFile(commandPath, `@echo off\r\n"${process.execPath}" "${filePath}" %*\r\n`, 'utf8');
+  return commandPath;
+}
+
 async function getFreePort() {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
@@ -106,11 +117,11 @@ async function waitForJson(filePath, predicate, label) {
   throw new Error(`timed out waiting for ${label}: ${lastError?.message ?? 'predicate not met'}`);
 }
 
-async function withStartedCodexPro(args, env, fn) {
+async function withStartedCodexPro(args, env, fn, options = {}) {
   const child = spawn(process.execPath, ['scripts/codexpro.mjs', 'start', ...args], {
     cwd: path.resolve('.'),
     env,
-    stdio: ['ignore', 'pipe', 'pipe']
+    stdio: ['pipe', 'pipe', 'pipe']
   });
   let output = '';
   let closed = false;
@@ -125,7 +136,10 @@ async function withStartedCodexPro(args, env, fn) {
   } catch (error) {
     throw new Error(`${error.message}\nstart output:\n${output}`);
   } finally {
-    if (!closed) child.kill('SIGTERM');
+    if (!closed) {
+      if (process.platform === 'win32' && !options.forceKill) child.stdin.end('q\n');
+      else child.kill('SIGTERM');
+    }
     await closedPromise;
   }
 }
@@ -490,7 +504,19 @@ await withStartedCodexPro([
   if (runtime.toolCards !== true || runtime.pid !== child.pid) {
     throw new Error(`runtime status did not persist toolCards: ${JSON.stringify(runtime)}`);
   }
-});
+}, { forceKill: true });
+const previousCodexProHome = process.env.CODEXPRO_HOME;
+process.env.CODEXPRO_HOME = home;
+try {
+  const { readRuntimeConnection } = await import('../dist/profileStore.js');
+  const stoppedRuntime = readRuntimeConnection(runtimeRoot);
+  if (Object.keys(stoppedRuntime).length > 0) {
+    throw new Error(`stale runtime status remained visible after launcher exit: ${JSON.stringify(stoppedRuntime)}`);
+  }
+} finally {
+  if (previousCodexProHome === undefined) delete process.env.CODEXPRO_HOME;
+  else process.env.CODEXPRO_HOME = previousCodexProHome;
+}
 try {
   await fs.access(runtimePath);
   throw new Error('runtime status was not cleared after launcher SIGTERM');
@@ -557,15 +583,14 @@ if (runInteractiveQuit([
 const cloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-'));
 const cloudflarePort = await getFreePort();
 const cloudflarePath = await runtimeStatusPath(cloudflareRoot, home);
-const fakeCloudflared = path.join(home, 'fake-cloudflared.mjs');
-await fs.writeFile(fakeCloudflared, [
+const fakeCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
   "console.error('https://api.trycloudflare.com/tunnel');",
   "setTimeout(() => console.error('https://real-codexpro.trycloudflare.com'), 100);",
   'setInterval(() => {}, 1000);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 await withStartedCodexPro([
   '--root',
   cloudflareRoot,
@@ -589,18 +614,17 @@ const proxyCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-se
 const proxyCloudflarePort = await getFreePort();
 const proxyCloudflarePath = await runtimeStatusPath(proxyCloudflareRoot, home);
 const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-fake-bin-'));
-const fakeCurl = path.join(fakeBin, 'curl');
+const fakeCurlScript = path.join(fakeBin, process.platform === 'win32' ? 'curl.cjs' : 'curl');
 const curlArgsPath = path.join(home, 'fake-curl-args.json');
 const cloudflaredArgsPath = path.join(home, 'fake-cloudflared-proxy-args.json');
-const fakeProxyCloudflared = path.join(home, 'fake-cloudflared-proxy.mjs');
-await fs.writeFile(fakeCurl, [
+await writeNodeExecutable(fakeCurlScript, [
   '#!/usr/bin/env node',
   "const fs = require('node:fs');",
   "fs.writeFileSync(process.env.CODEXPRO_FAKE_CURL_ARGS, JSON.stringify(process.argv.slice(2)));",
   "console.log(JSON.stringify({ success: true, result: { id: 'proxy-tunnel-id', hostname: 'proxy-codexpro.trycloudflare.com', account_tag: 'account-tag', secret: 'proxy-secret-1234567890' } }));",
   ''
-].join('\n'), { mode: 0o700 });
-await fs.writeFile(fakeProxyCloudflared, [
+], path.join(fakeBin, 'curl.cmd'));
+const fakeProxyCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared-proxy.mjs'), [
   '#!/usr/bin/env node',
   "import fs from 'node:fs';",
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
@@ -611,7 +635,7 @@ await fs.writeFile(fakeProxyCloudflared, [
   "if (credentials.TunnelID !== 'proxy-tunnel-id' || credentials.AccountTag !== 'account-tag' || credentials.TunnelSecret !== 'proxy-secret-1234567890') process.exit(4);",
   "setInterval(() => {}, 1000);",
   ''
-].join('\n'), { mode: 0o700 });
+]);
 await withStartedCodexPro([
   '--root',
   proxyCloudflareRoot,
@@ -654,14 +678,13 @@ try {
 
 const proxyCloudflareFailRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-proxy-fail-'));
 const proxyCloudflareFailPort = await getFreePort();
-const fakeFailingProxyCloudflared = path.join(home, 'fake-cloudflared-proxy-fail.mjs');
-await fs.writeFile(fakeFailingProxyCloudflared, [
+const fakeFailingProxyCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared-proxy-fail.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
   "console.error('proxy tunnel startup failed');",
   'process.exit(7);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 const proxyFailure = runFail([
   'start',
   '--root',
@@ -687,15 +710,14 @@ if (!proxyFailure.includes('proxy tunnel startup failed')) {
 
 const namedCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-named-'));
 const namedCloudflarePort = await getFreePort();
-const fakeNamedCloudflared = path.join(home, 'fake-cloudflared-named.mjs');
 const cloudflareRawToken = 'cf_audit_secret_1234567890TOKEN';
-await fs.writeFile(fakeNamedCloudflared, [
+const fakeNamedCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared-named.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
   "console.error('fake tunnel saw TUNNEL_TOKEN=' + process.env.TUNNEL_TOKEN);",
   'process.exit(2);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 const namedFailure = runFail([
   'start',
   '--root',
@@ -718,14 +740,13 @@ if (namedFailure.includes(cloudflareRawToken) || !namedFailure.includes('TUNNEL_
   throw new Error(`named tunnel failure leaked or failed to redact Cloudflare token\n${namedFailure}`);
 }
 
-const fakeNgrok = path.join(home, 'fake-ngrok.mjs');
-await fs.writeFile(fakeNgrok, [
+const fakeNgrok = await writeNodeExecutable(path.join(home, 'fake-ngrok.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('version')) { console.log('ngrok version 3.0.0'); process.exit(0); }",
   "console.error('NGROK_ARGS=' + process.argv.slice(2).join('|'));",
   'process.exit(2);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 run([
   'settings',
   'set',
@@ -760,14 +781,13 @@ if (!ngrokFailure.includes(`--config|${path.join(realNgrokRoot, 'new-ngrok.yml')
   throw new Error(`ngrok start did not let env config override saved profile\n${ngrokFailure}`);
 }
 
-const fakeTailscale = path.join(home, 'fake-tailscale.mjs');
-await fs.writeFile(fakeTailscale, [
+const fakeTailscale = await writeNodeExecutable(path.join(home, 'fake-tailscale.mjs'), [
   '#!/usr/bin/env node',
   "if (process.argv.includes('version')) { console.log('1.80.0'); process.exit(0); }",
   "console.error('TAILSCALE_ARGS=' + process.argv.slice(2).join('|'));",
   'process.exit(2);',
   ''
-].join('\n'), { mode: 0o700 });
+]);
 const tailscaleRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-tailscale-'));
 const tailscalePort = await getFreePort();
 const tailscaleFailure = runFail([

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -246,6 +246,7 @@ raise SystemExit(proc.returncode or 0)
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-root-'));
 const reuseRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-reuse-'));
+const realReuseRoot = await fs.realpath(reuseRoot);
 const policyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-policy-'));
 const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-runtime-'));
 const staleRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-stale-'));
@@ -298,7 +299,7 @@ if (!saved.includes('Saved workspace settings')) {
 }
 
 const shown = run(['settings', 'show', '--root', root], env);
-for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '19087', 'Tool cards', 'on', 'Bash transcript', 'full', 'Projects', reuseRoot, '<saved>']) {
+for (const expected of ['Tunnel', 'ngrok', 'codexpro-test.ngrok-free.app', '19087', 'Tool cards', 'on', 'Bash transcript', 'full', 'Projects', realReuseRoot, '<saved>']) {
   if (!shown.includes(expected)) {
     throw new Error(`settings show missing ${expected}\n${shown}`);
   }
@@ -312,7 +313,7 @@ if (
   || profile.toolCards !== true
   || profile.bashTranscript !== 'full'
   || profile.widgetDomain !== 'https://widgets.codexpro.test'
-  || JSON.stringify(profile.allowedRoots) !== JSON.stringify([await fs.realpath(reuseRoot)])
+  || JSON.stringify(profile.allowedRoots) !== JSON.stringify([realReuseRoot])
 ) {
   throw new Error(`settings profile did not persist tool/widget options: ${JSON.stringify(profile)}`);
 }

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -245,6 +245,7 @@ raise SystemExit(proc.returncode or 0)
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-root-'));
+const realRoot = await fs.realpath(root);
 const reuseRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-reuse-'));
 const realReuseRoot = await fs.realpath(reuseRoot);
 const policyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-policy-'));
@@ -859,7 +860,7 @@ if (!tailscalePortFailure.includes(`funnel|--https=8443|http://127.0.0.1:${tails
 }
 
 const listed = run(['settings', 'list'], env);
-if (!listed.includes(root) || !listed.includes('codexpro-test.ngrok-free.app') || !listed.includes('codexpro-test.tailnet.ts.net')) {
+if (!listed.includes(realRoot) || !listed.includes('codexpro-test.ngrok-free.app') || !listed.includes('codexpro-test.tailnet.ts.net')) {
   throw new Error(`settings list missing saved profile\n${listed}`);
 }
 

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -117,6 +117,20 @@ async function waitForJson(filePath, predicate, label) {
   throw new Error(`timed out waiting for ${label}: ${lastError?.message ?? 'predicate not met'}`);
 }
 
+async function waitForProcessExit(pid, label) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === 'ESRCH') return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for ${label} process ${pid} to exit`);
+}
+
 async function withStartedCodexPro(args, env, fn, options = {}) {
   const child = spawn(process.execPath, ['scripts/codexpro.mjs', 'start', ...args], {
     cwd: path.resolve('.'),
@@ -583,9 +597,12 @@ if (runInteractiveQuit([
 const cloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-'));
 const cloudflarePort = await getFreePort();
 const cloudflarePath = await runtimeStatusPath(cloudflareRoot, home);
+const fakeCloudflaredPidPath = path.join(home, 'fake-cloudflared.pid');
 const fakeCloudflared = await writeNodeExecutable(path.join(home, 'fake-cloudflared.mjs'), [
   '#!/usr/bin/env node',
+  "import fs from 'node:fs';",
   "if (process.argv.includes('--version')) { console.log('cloudflared version 2026.6.0'); process.exit(0); }",
+  'fs.writeFileSync(process.env.CODEXPRO_FAKE_CLOUDFLARED_PID, String(process.pid));',
   "console.error('https://api.trycloudflare.com/tunnel');",
   "setTimeout(() => console.error('https://real-codexpro.trycloudflare.com'), 100);",
   'setInterval(() => {}, 1000);',
@@ -603,12 +620,21 @@ await withStartedCodexPro([
   '--token',
   'codexpro-cloudflare-token',
   '--no-copy-url'
-], withoutProxyEnv(env), async () => {
+], withoutProxyEnv({ ...env, CODEXPRO_FAKE_CLOUDFLARED_PID: fakeCloudflaredPidPath }), async () => {
   const runtime = await waitForJson(cloudflarePath, (data) => data.endpoint?.includes('trycloudflare.com'), 'cloudflare runtime status');
   if (runtime.endpoint.includes('api.trycloudflare.com') || !runtime.endpoint.startsWith('https://real-codexpro.trycloudflare.com/mcp')) {
     throw new Error(`quick tunnel saved the wrong endpoint: ${JSON.stringify(runtime)}`);
   }
 });
+if (process.platform === 'win32') {
+  const fakeCloudflaredPid = Number(await fs.readFile(fakeCloudflaredPidPath, 'utf8'));
+  try {
+    await waitForProcessExit(fakeCloudflaredPid, 'fake cloudflared shim descendant');
+  } catch (error) {
+    spawnSync('taskkill.exe', ['/pid', String(fakeCloudflaredPid), '/t', '/f'], { stdio: 'ignore' });
+    throw error;
+  }
+}
 
 const proxyCloudflareRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-cloudflare-proxy-'));
 const proxyCloudflarePort = await getFreePort();

--- a/scripts/skill-precedence-smoke.mjs
+++ b/scripts/skill-precedence-smoke.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { discoverSkillInventory, loadSkill } from '../dist/capabilitiesOps.js';
+
+async function writeSkill(root, relativeDir, name, description, heading) {
+  const dir = path.join(root, relativeDir);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'SKILL.md'), [
+    '---',
+    `name: ${name}`,
+    `description: ${description}`,
+    '---',
+    '',
+    `# ${heading}`,
+    ''
+  ].join('\n'), 'utf8');
+}
+
+function onlySkill(inventory, name) {
+  const matches = inventory.filter((skill) => skill.name === name);
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one active ${name}, found ${matches.length}: ${JSON.stringify(matches)}`);
+  }
+  return matches[0];
+}
+
+const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-workspace-'));
+const homeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-home-'));
+
+try {
+  await writeSkill(workspaceRoot, path.join('.codex', 'skills', 'smoke-skill'), 'smoke-skill', 'Preferred workspace skill.', 'Workspace Codex Skill');
+  await writeSkill(workspaceRoot, path.join('.agents', 'skills', 'smoke-skill'), 'smoke-skill', 'Suppressed workspace duplicate.', 'Workspace Agents Duplicate');
+  await writeSkill(homeRoot, path.join('.codex', 'skills', 'smoke-skill'), 'smoke-skill', 'Suppressed user duplicate.', 'User Duplicate');
+  await writeSkill(homeRoot, path.join('.agents', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Preferred user-global skill.', 'User Global Preferred Skill');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'smoke-skill'), 'smoke-skill', 'Suppressed plugin duplicate.', 'Plugin Smoke Duplicate');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Suppressed plugin global duplicate.', 'Plugin Global Duplicate');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'First plugin copy.', 'Plugin First Copy');
+  await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-b', '2.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'Second plugin copy.', 'Plugin Second Copy');
+
+  const workspace = {
+    id: 'skill-precedence-smoke',
+    root: workspaceRoot,
+    openedAt: new Date().toISOString()
+  };
+  const discoveryOptions = { includeGlobal: true, maxSkills: 50, homeDir: homeRoot };
+  const inventory = await discoverSkillInventory(workspace, discoveryOptions);
+
+  const workspaceWinner = onlySkill(inventory, 'smoke-skill');
+  if (workspaceWinner.source !== 'workspace' || workspaceWinner.path !== '$WORKSPACE/.codex/skills/smoke-skill/SKILL.md') {
+    throw new Error(`workspace precedence winner was wrong: ${JSON.stringify(workspaceWinner)}`);
+  }
+
+  const userWinner = onlySkill(inventory, 'global-smoke-skill');
+  if (userWinner.source !== 'user' || userWinner.path !== '~/.agents/skills/global-smoke-skill/SKILL.md') {
+    throw new Error(`user precedence winner was wrong: ${JSON.stringify(userWinner)}`);
+  }
+
+  const pluginWinner = onlySkill(inventory, 'plugin-only-skill');
+  if (pluginWinner.source !== 'plugin') {
+    throw new Error(`plugin duplicate was not reduced to one plugin winner: ${JSON.stringify(pluginWinner)}`);
+  }
+
+  const loadedWorkspace = await loadSkill(workspace, { name: 'smoke-skill', maxSkills: 50, homeDir: homeRoot });
+  if (!loadedWorkspace.text.includes('# Workspace Codex Skill')) {
+    throw new Error(`name-only load did not choose the workspace winner: ${loadedWorkspace.skill.path}`);
+  }
+
+  const loadedUser = await loadSkill(workspace, { name: 'global-smoke-skill', maxSkills: 50, homeDir: homeRoot });
+  if (!loadedUser.text.includes('# User Global Preferred Skill')) {
+    throw new Error(`name-only load did not choose the user winner: ${loadedUser.skill.path}`);
+  }
+
+  const loadedPluginOverride = await loadSkill(workspace, {
+    name: 'global-smoke-skill',
+    source: 'plugin',
+    maxSkills: 50,
+    homeDir: homeRoot
+  });
+  if (!loadedPluginOverride.text.includes('# Plugin Global Duplicate')) {
+    throw new Error(`source override did not load the suppressed plugin copy: ${loadedPluginOverride.skill.path}`);
+  }
+
+  const loadedPathOverride = await loadSkill(workspace, {
+    name: 'smoke-skill',
+    path: '$WORKSPACE/.agents/skills/smoke-skill/SKILL.md',
+    maxSkills: 50,
+    homeDir: homeRoot
+  });
+  if (!loadedPathOverride.text.includes('# Workspace Agents Duplicate')) {
+    throw new Error(`path override did not load the suppressed workspace copy: ${loadedPathOverride.skill.path}`);
+  }
+
+  console.log('✓ skill precedence smoke test passed');
+} finally {
+  await fs.rm(workspaceRoot, { recursive: true, force: true });
+  await fs.rm(homeRoot, { recursive: true, force: true });
+}

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -654,7 +654,8 @@ for (let attempt = 0; attempt < 12; attempt += 1) {
     throw new Error(`apply_patch did not share the per-file write lock: ${JSON.stringify(raceResults)}`);
   }
   const finalText = await fs.readFile(path.join(tmp, 'patch-race.txt'), 'utf8');
-  if (finalText !== edited && finalText !== patched) {
+  const normalizedFinalText = finalText.replaceAll('\r\n', '\n');
+  if (normalizedFinalText !== edited && normalizedFinalText !== patched) {
     throw new Error(`apply_patch race produced a lost or partial update: ${JSON.stringify(finalText)}`);
   }
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -398,15 +398,17 @@ for (const legacyToolCardUri of legacyToolCardUris) {
 }
 const current = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
 const realTmp = await fs.realpath(tmp);
-if (current.structuredContent.root !== realTmp) throw new Error(`open_current_workspace opened ${current.structuredContent.root}, expected ${realTmp}`);
+const realOpenedRoot = await fs.realpath(current.structuredContent.root);
+if (realOpenedRoot.toLowerCase() !== realTmp.toLowerCase()) throw new Error(`open_current_workspace opened ${current.structuredContent.root}, expected ${realTmp}`);
 if (current.structuredContent.codexpro_tool !== 'open_current_workspace') throw new Error('tool result was not tagged for widget rendering');
 if (current.structuredContent.tool_mode !== 'full') throw new Error(`open_current_workspace did not expose tool_mode: ${current.structuredContent.tool_mode}`);
 if (current.structuredContent.skill_inventory?.length) {
   throw new Error('open_current_workspace discovered skills by default');
 }
 const currentWithSkills = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false, include_skills: true } });
-if (!currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'smoke-skill')) {
-  throw new Error('open_current_workspace did not discover workspace skill inventory when requested');
+const activeSmokeSkills = currentWithSkills.structuredContent.skill_inventory?.filter?.((skill) => skill.name === 'smoke-skill') ?? [];
+if (activeSmokeSkills.length !== 1 || activeSmokeSkills[0].source !== 'workspace') {
+  throw new Error(`open_current_workspace did not expose exactly one workspace smoke-skill: ${JSON.stringify(activeSmokeSkills)}`);
 }
 if (currentWithSkills.structuredContent.skill_inventory?.some?.((skill) => skill.name === 'outside-skill')) {
   throw new Error('open_current_workspace followed a symlinked workspace skill root outside the workspace');
@@ -461,17 +463,22 @@ const snapshotAlias = await client.request('tools/call', {
 if (!snapshotAlias.structuredContent.tree) {
   throw new Error('workspace_snapshot did not accept max_files alias or return a tree');
 }
-await expectToolError('load_skill', { name: 'smoke-skill', source: 'workspace' }, /Multiple skills named smoke-skill/);
 const loadedSkill = await client.request('tools/call', {
+  name: 'load_skill',
+  arguments: { name: 'smoke-skill' }
+});
+if (loadedSkill.structuredContent.skill?.source !== 'workspace' || !loadedSkill.structuredContent.text?.includes('# Smoke Skill')) {
+  throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
+}
+const suppressedSkill = await client.request('tools/call', {
   name: 'load_skill',
   arguments: {
     name: 'smoke-skill',
-    source: 'workspace',
-    path: '$WORKSPACE/.codex/skills/smoke-skill/SKILL.md'
+    path: '$WORKSPACE/.agents/skills/smoke-skill/SKILL.md'
   }
 });
-if (loadedSkill.structuredContent.skill?.name !== 'smoke-skill' || !loadedSkill.structuredContent.text?.includes('# Smoke Skill')) {
-  throw new Error('load_skill did not return bounded SKILL.md content for smoke-skill');
+if (!suppressedSkill.structuredContent.text?.includes('# Duplicate Smoke Skill')) {
+  throw new Error('load_skill path override did not load the suppressed workspace duplicate');
 }
 await expectToolError('load_skill', { name: 'missing-skill' }, /Skill not found/);
 await expectToolError('load_skill', { name: 'outside-skill', source: 'workspace', include_global_skills: false }, /Skill not found/);
@@ -935,7 +942,9 @@ const pwdBashText = pwdBash.content?.[0]?.text ?? '';
 if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwdBashText.includes('## stderr')) {
   throw new Error(`default bash transcript should be compact: ${pwdBashText}`);
 }
-if (!pwdBash.structuredContent.stdout?.includes(path.basename(tmp))) {
+const normalizedPwd = (pwdBash.structuredContent.stdout ?? '').trim().replace(/^\/([A-Za-z])\//, '$1:/').replaceAll('/', path.sep).toLowerCase();
+const normalizedTmp = tmp.replaceAll('/', path.sep).toLowerCase();
+if (!normalizedPwd.includes(normalizedTmp)) {
   throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
 }
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
@@ -1319,7 +1328,8 @@ await fullTranscriptClient.request('initialize', {
 fullTranscriptClient.notify('notifications/initialized');
 const fullTranscriptBash = await fullTranscriptClient.request('tools/call', { name: 'bash', arguments: { command: 'pwd' } });
 const fullTranscriptText = fullTranscriptBash.content?.[0]?.text ?? '';
-if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(path.basename(tmp))) {
+const normalizedFullTranscriptText = fullTranscriptText.replace(/\/([A-Za-z])\//g, '$1:/').replaceAll('/', path.sep).toLowerCase();
+if (!fullTranscriptText.includes('## stdout') || !normalizedFullTranscriptText.includes(normalizedTmp)) {
   throw new Error(`full bash transcript mode did not preserve raw stdout in chat text: ${fullTranscriptText}`);
 }
 fullTranscriptClient.close();

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -942,9 +942,9 @@ const pwdBashText = pwdBash.content?.[0]?.text ?? '';
 if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwdBashText.includes('## stderr')) {
   throw new Error(`default bash transcript should be compact: ${pwdBashText}`);
 }
-const normalizedPwd = (pwdBash.structuredContent.stdout ?? '').trim().replace(/^\/([A-Za-z])\//, '$1:/').replaceAll('/', path.sep).toLowerCase();
-const normalizedTmp = tmp.replaceAll('/', path.sep).toLowerCase();
-if (!normalizedPwd.includes(normalizedTmp)) {
+const normalizedPwd = (pwdBash.structuredContent.stdout ?? '').trim().replaceAll('\\', '/').toLowerCase();
+const expectedPwdLeaf = path.basename(tmp).toLowerCase();
+if (!normalizedPwd.endsWith(`/${expectedPwdLeaf}`)) {
   throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
 }
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
@@ -1328,8 +1328,8 @@ await fullTranscriptClient.request('initialize', {
 fullTranscriptClient.notify('notifications/initialized');
 const fullTranscriptBash = await fullTranscriptClient.request('tools/call', { name: 'bash', arguments: { command: 'pwd' } });
 const fullTranscriptText = fullTranscriptBash.content?.[0]?.text ?? '';
-const normalizedFullTranscriptText = fullTranscriptText.replace(/\/([A-Za-z])\//g, '$1:/').replaceAll('/', path.sep).toLowerCase();
-if (!fullTranscriptText.includes('## stdout') || !normalizedFullTranscriptText.includes(normalizedTmp)) {
+const fullTranscriptStdout = (fullTranscriptBash.structuredContent.stdout ?? '').trim();
+if (!fullTranscriptText.includes('## stdout') || !fullTranscriptStdout || !fullTranscriptText.includes(fullTranscriptStdout)) {
   throw new Error(`full bash transcript mode did not preserve raw stdout in chat text: ${fullTranscriptText}`);
 }
 fullTranscriptClient.close();

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -935,7 +935,7 @@ const pwdBashText = pwdBash.content?.[0]?.text ?? '';
 if (!pwdBashText.includes('Exit: 0') || pwdBashText.includes('## stdout') || pwdBashText.includes('## stderr')) {
   throw new Error(`default bash transcript should be compact: ${pwdBashText}`);
 }
-if (!pwdBash.structuredContent.stdout?.includes(tmp)) {
+if (!pwdBash.structuredContent.stdout?.includes(path.basename(tmp))) {
   throw new Error(`compact bash transcript dropped structured stdout: ${JSON.stringify(pwdBash.structuredContent)}`);
 }
 await expectToolError('bash', { workspace_id: ws, command: 'find /tmp' }, /blocked/i);
@@ -1319,7 +1319,7 @@ await fullTranscriptClient.request('initialize', {
 fullTranscriptClient.notify('notifications/initialized');
 const fullTranscriptBash = await fullTranscriptClient.request('tools/call', { name: 'bash', arguments: { command: 'pwd' } });
 const fullTranscriptText = fullTranscriptBash.content?.[0]?.text ?? '';
-if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(tmp)) {
+if (!fullTranscriptText.includes('## stdout') || !fullTranscriptText.includes(path.basename(tmp))) {
   throw new Error(`full bash transcript mode did not preserve raw stdout in chat text: ${fullTranscriptText}`);
 }
 fullTranscriptClient.close();

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -107,7 +107,9 @@ async function makeFixture() {
   await fs.writeFile(path.join(root, 'AGENTS.md'), '# Stress Agents\n\nKeep checks local.\n', 'utf8');
   await fs.writeFile(path.join(root, 'demo.txt'), 'alpha\n--flag root\narrow -> value\n', 'utf8');
   await fs.writeFile(path.join(root, '.hidden.txt'), 'needle hidden\n', 'utf8');
-  await fs.writeFile(path.join(root, 'visible:123:file.txt'), 'needle colon path\n', 'utf8');
+  if (process.platform !== 'win32') {
+    await fs.writeFile(path.join(root, 'visible:123:file.txt'), 'needle colon path\n', 'utf8');
+  }
   await fs.mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
   await fs.writeFile(path.join(root, '.github', 'workflows', 'ci.yml'), 'name: ci\n', 'utf8');
   await fs.mkdir(path.join(root, 'many'), { recursive: true });
@@ -207,11 +209,13 @@ async function runFullModeStress(root) {
     });
     assert(hiddenSearch.structuredContent.matches.some((match) => match.path === '.hidden.txt'), 'include_hidden search missed hidden file');
 
-    const colonSearch = await client.request('tools/call', {
-      name: 'search',
-      arguments: { workspace_id: ws, query: 'needle colon path', max_results: 10 }
-    });
-    assert(colonSearch.structuredContent.matches.some((match) => match.path === 'visible:123:file.txt' && match.line === 1), `colon path search parsed incorrectly: ${JSON.stringify(colonSearch.structuredContent.matches)}`);
+    if (process.platform !== 'win32') {
+      const colonSearch = await client.request('tools/call', {
+        name: 'search',
+        arguments: { workspace_id: ws, query: 'needle colon path', max_results: 10 }
+      });
+      assert(colonSearch.structuredContent.matches.some((match) => match.path === 'visible:123:file.txt' && match.line === 1), `colon path search parsed incorrectly: ${JSON.stringify(colonSearch.structuredContent.matches)}`);
+    }
 
     const superRead = await client.request('tools/call', {
       name: 'codexpro',
@@ -456,7 +460,10 @@ async function runMcpInventoryStress() {
   await fs.writeFile(path.join(fakeHome, '.codex', 'config.toml'), toml, 'utf8');
   await fs.writeFile(path.join(fakeHome, '.cursor', 'mcp.json'), JSON.stringify({ mcpServers: cursorServers }), 'utf8');
 
-  const client = await initClient(root, { HOME: fakeHome });
+  const client = await initClient(root, {
+    HOME: fakeHome,
+    ...(process.platform === 'win32' ? { USERPROFILE: fakeHome } : {})
+  });
   try {
     const opened = await client.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
     const inventory = await client.request('tools/call', {

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -412,7 +412,7 @@ async function runGlobalSkillStress(root) {
     assert(loadedByName.structuredContent.text.includes('# Global Only Skill'), 'load_skill did not load unique user skill by name');
   } finally {
     client?.close();
-    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 }
 
@@ -630,7 +630,7 @@ async function runBashOutputTerminationStress() {
     assert(retainedBytes < 9000, `output-limited bash retained too much output: ${retainedBytes} bytes`);
   } finally {
     client.close();
-    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 }
 
@@ -854,7 +854,7 @@ async function runAnalysisBudgetStress() {
     assert(limitedOutput.structuredContent.warnings.some((warning) => warning.includes('Structured output was limited')), 'inspect output limit did not report a warning');
   } finally {
     client.close();
-    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 }
 

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -3,6 +3,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+const REQUEST_TIMEOUT_MS = process.platform === 'win32' ? 45_000 : 20_000;
+
 function assert(ok, message) {
   if (!ok) throw new Error(message);
 }
@@ -68,7 +70,11 @@ class McpStdioClient {
     const id = this.nextId++;
     this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
     return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error(`timeout waiting for ${method}\n${this.stderr}`)), 20000);
+      const operation = method === 'tools/call' && params?.name ? `${method}:${params.name}` : method;
+      const timer = setTimeout(
+        () => reject(new Error(`timeout waiting for ${operation} after ${REQUEST_TIMEOUT_MS} ms\n${this.stderr}`)),
+        REQUEST_TIMEOUT_MS
+      );
       timer.unref();
       this.pending.set(id, { resolve, reject, timer });
     });

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -203,7 +203,10 @@ function trimOutput(value: string, maxBytes: number): { value: string; truncated
 function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
   if (!child.pid) return;
   if (process.platform === "win32") {
-    const args = ["/pid", String(child.pid), "/t", ...(signal === "SIGKILL" ? ["/f"] : [])];
+    // Windows does not provide Unix-style cooperative signals to process trees.
+    // Force the full tree while the parent PID still identifies its descendants;
+    // otherwise the shell can exit first and orphan an output-heavy grandchild.
+    const args = ["/pid", String(child.pid), "/t", "/f"];
     const result = spawnSync("taskkill", args, { stdio: "ignore", windowsHide: true });
     if (result.status !== 0) child.kill(signal);
     return;

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -14,6 +14,7 @@ export interface SkillInventoryItem {
 
 interface SkillInventoryRecord extends SkillInventoryItem {
   absPath: string;
+  precedence: number;
 }
 
 export interface LoadedSkill {
@@ -89,8 +90,7 @@ function realpathOrUndefined(filePath: string): string | undefined {
   }
 }
 
-function displayPath(absPath: string, workspaceRoot: string): string {
-  const home = os.homedir();
+function displayPath(absPath: string, workspaceRoot: string, home = os.homedir()): string {
   if (absPath === workspaceRoot) return "$WORKSPACE";
   if (absPath.startsWith(`${workspaceRoot}${path.sep}`)) {
     return `$WORKSPACE/${path.relative(workspaceRoot, absPath).split(path.sep).join("/")}`;
@@ -102,10 +102,10 @@ function displayPath(absPath: string, workspaceRoot: string): string {
   return absPath;
 }
 
-function skillSource(skillPath: string, workspaceRoot: string): SkillInventoryItem["source"] {
+function skillSource(skillPath: string, workspaceRoot: string, home = os.homedir()): SkillInventoryItem["source"] {
   if (skillPath.startsWith(`${workspaceRoot}${path.sep}`)) return "workspace";
   if (skillPath.includes(`${path.sep}.codex${path.sep}plugins${path.sep}`)) return "plugin";
-  if (skillPath.startsWith(`${os.homedir()}${path.sep}`)) return "user";
+  if (skillPath.startsWith(`${home}${path.sep}`)) return "user";
   return "other";
 }
 
@@ -124,6 +124,19 @@ function compareSkills(a: SkillInventoryItem, b: SkillInventoryItem): number {
   );
 }
 
+function compareSkillPrecedence(a: SkillInventoryRecord, b: SkillInventoryRecord): number {
+  return (
+    a.precedence - b.precedence ||
+    skillSourceRank(a.source) - skillSourceRank(b.source) ||
+    a.name.localeCompare(b.name) ||
+    a.path.localeCompare(b.path)
+  );
+}
+
+function activeSkillRecords(records: SkillInventoryRecord[]): SkillInventoryRecord[] {
+  return unique([...records].sort(compareSkillPrecedence), (item) => item.name).sort(compareSkills);
+}
+
 function publicSkill(record: SkillInventoryRecord): SkillInventoryItem {
   return {
     name: record.name,
@@ -138,28 +151,35 @@ function frontmatterValue(text: string, key: string): string | undefined {
   return match?.[1]?.trim().replace(/^["']|["']$/g, "");
 }
 
-async function findSkillFiles(root: string, maxDepth: number, out: string[], maxItems: number): Promise<void> {
+async function findSkillFiles(
+  root: string,
+  maxDepth: number,
+  out: Array<{ file: string; precedence: number }>,
+  maxItems: number,
+  precedence: number
+): Promise<void> {
   if (out.length >= maxItems || maxDepth < 0) return;
-  const entries = await safeReaddir(root);
+  const entries = (await safeReaddir(root)).sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {
     if (out.length >= maxItems) return;
     if (entry.name === "node_modules" || entry.name === ".git") continue;
     const abs = path.join(root, entry.name);
     if (entry.isFile() && entry.name === "SKILL.md") {
-      out.push(abs);
+      out.push({ file: abs, precedence });
       continue;
     }
     if (entry.isDirectory()) {
-      await findSkillFiles(abs, maxDepth - 1, out, maxItems);
+      await findSkillFiles(abs, maxDepth - 1, out, maxItems, precedence);
     }
   }
 }
 
 async function discoverSkillRecords(
   workspace: Workspace,
-  options: { includeGlobal?: boolean; maxSkills?: number } = {}
+  options: { includeGlobal?: boolean; maxSkills?: number; homeDir?: string } = {}
 ): Promise<SkillInventoryRecord[]> {
   const maxSkills = Math.max(1, Math.min(options.maxSkills ?? 120, 500));
+  const homeDir = options.homeDir ?? os.homedir();
   const workspaceRoots = [
     path.join(workspace.root, ".codex", "skills"),
     path.join(workspace.root, ".agents", "skills"),
@@ -172,21 +192,28 @@ async function discoverSkillRecords(
     ...workspaceRoots,
     ...(options.includeGlobal
       ? [
-          path.join(os.homedir(), ".codex", "skills"),
-          path.join(os.homedir(), ".agents", "skills"),
-          path.join(os.homedir(), ".codex", "plugins", "cache")
+          path.join(homeDir, ".codex", "skills"),
+          path.join(homeDir, ".agents", "skills"),
+          path.join(homeDir, ".codex", "plugins", "cache")
         ]
       : [])
   ].filter((dir) => fs.existsSync(dir));
 
-  const skillFiles: string[] = [];
-  for (const root of roots) {
-    await findSkillFiles(root, root.includes(`${path.sep}plugins${path.sep}cache`) ? 9 : 3, skillFiles, maxSkills);
+  const skillFiles: Array<{ file: string; precedence: number }> = [];
+  for (const [precedence, root] of roots.entries()) {
+    await findSkillFiles(
+      root,
+      root.includes(`${path.sep}plugins${path.sep}cache`) ? 9 : 3,
+      skillFiles,
+      maxSkills,
+      precedence
+    );
     if (skillFiles.length >= maxSkills) break;
   }
 
   const items: SkillInventoryRecord[] = [];
-  for (const file of skillFiles.slice(0, maxSkills)) {
+  for (const discovered of skillFiles.slice(0, maxSkills)) {
+    const file = discovered.file;
     const realFile = realpathOrUndefined(file) ?? file;
     if (isSubpath(file, workspace.root) && !isSubpath(realFile, workspace.root)) continue;
     let text = "";
@@ -200,20 +227,21 @@ async function discoverSkillRecords(
     items.push({
       name,
       description,
-      source: skillSource(realFile, workspace.root),
-      path: displayPath(realFile, workspace.root),
-      absPath: realFile
+      source: skillSource(realFile, workspace.root, homeDir),
+      path: displayPath(realFile, workspace.root, homeDir),
+      absPath: realFile,
+      precedence: discovered.precedence
     });
   }
 
-  return unique(items, (item) => `${item.source}:${item.name}:${item.path}`).sort(compareSkills);
+  return unique(items, (item) => `${item.source}:${item.name}:${item.path}`).sort(compareSkillPrecedence);
 }
 
 export async function discoverSkillInventory(
   workspace: Workspace,
-  options: { includeGlobal?: boolean; maxSkills?: number } = {}
+  options: { includeGlobal?: boolean; maxSkills?: number; homeDir?: string } = {}
 ): Promise<SkillInventoryItem[]> {
-  return (await discoverSkillRecords(workspace, options)).map(publicSkill);
+  return activeSkillRecords(await discoverSkillRecords(workspace, options)).map(publicSkill);
 }
 
 export async function loadSkill(
@@ -225,6 +253,7 @@ export async function loadSkill(
     includeGlobal?: boolean;
     maxSkills?: number;
     maxBytes?: number;
+    homeDir?: string;
   }
 ): Promise<LoadedSkill> {
   const name = options.name.trim();
@@ -233,16 +262,21 @@ export async function loadSkill(
 
   const records = await discoverSkillRecords(workspace, {
     includeGlobal: options.includeGlobal !== false,
-    maxSkills: options.maxSkills
+    maxSkills: options.maxSkills,
+    homeDir: options.homeDir
   });
-  const matches = records.filter(
+  const activeRecords = activeSkillRecords(records);
+  const candidateRecords = requestedPath
+    ? records
+    : activeSkillRecords(options.source ? records.filter((skill) => skill.source === options.source) : records);
+  const matches = candidateRecords.filter(
     (skill) =>
       skill.name === name &&
       (!options.source || skill.source === options.source) &&
       (!requestedPath || skill.path === requestedPath)
   );
   if (!matches.length) {
-    const near = records
+    const near = activeRecords
       .filter((skill) => skill.name.toLowerCase().includes(name.toLowerCase()))
       .slice(0, 8)
       .map((skill) => `${skill.name} [${skill.source}]`)
@@ -252,7 +286,7 @@ export async function loadSkill(
   }
   if (matches.length > 1) {
     const choices = matches.map((skill) => `${skill.name} [${skill.source}] at ${skill.path}`).join("; ");
-    throw new Error(`Multiple skills named ${name} were found. Pass source and path to choose one: ${choices}`);
+    throw new Error(`Multiple exact skill matches remained for ${name}: ${choices}`);
   }
 
   const [skill] = matches;

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -179,14 +179,16 @@ async function discoverSkillRecords(
   options: { includeGlobal?: boolean; maxSkills?: number; homeDir?: string } = {}
 ): Promise<SkillInventoryRecord[]> {
   const maxSkills = Math.max(1, Math.min(options.maxSkills ?? 120, 500));
-  const homeDir = options.homeDir ?? os.homedir();
+  const workspaceRoot = realpathOrUndefined(workspace.root) ?? path.resolve(workspace.root);
+  const requestedHomeDir = options.homeDir ?? os.homedir();
+  const homeDir = realpathOrUndefined(requestedHomeDir) ?? path.resolve(requestedHomeDir);
   const workspaceRoots = [
-    path.join(workspace.root, ".codex", "skills"),
-    path.join(workspace.root, ".agents", "skills"),
-    path.join(workspace.root, "skills")
+    path.join(workspaceRoot, ".codex", "skills"),
+    path.join(workspaceRoot, ".agents", "skills"),
+    path.join(workspaceRoot, "skills")
   ].flatMap((dir) => {
     const real = realpathOrUndefined(dir);
-    return real && isSubpath(real, workspace.root) ? [real] : [];
+    return real && isSubpath(real, workspaceRoot) ? [real] : [];
   });
   const roots = [
     ...workspaceRoots,
@@ -215,7 +217,7 @@ async function discoverSkillRecords(
   for (const discovered of skillFiles.slice(0, maxSkills)) {
     const file = discovered.file;
     const realFile = realpathOrUndefined(file) ?? file;
-    if (isSubpath(file, workspace.root) && !isSubpath(realFile, workspace.root)) continue;
+    if (isSubpath(file, workspaceRoot) && !isSubpath(realFile, workspaceRoot)) continue;
     let text = "";
     try {
       text = await safeReadText(realFile);
@@ -227,8 +229,8 @@ async function discoverSkillRecords(
     items.push({
       name,
       description,
-      source: skillSource(realFile, workspace.root, homeDir),
-      path: displayPath(realFile, workspace.root, homeDir),
+      source: skillSource(realFile, workspaceRoot, homeDir),
+      path: displayPath(realFile, workspaceRoot, homeDir),
       absPath: realFile,
       precedence: discovered.precedence
     });
@@ -295,7 +297,8 @@ export async function loadSkill(
   }
   if (skill.source === "workspace") {
     const realSkillPath = realpathOrUndefined(skill.absPath);
-    if (!realSkillPath || !isSubpath(realSkillPath, workspace.root)) {
+    const realWorkspaceRoot = realpathOrUndefined(workspace.root) ?? path.resolve(workspace.root);
+    if (!realSkillPath || !isSubpath(realSkillPath, realWorkspaceRoot)) {
       throw new Error(`Refusing to load workspace skill outside workspace: ${skill.path}`);
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,7 +143,7 @@ function toRealDir(input: string): string {
   if (!stat.isDirectory()) {
     throw new Error(`Not a directory: ${resolved}`);
   }
-  return fs.realpathSync(resolved);
+  return fs.realpathSync.native(resolved);
 }
 
 function numberFrom(value: string | undefined, fallback: number, min: number, max: number): number {

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -42,7 +42,7 @@ function workspaceIdForRoot(realRoot: string): string {
 
 function maybeRealpath(existingPath: string): string | undefined {
   try {
-    return fs.realpathSync(existingPath);
+    return fs.realpathSync.native(existingPath);
   } catch {
     return undefined;
   }
@@ -85,7 +85,7 @@ export class WorkspaceManager {
     if (!stat.isDirectory()) {
       throw new CodexProError(`Workspace root is not a directory: ${resolved}`);
     }
-    const realRoot = fs.realpathSync(resolved);
+    const realRoot = fs.realpathSync.native(resolved);
     const allowed = this.config.allowedRoots.some((allowedRoot) => isSubpath(realRoot, allowedRoot));
     if (!allowed) {
       throw new CodexProError(

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -40,6 +40,7 @@ export interface WorkspaceProfile {
 export interface RuntimeConnection {
   version?: number;
   root?: string;
+  pid?: number;
   updatedAt?: string;
   endpoint?: string;
   localBase?: string;
@@ -137,5 +138,23 @@ export function readRuntimeConnection(root: string): RuntimeConnection {
   if (!runtime || typeof runtime !== "object" || Array.isArray(runtime)) return {};
   const typed = runtime as RuntimeConnection;
   if (typed.root && typed.root !== root) return {};
+  if (typeof typed.pid === "number" && !processIsAlive(typed.pid)) {
+    try {
+      fs.rmSync(runtimePath, { force: true });
+    } catch {
+      // Best-effort stale runtime cleanup.
+    }
+    return {};
+  }
   return typed;
+}
+
+function processIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && typeof error === "object" && "code" in error && error.code === "EPERM");
+  }
 }

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -66,8 +66,17 @@ export function profileDir(): string {
   return path.join(codexProHome(), "profiles");
 }
 
+function canonicalRootForIdentity(root: string): string {
+  const resolved = path.resolve(root);
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 export function profileIdForRoot(root: string): string {
-  return createHash("sha256").update(root).digest("hex").slice(0, 24);
+  return createHash("sha256").update(canonicalRootForIdentity(root)).digest("hex").slice(0, 24);
 }
 
 export function profilePathForRoot(root: string): string {
@@ -97,20 +106,21 @@ export function readWorkspaceProfile(root: string): WorkspaceProfile {
   const profile = readJsonFile(profilePath);
   if (!profile || typeof profile !== "object" || Array.isArray(profile)) return {};
   const typed = profile as WorkspaceProfile;
-  if (typed.root && typed.root !== root) return {};
+  if (typed.root && canonicalRootForIdentity(typed.root) !== canonicalRootForIdentity(root)) return {};
   return { ...typed, profilePath };
 }
 
 export function saveWorkspaceProfile(root: string, profile: WorkspaceProfile): string {
+  const canonicalRoot = canonicalRootForIdentity(root);
   const dir = profileDir();
-  const filePath = profilePathForRoot(root);
+  const filePath = profilePathForRoot(canonicalRoot);
   const { profilePath: _profilePath, ...rest } = profile;
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const payload: WorkspaceProfile = {
     version: 1,
     updatedAt: new Date().toISOString(),
     ...rest,
-    root
+    root: canonicalRoot
   };
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
   try {
@@ -137,7 +147,7 @@ export function readRuntimeConnection(root: string): RuntimeConnection {
   const runtime = readJsonFile(runtimePath);
   if (!runtime || typeof runtime !== "object" || Array.isArray(runtime)) return {};
   const typed = runtime as RuntimeConnection;
-  if (typed.root && typed.root !== root) return {};
+  if (typed.root && canonicalRootForIdentity(typed.root) !== canonicalRootForIdentity(root)) return {};
   if (typeof typed.pid === "number" && !processIsAlive(typed.pid)) {
     try {
       fs.rmSync(runtimePath, { force: true });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1343,8 +1343,8 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       inputSchema: {
         workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
         name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
-        source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source when multiple skills share a name."),
-        path: z.string().optional().describe("Exact sanitized path from skill_inventory when name/source are still ambiguous."),
+        source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source override. Without it, the highest-precedence skill is loaded."),
+        path: z.string().optional().describe("Optional exact sanitized path override for diagnostics or an explicitly selected suppressed duplicate."),
         include_global_skills: z.boolean().optional().describe("Also scan installed user/plugin skills. Default: auto when source/path is not workspace."),
         max_skills: z.number().int().min(1).max(500).optional().describe("Maximum skills to scan while resolving the requested skill. Default: 500."),
         max_bytes: z.number().int().min(1000).max(100000).optional().describe("Maximum bytes to return from SKILL.md. Default: 40000.")


### PR DESCRIPTION
## Summary

- add Ubuntu and Windows CI coverage plus cross-platform smoke and stress fixtures
- terminate Windows tunnel shim process trees and discard stale runtime status
- choose one deterministic active skill per name, preferring workspace skills over user and plugin copies
- preserve explicit source and path overrides for intentionally loading suppressed duplicate skills
- fix macOS and Windows canonical-path behavior discovered while validating the contributed changes

## Contributor credit

- @Zawonyee authored the Windows CI and runtime hardening in PR #69. Integrated commits `058e7f5` and `ebe401b` on `main` retain Zao's author metadata.
- @misaka310 authored the workspace skill precedence behavior in PR #77. Integrated commit `9c50c60` on `main` retains misaka310's author metadata.
- The maintainer commits resolve current-main conflicts and fix portability failures found by the combined CI matrix.

## Why

The original branches were based on an older `main` and conflicted after PR #79. This PR is the integration branch that preserves their authorship while resolving those conflicts against the current release.

## Validation

- `npm ci`
- `npm run build`
- all smoke suites, including `skill-precedence-smoke`
- `npm run stress`
- `npm audit --audit-level=high` - 0 vulnerabilities
- `npm run release:pack`
- `git diff --check`
- GitHub Actions on Ubuntu and Windows

Integrates and supersedes #69 and #77.
