### PR TITLE
feat: support symlinked skill directories

### DIFF
--- a/scripts/skill-precedence-smoke.mjs
+++ b/scripts/skill-precedence-smoke.mjs
@@ -37,6 +37,13 @@ try {
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Suppressed plugin global duplicate.', 'Plugin Global Duplicate');
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'First plugin copy.', 'Plugin First Copy');
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-b', '2.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'Second plugin copy.', 'Plugin Second Copy');
+  const linkedSkillDir = path.join(homeRoot, '.cc-switch', 'skills', 'linked-skill');
+  await writeSkill(homeRoot, path.join('.cc-switch', 'skills', 'linked-skill'), 'linked-skill', 'Symlinked user skill.', 'Symlinked User Skill');
+  await fs.symlink(
+    linkedSkillDir,
+    path.join(homeRoot, '.codex', 'skills', 'linked-skill'),
+    process.platform === 'win32' ? 'junction' : 'dir'
+  );
 
   const workspace = {
     id: 'skill-precedence-smoke',
@@ -61,6 +68,11 @@ try {
     throw new Error(`plugin duplicate was not reduced to one plugin winner: ${JSON.stringify(pluginWinner)}`);
   }
 
+  const linkedSkill = onlySkill(inventory, 'linked-skill');
+  if (linkedSkill.source !== 'user' || linkedSkill.path !== '~/.cc-switch/skills/linked-skill/SKILL.md') {
+    throw new Error(`symlinked user skill was not discovered through its real directory: ${JSON.stringify(linkedSkill)}`);
+  }
+
   const loadedWorkspace = await loadSkill(workspace, { name: 'smoke-skill', maxSkills: 50, homeDir: homeRoot });
   if (!loadedWorkspace.text.includes('# Workspace Codex Skill')) {
     throw new Error(`name-only load did not choose the workspace winner: ${loadedWorkspace.skill.path}`);
@@ -69,6 +81,11 @@ try {
   const loadedUser = await loadSkill(workspace, { name: 'global-smoke-skill', maxSkills: 50, homeDir: homeRoot });
   if (!loadedUser.text.includes('# User Global Preferred Skill')) {
     throw new Error(`name-only load did not choose the user winner: ${loadedUser.skill.path}`);
+  }
+
+  const loadedLinkedSkill = await loadSkill(workspace, { name: 'linked-skill', maxSkills: 50, homeDir: homeRoot });
+  if (!loadedLinkedSkill.text.includes('# Symlinked User Skill')) {
+    throw new Error(`name-only load did not follow the symlinked skill directory: ${loadedLinkedSkill.skill.path}`);
   }
 
   const loadedPluginOverride = await loadSkill(workspace, {

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -170,6 +170,17 @@ async function findSkillFiles(
     }
     if (entry.isDirectory()) {
       await findSkillFiles(abs, maxDepth - 1, out, maxItems, precedence);
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      try {
+        const target = await fsp.realpath(abs);
+        if ((await fsp.stat(target)).isDirectory()) {
+          await findSkillFiles(target, maxDepth - 1, out, maxItems, precedence);
+        }
+      } catch {
+        // Ignore broken or inaccessible skill directory links.
+      }
     }
   }
 }


### PR DESCRIPTION
## Current behavior

CodexPro discovers skills by recursively scanning configured skill roots, including `~/.codex/skills`.

Some skill managers, such as cc-switch, install skills by creating directory symlinks under `~/.codex/skills`. These entries are reported as symbolic links rather than regular directories and are therefore not included in the skill inventory.

## New capability

CodexPro now supports skill directories installed through symbolic links.

The skill scanner:

- Detects directory symlinks during discovery.
- Resolves each link with `realpath`.
- Uses `stat` to confirm that the target is a directory before scanning it.
- Ignores broken, inaccessible, and non-directory links.
- Makes discovered skills available through both the skill inventory and `load_skill`.

Regression coverage includes discovering and loading a symlinked user skill.

## Security impact

This capability affects read-only skill discovery. A directory symlink under a configured skill root may cause CodexPro to scan its target for `SKILL.md`.

Existing scan depth and item limits remain in effect. Broken or inaccessible links are ignored. Authentication, shell execution, write operations, and tunnel behavior are unchanged.

## Testing

- [x] `npm run build`
- [x] `npm run smoke`
- [x] Verified that `open_current_workspace` with `include_skills=true` and `include_global_skills=true` discovers a cc-switch symlinked skill
- [x] Verified that `load_skill` loads the resolved `SKILL.md`

## Documentation

No documentation changes are included because this extends discovery within an existing skill root without adding commands, flags, or configuration.