### PR TITLE
release: codexpro 0.30.0 user issue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Rejected invalid relative `HOME` values such as `=` in restricted bash child environments, prefer a usable absolute `USERPROFILE`/`HOME`, and forward Windows `APPDATA`/`LOCALAPPDATA` when valid so npm cache dirs are not created inside workspaces.
 - Raised the bash `timeout_ms` hard cap from 180s to 10 minutes by default (max 15 minutes via `CODEXPRO_MAX_BASH_TIMEOUT_MS`). Per-command default remains 30s.
 - Follow directory symlinks under configured skill roots during skill discovery so managers such as cc-switch can install skills as links. Thanks @yuczzzzz. Keep symlinked/junction skills tagged by their configured scan root and accept both realpathed and caller-supplied home spellings so Windows junctions keep `user` / `~/` identity.
+- Added `import_file` for ChatGPT Apps SDK attachments (`openai/fileParams`), with HTTPS host allowlisting, redirect revalidation, streaming size limits, SHA-256 checks, MIME sniffing, and workspace write-mode gating.
 - Documented update steps (`npm install -g codexpro@latest`), ChatGPT web Agent vs CodexPro, and dual-account / dual-tunnel process separation in the English and Chinese FAQs.
 - Updated transitive dependencies so `npm audit --audit-level=high` reports zero known vulnerabilities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.
 - Rejected invalid relative `HOME` values such as `=` in restricted bash child environments, prefer a usable absolute `USERPROFILE`/`HOME`, and forward Windows `APPDATA`/`LOCALAPPDATA` when valid so npm cache dirs are not created inside workspaces.
 - Raised the bash `timeout_ms` hard cap from 180s to 10 minutes by default (max 15 minutes via `CODEXPRO_MAX_BASH_TIMEOUT_MS`). Per-command default remains 30s.
-- Follow directory symlinks under configured skill roots during skill discovery so managers such as cc-switch can install skills as links. Thanks @yuczzzzz.
+- Follow directory symlinks under configured skill roots during skill discovery so managers such as cc-switch can install skills as links. Thanks @yuczzzzz. Classify resolved skill paths with case-insensitive root checks so Windows junctions keep `user` / `~/` identity.
 - Documented update steps (`npm install -g codexpro@latest`), ChatGPT web Agent vs CodexPro, and dual-account / dual-tunnel process separation in the English and Chinese FAQs.
 - Updated transitive dependencies so `npm audit --audit-level=high` reports zero known vulnerabilities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.
 - Rejected invalid relative `HOME` values such as `=` in restricted bash child environments, prefer a usable absolute `USERPROFILE`/`HOME`, and forward Windows `APPDATA`/`LOCALAPPDATA` when valid so npm cache dirs are not created inside workspaces.
 - Raised the bash `timeout_ms` hard cap from 180s to 10 minutes by default (max 15 minutes via `CODEXPRO_MAX_BASH_TIMEOUT_MS`). Per-command default remains 30s.
-- Follow directory symlinks under configured skill roots during skill discovery so managers such as cc-switch can install skills as links. Thanks @yuczzzzz. Classify resolved skill paths with case-insensitive root checks so Windows junctions keep `user` / `~/` identity.
+- Follow directory symlinks under configured skill roots during skill discovery so managers such as cc-switch can install skills as links. Thanks @yuczzzzz. Keep symlinked/junction skills tagged by their configured scan root and accept both realpathed and caller-supplied home spellings so Windows junctions keep `user` / `~/` identity.
 - Documented update steps (`npm install -g codexpro@latest`), ChatGPT web Agent vs CodexPro, and dual-account / dual-tunnel process separation in the English and Chinese FAQs.
 - Updated transitive dependencies so `npm audit --audit-level=high` reports zero known vulnerabilities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.30.0 (2026-08-08)
+
+- Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.
+- Rejected invalid relative `HOME` values such as `=` in restricted bash child environments, prefer a usable absolute `USERPROFILE`/`HOME`, and forward Windows `APPDATA`/`LOCALAPPDATA` when valid so npm cache dirs are not created inside workspaces.
+- Raised the bash `timeout_ms` hard cap from 180s to 10 minutes by default (max 15 minutes via `CODEXPRO_MAX_BASH_TIMEOUT_MS`). Per-command default remains 30s.
+- Follow directory symlinks under configured skill roots during skill discovery so managers such as cc-switch can install skills as links. Thanks @yuczzzzz.
+- Documented update steps (`npm install -g codexpro@latest`), ChatGPT web Agent vs CodexPro, and dual-account / dual-tunnel process separation in the English and Chinese FAQs.
+- Updated transitive dependencies so `npm audit --audit-level=high` reports zero known vulnerabilities.
+
 - Added saved additional projects with `codexpro settings set --project <path>`, session-local workspace selection through the existing `open_workspace` tool, and `--clear-projects` for removing the saved allowlist.
 - Isolated workspace selection between HTTP MCP sessions while preserving explicit workspace-id access for configured roots, with stdio, HTTP, profile, and regression coverage.
 - Added native workspace image inspection for PNG, JPEG, GIF, and WebP files through `view_image`.

--- a/FAQ.md
+++ b/FAQ.md
@@ -88,6 +88,29 @@ codexpro start
 
 `npx codexpro@latest start` still works as a no-install fallback, but the global install is easier for normal users.
 
+## How do I update CodexPro?
+
+There is no `codexpro update` command. Reinstall the latest package and restart the connector:
+
+```bash
+npm install -g codexpro@latest
+codexpro --version
+```
+
+Then stop the old process and run `codexpro start` again from the launch repo. Saved profiles under `~/.codexpro` stay in place.
+
+If docs mention a feature that `codexpro --version` does not include yet, GitHub `main` is ahead of npm `latest`. Wait for the next release or install from the tagged GitHub release.
+
+## How is CodexPro different from ChatGPT's built-in web Agent?
+
+They solve different jobs.
+
+ChatGPT's web Agent is for browsing, web research, and general web tasks. By default it cannot open a local Git repo on your machine, read `AGENTS.md`, inspect your current branch/`git diff`, run local verification commands, or keep edits inside an allowed workspace.
+
+CodexPro is a local MCP bridge: your ChatGPT session talks to an approved folder on your computer through Developer Mode / Plugins. It does not replace the web Agent, bypass account limits, or turn ChatGPT into a remote shell service.
+
+Use the web Agent for web work. Use CodexPro when the source of truth is a local repository.
+
 ## What do I enable in ChatGPT?
 
 Open ChatGPT and go to:
@@ -298,24 +321,30 @@ The same hostname and CodexPro token are reused for that workspace.
 For convenient switching through one connector, save the additional projects on the launch workspace:
 
 ```bash
-codexpro settings set --project ~/code/repo-b --project ~/code/repo-c
+cd ~/code/app
+codexpro settings set --project ~/code/web --project ~/code/api
+codexpro settings show
 codexpro start
 ```
 
-Ask ChatGPT to open an allowed project. `open_workspace` makes it the selected project for that MCP session, and later tools can omit `workspace_id`. `open_current_workspace` switches back to the launch project.
+Confirm `Projects` lists the extra roots, then restart the connector so the admin page Allowed Roots list refreshes. Ask ChatGPT to open an allowed project. `open_workspace` makes it the selected project for that MCP session, and later tools can omit `workspace_id`. `open_current_workspace` switches back to the launch project.
+
+`--clear-projects` removes the saved extra roots from that launch workspace profile:
+
+```bash
+codexpro settings set --clear-projects
+```
 
 Workspace selection is isolated between MCP sessions created by the client. A ChatGPT conversation is not guaranteed to map one-to-one to an MCP session, so use separate CodexPro processes when strict isolation matters.
 
-For separate processes, use different local ports and different tunnel hostnames.
-
-Example:
+For separate processes, two ChatGPT accounts, or two ngrok domains on one machine, run two CodexPro processes with different local ports and different public hostnames:
 
 ```text
-repo A: port 8787, hostname A
-repo B: port 8788, hostname B
+repo A: port 8787, hostname A, ChatGPT plugin URL A
+repo B: port 8788, hostname B, ChatGPT plugin URL B
 ```
 
-Run `codexpro setup` in each repo and save a profile per workspace.
+Run `codexpro setup` in each repo and save a profile per workspace. Do not reuse one Server URL across both accounts.
 
 ## How do multiple ChatGPT sessions avoid overwriting each other?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -111,6 +111,29 @@ CodexPro is a local MCP bridge: your ChatGPT session talks to an approved folder
 
 Use the web Agent for web work. Use CodexPro when the source of truth is a local repository.
 
+## How do I import a ChatGPT attachment into my repo?
+
+In workspace write mode, CodexPro advertises `import_file`. ChatGPT must pass an Apps SDK file object:
+
+```json
+{
+  "download_url": "https://...",
+  "file_id": "file_...",
+  "mime_type": "image/png",
+  "file_name": "screenshot.png"
+}
+```
+
+CodexPro marks that argument with `_meta["openai/fileParams"]`. It downloads only temporary HTTPS URLs from approved ChatGPT/OpenAI file hosts, enforces `CODEXPRO_MAX_IMPORT_BYTES`, rejects private/loopback redirect targets, and writes into the allowed workspace only. Overwrite defaults to false. Arbitrary user- or model-supplied download URLs are rejected.
+
+Example destination:
+
+```text
+docs/evidence/screenshot.png
+```
+
+If the client does not provide `download_url` and `file_id`, the tool returns an unsupported-reference error and creates no files.
+
 ## What do I enable in ChatGPT?
 
 Open ChatGPT and go to:

--- a/FAQ_ZH.md
+++ b/FAQ_ZH.md
@@ -53,6 +53,23 @@ CodexPro 是本地 MCP bridge：用你自己的 ChatGPT 会话，通过 Develope
 
 网页工作用网页 Agent；本地仓库是事实来源时用 CodexPro。
 
+## 怎么把 ChatGPT 附件导入仓库？
+
+在 workspace write 模式下，CodexPro 会暴露 `import_file`。ChatGPT 需要传入 Apps SDK 文件对象：
+
+```json
+{
+  "download_url": "https://...",
+  "file_id": "file_...",
+  "mime_type": "image/png",
+  "file_name": "screenshot.png"
+}
+```
+
+该参数通过 `_meta["openai/fileParams"]` 声明。CodexPro 只会从已批准的 ChatGPT/OpenAI 文件域名下载临时 HTTPS URL，遵守 `CODEXPRO_MAX_IMPORT_BYTES`，拒绝私网/回环重定向，并且只写入已允许的工作区。默认不允许覆盖。任意用户或模型自行提供的下载 URL 会被拒绝。
+
+如果客户端没有同时提供 `download_url` 和 `file_id`，工具会返回 unsupported-reference 错误，并且不会创建任何文件。
+
 ## ChatGPT 里要打开什么设置？
 
 在 ChatGPT 中打开：

--- a/FAQ_ZH.md
+++ b/FAQ_ZH.md
@@ -30,6 +30,29 @@ codexpro start
 
 `npx codexpro@latest start` 仍然可用，但普通用户更容易理解全局安装。
 
+## 怎么更新 CodexPro？
+
+没有 `codexpro update` 命令。重新安装最新包并重启连接即可：
+
+```bash
+npm install -g codexpro@latest
+codexpro --version
+```
+
+然后停掉旧进程，在启动仓库里重新运行 `codexpro start`。`~/.codexpro` 下的已保存配置会保留。
+
+如果文档写了某个功能，但 `codexpro --version` 还没有，说明 GitHub `main` 比 npm `latest` 新。等下一版发布，或从带 tag 的 GitHub release 安装。
+
+## CodexPro 和网页版自带 Agent 有什么区别？
+
+用途不同。
+
+ChatGPT 网页版 Agent 适合浏览、网页研究和通用网页任务。默认情况下，它不能打开你电脑上的本地 Git 仓库，不能读 `AGENTS.md`，不能看当前分支/`git diff`，也不能在你批准的本地工作区内做受控编辑或跑本地验证命令。
+
+CodexPro 是本地 MCP bridge：用你自己的 ChatGPT 会话，通过 Developer Mode / Plugins 连接你电脑上明确允许的仓库。它不是网页 Agent 的替代品，也不绕过账号限制，更不是远程 shell 服务。
+
+网页工作用网页 Agent；本地仓库是事实来源时用 CodexPro。
+
 ## ChatGPT 里要打开什么设置？
 
 在 ChatGPT 中打开：
@@ -232,25 +255,31 @@ Cloudflare quick tunnel 是一次性的临时地址。每次重新启动 tunnel�
 
 ## 同时跑两个仓库怎么办？
 
-如果只是希望通过同一个 connector 切换项目，可以先在主项目保存额外项目：
+如果只是希望通过同一个 connector 切换项目，先在启动仓库保存额外项目：
 
 ```bash
-codexpro settings set --project ~/code/repo-b --project ~/code/repo-c
+cd ~/code/app
+codexpro settings set --project ~/code/web --project ~/code/api
+codexpro settings show
 codexpro start
 ```
 
-`open_workspace` 会把已允许的项目设为当前 MCP session 的选择。之后其他工具可以省略 `workspace_id`。`open_current_workspace` 会切回启动时的主项目。
+确认输出里的 `Projects` 列出了额外根目录，然后重启 connector，管理页 Allowed Roots 才会刷新。让 ChatGPT 打开已允许的项目。`open_workspace` 会把它设为当前 MCP session 的选择，之后其他工具可以省略 `workspace_id`。`open_current_workspace` 会切回启动时的主项目。
 
-项目选择按 MCP session 隔离，但 ChatGPT conversation 不保证和 MCP session 一一对应。需要严格隔离时，请为每个仓库使用不同本地端口和不同 tunnel hostname。
+清除已保存的额外项目：
 
-示例：
-
-```text
-repo A: port 8787, hostname A
-repo B: port 8788, hostname B
+```bash
+codexpro settings set --clear-projects
 ```
 
-分别在两个仓库里运行 `codexpro setup` 并保存 profile。
+项目选择按 MCP session 隔离，但 ChatGPT conversation 不保证和 MCP session 一一对应。需要严格隔离、两个 ChatGPT 账号、或两个 ngrok 域名时，请跑两个 CodexPro 进程，并用不同本地端口和不同公网 hostname：
+
+```text
+repo A: port 8787, hostname A, ChatGPT plugin URL A
+repo B: port 8788, hostname B, ChatGPT plugin URL B
+```
+
+分别在两个仓库里运行 `codexpro setup` 并保存 profile。不要把同一个 Server URL 给两个账号共用。
 
 ## 多个 ChatGPT session 怎么避免互相覆盖？
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ CodexPro starts a local MCP server for the current workspace. ChatGPT can then:
 - read files and inspect the repo
 - search code
 - make scoped edits with `write`, `edit`, or guarded `apply_patch`
+- import ChatGPT Apps SDK attachments with `import_file` in workspace write mode
 - run safe verification commands through `bash`
 - review changed files with `show_changes`
 - write handoff plans under `.ai-bridge`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,8 @@ CodexPro can expose:
 - git status and diffs
 - `.ai-bridge` planning files
 - optional shell command execution through the `bash` tool, hidden when bash mode is off
-- optional write/edit/apply_patch capability depending on `CODEXPRO_WRITE_MODE`, advertised only in workspace write mode
+- optional write/edit/apply_patch/import_file capability depending on `CODEXPRO_WRITE_MODE`, advertised only in workspace write mode
+- optional ChatGPT attachment import through `import_file`, which downloads only platform-provided HTTPS file references from approved origins and never accepts arbitrary model-supplied URLs
 - optional local handoff execution through `codexpro execute-handoff`, run from the user's terminal only
 - optional local execute/review looping through `codexpro loop-handoff`, run from the user's terminal only with a user-provided reviewer command and iteration limit
 

--- a/config.example.env
+++ b/config.example.env
@@ -4,6 +4,8 @@ CODEXPRO_ALLOWED_ROOTS=/absolute/path/to/your/repo
 CODEXPRO_HOST=127.0.0.1
 CODEXPRO_PORT=8787
 CODEXPRO_BASH_MODE=safe
+# Optional hard cap for bash tool timeout_ms. Default 600000 (10m), max 900000 (15m).
+# CODEXPRO_MAX_BASH_TIMEOUT_MS=600000
 # Optional local bash session guard. If required, bash tool calls must include the matching session_id.
 # CODEXPRO_BASH_SESSION_ID=main
 # CODEXPRO_REQUIRE_BASH_SESSION=1

--- a/config.example.env
+++ b/config.example.env
@@ -6,6 +6,11 @@ CODEXPRO_PORT=8787
 CODEXPRO_BASH_MODE=safe
 # Optional hard cap for bash tool timeout_ms. Default 600000 (10m), max 900000 (15m).
 # CODEXPRO_MAX_BASH_TIMEOUT_MS=600000
+# Max bytes for import_file ChatGPT attachment downloads. Default 5000000.
+# CODEXPRO_MAX_IMPORT_BYTES=5000000
+# Extra approved HTTPS hosts for import_file, comma-separated. Loopback stays blocked unless explicitly enabled for tests.
+# CODEXPRO_IMPORT_ALLOWED_HOSTS=files.oaiusercontent.com
+# CODEXPRO_IMPORT_ALLOW_LOOPBACK=0
 # Optional local bash session guard. If required, bash tool calls must include the matching session_id.
 # CODEXPRO_BASH_SESSION_ID=main
 # CODEXPRO_REQUIRE_BASH_SESSION=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexpro",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexpro",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1077,9 +1077,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1229,9 +1229,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1280,9 +1280,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexpro",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "A local MCP/App SDK-style connector that lets ChatGPT inspect, edit, and hand off work to Codex inside a local dev workspace.",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "start:http": "node dist/http.js",
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
-    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
+    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/import-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
     "stress": "npm run build && node scripts/stress.mjs",
     "analysis:smoke": "npm run build && node scripts/analysis-smoke.mjs",
     "analysis:cli-smoke": "npm run build && node scripts/analysis-cli-smoke.mjs",

--- a/scripts/import-smoke.mjs
+++ b/scripts/import-smoke.mjs
@@ -1,0 +1,291 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+);
+const pngSha = createHash('sha256').update(png).digest('hex');
+
+class McpStdioClient {
+  constructor(command, args, options = {}) {
+    this.child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    this.buffer = '';
+    this.nextId = 1;
+    this.pending = new Map();
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', (chunk) => {
+      this.buffer += chunk;
+      while (true) {
+        const index = this.buffer.indexOf('\n');
+        if (index < 0) break;
+        const line = this.buffer.slice(0, index).trim();
+        this.buffer = this.buffer.slice(index + 1);
+        if (!line) continue;
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id == null) continue;
+        const pending = this.pending.get(message.id);
+        if (!pending) continue;
+        this.pending.delete(message.id);
+        if (message.error) pending.reject(new Error(JSON.stringify(message.error)));
+        else pending.resolve(message.result);
+      }
+    });
+  }
+
+  request(method, params = {}) {
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params });
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(`${payload}\n`);
+    });
+  }
+
+  notify(method, params = {}) {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+  }
+
+  close() {
+    this.child.stdin.end();
+    this.child.kill('SIGTERM');
+  }
+}
+
+function startFixtureServer(payload, options = {}) {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (options.redirectTo) {
+        res.statusCode = 302;
+        res.setHeader('Location', options.redirectTo);
+        res.end();
+        return;
+      }
+      if (options.oversizedHeader) {
+        res.statusCode = 200;
+        res.setHeader('Content-Length', String(options.oversizedHeader));
+        res.setHeader('Content-Type', 'application/octet-stream');
+        res.end(payload);
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('Content-Type', options.contentType ?? 'image/png');
+      res.end(payload);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        server,
+        url: `http://127.0.0.1:${port}/fixture.png`,
+        close: () => new Promise((done) => server.close(() => done()))
+      });
+    });
+  });
+}
+
+const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-import-smoke-'));
+const {
+  assertSafeImportUrl,
+  detectMimeType,
+  importAttachmentFile,
+  mimeTypeStatus,
+  parseAttachmentFileReference
+} = await import(pathToFileURL(path.join(path.resolve('.'), 'dist', 'importOps.js')).href);
+const { loadConfig } = await import(pathToFileURL(path.join(path.resolve('.'), 'dist', 'config.js')).href);
+const { PathGuard, WorkspaceManager } = await import(pathToFileURL(path.join(path.resolve('.'), 'dist', 'guard.js')).href);
+
+try {
+  try {
+    parseAttachmentFileReference('file_abc');
+    throw new Error('bare file id should be rejected');
+  } catch (error) {
+    if (!String(error.message).includes('Unsupported attachment reference')) throw error;
+  }
+
+  try {
+    await assertSafeImportUrl('https://evil.example/file.bin');
+    throw new Error('unapproved host should be rejected');
+  } catch (error) {
+    if (!String(error.message).includes('approved ChatGPT file origin')) throw error;
+  }
+
+  try {
+    await assertSafeImportUrl('http://127.0.0.1/file.bin');
+    throw new Error('loopback should be rejected by default');
+  } catch (error) {
+    if (!String(error.message).includes('HTTPS') && !String(error.message).includes('blocked')) throw error;
+  }
+
+  if (detectMimeType(png) !== 'image/png') throw new Error('PNG detection failed');
+  if (mimeTypeStatus('image/png', 'image/png') !== 'matched') throw new Error('matched mime status failed');
+  if (mimeTypeStatus('image/jpeg', 'image/png') !== 'mismatched') throw new Error('mismatched mime status failed');
+  if (mimeTypeStatus(undefined, null) !== 'unknown') throw new Error('unknown mime status failed');
+
+  const fixture = await startFixtureServer(png);
+  const redirectFixture = await startFixtureServer(png);
+  const redirector = await startFixtureServer(png, { redirectTo: redirectFixture.url });
+  try {
+    const config = loadConfig(['--root', root, '--write', 'workspace', '--bash', 'off']);
+    const guard = new PathGuard(config);
+    const workspace = new WorkspaceManager(config).defaultWorkspace();
+    const env = { ...process.env, CODEXPRO_IMPORT_ALLOW_LOOPBACK: '1' };
+
+    const imported = await importAttachmentFile(config, guard, workspace, {
+      file: {
+        download_url: fixture.url,
+        file_id: 'file_smoke_png',
+        mime_type: 'image/png',
+        file_name: 'fixture.png'
+      },
+      destination: 'docs/evidence/fixture.png',
+      expectedSha256: pngSha,
+      env
+    });
+    if (imported.sha256 !== pngSha || imported.mime_type_status !== 'matched' || imported.bytes !== png.byteLength) {
+      throw new Error(`PNG import failed: ${JSON.stringify(imported)}`);
+    }
+    const saved = await fs.readFile(path.join(root, 'docs/evidence/fixture.png'));
+    if (!saved.equals(png)) throw new Error('saved PNG bytes mismatch');
+
+    try {
+      await importAttachmentFile(config, guard, workspace, {
+        file: {
+          download_url: fixture.url,
+          file_id: 'file_smoke_png',
+          mime_type: 'image/png'
+        },
+        destination: 'docs/evidence/fixture.png',
+        env
+      });
+      throw new Error('default no-overwrite should fail');
+    } catch (error) {
+      if (!String(error.message).includes('overwrite=false')) throw error;
+    }
+
+    const overwritten = await importAttachmentFile(config, guard, workspace, {
+      file: {
+        download_url: fixture.url,
+        file_id: 'file_smoke_png',
+        mime_type: 'image/png'
+      },
+      destination: 'docs/evidence/fixture.png',
+      overwrite: true,
+      env
+    });
+    if (!overwritten.overwritten) throw new Error('overwrite path did not report overwritten');
+
+    const redirected = await importAttachmentFile(config, guard, workspace, {
+      file: {
+        download_url: redirector.url,
+        file_id: 'file_smoke_redirect',
+        mime_type: 'image/png'
+      },
+      destination: 'docs/evidence/redirected.png',
+      env
+    });
+    if (redirected.sha256 !== pngSha) throw new Error(`redirect import failed: ${JSON.stringify(redirected)}`);
+
+    const tinyConfig = {
+      ...config,
+      maxImportBytes: 8
+    };
+    try {
+      await importAttachmentFile(tinyConfig, guard, workspace, {
+        file: {
+          download_url: fixture.url,
+          file_id: 'file_smoke_oversize',
+          mime_type: 'image/png'
+        },
+        destination: 'docs/evidence/too-big.png',
+        env
+      });
+      throw new Error('oversized import should fail');
+    } catch (error) {
+      if (!String(error.message).includes('too large') && !String(error.message).includes('exceeded import size')) {
+        throw error;
+      }
+    }
+
+    const client = new McpStdioClient(process.execPath, ['dist/stdio.js', '--root', root, '--allow-root', root, '--write', 'workspace', '--bash', 'off'], {
+      cwd: path.resolve('.'),
+      env: {
+        ...process.env,
+        CODEXPRO_ROOT: root,
+        CODEXPRO_ALLOWED_ROOTS: root,
+        CODEXPRO_WRITE_MODE: 'workspace',
+        CODEXPRO_IMPORT_ALLOW_LOOPBACK: '1',
+        CODEXPRO_ALLOW_NO_HTTP_TOKEN: '1'
+      }
+    });
+    try {
+      await client.request('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'codexpro-import-smoke', version: '0.1.0' }
+      });
+      client.notify('notifications/initialized');
+      const tools = await client.request('tools/list', {});
+      const importTool = tools.tools.find((tool) => tool.name === 'import_file');
+      if (!importTool) throw new Error('import_file tool missing');
+      const fileParams = importTool._meta?.['openai/fileParams'] ?? importTool.annotations?._meta?.['openai/fileParams'];
+      const metaFileParams = importTool._meta?.['openai/fileParams'];
+      // MCP SDK may nest meta differently; accept descriptor presence via tools/list raw shape.
+      const listedMeta = importTool._meta || {};
+      if (!Array.isArray(listedMeta['openai/fileParams']) || !listedMeta['openai/fileParams'].includes('file')) {
+        // Some SDK versions expose _meta only after unwrap; still require the tool schema file object.
+        const props = importTool.inputSchema?.properties?.file?.properties;
+        if (!props?.download_url || !props?.file_id) {
+          throw new Error(`import_file missing fileParams/schema: ${JSON.stringify(importTool)}`);
+        }
+      }
+      const opened = await client.request('tools/call', {
+        name: 'open_current_workspace',
+        arguments: { include_tree: false }
+      });
+      const viaTool = await client.request('tools/call', {
+        name: 'import_file',
+        arguments: {
+          workspace_id: opened.structuredContent.workspace_id,
+          file: {
+            download_url: fixture.url,
+            file_id: 'file_smoke_tool',
+            mime_type: 'image/png',
+            file_name: 'tool.png'
+          },
+          destination: 'docs/evidence/tool.png'
+        }
+      });
+      if (viaTool.isError) throw new Error(`import_file tool failed: ${JSON.stringify(viaTool)}`);
+      if (viaTool.structuredContent.sha256 !== pngSha) {
+        throw new Error(`import_file tool hash mismatch: ${JSON.stringify(viaTool.structuredContent)}`);
+      }
+      if (String(JSON.stringify(viaTool)).includes(fixture.url)) {
+        throw new Error('import_file result leaked download_url');
+      }
+    } finally {
+      client.close();
+    }
+  } finally {
+    await fixture.close();
+    await redirectFixture.close();
+    await redirector.close();
+  }
+
+  console.log('✓ import smoke test passed');
+} finally {
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/scripts/skill-precedence-smoke.mjs
+++ b/scripts/skill-precedence-smoke.mjs
@@ -37,6 +37,13 @@ try {
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Suppressed plugin global duplicate.', 'Plugin Global Duplicate');
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'First plugin copy.', 'Plugin First Copy');
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-b', '2.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'Second plugin copy.', 'Plugin Second Copy');
+  const linkedSkillDir = path.join(homeRoot, '.cc-switch', 'skills', 'linked-skill');
+  await writeSkill(homeRoot, path.join('.cc-switch', 'skills', 'linked-skill'), 'linked-skill', 'Symlinked user skill.', 'Symlinked User Skill');
+  await fs.symlink(
+    linkedSkillDir,
+    path.join(homeRoot, '.codex', 'skills', 'linked-skill'),
+    process.platform === 'win32' ? 'junction' : 'dir'
+  );
 
   const workspace = {
     id: 'skill-precedence-smoke',
@@ -61,6 +68,11 @@ try {
     throw new Error(`plugin duplicate was not reduced to one plugin winner: ${JSON.stringify(pluginWinner)}`);
   }
 
+  const linkedSkill = onlySkill(inventory, 'linked-skill');
+  if (linkedSkill.source !== 'user' || linkedSkill.path !== '~/.cc-switch/skills/linked-skill/SKILL.md') {
+    throw new Error(`symlinked user skill was not discovered through its real directory: ${JSON.stringify(linkedSkill)}`);
+  }
+
   const loadedWorkspace = await loadSkill(workspace, { name: 'smoke-skill', maxSkills: 50, homeDir: homeRoot });
   if (!loadedWorkspace.text.includes('# Workspace Codex Skill')) {
     throw new Error(`name-only load did not choose the workspace winner: ${loadedWorkspace.skill.path}`);
@@ -69,6 +81,11 @@ try {
   const loadedUser = await loadSkill(workspace, { name: 'global-smoke-skill', maxSkills: 50, homeDir: homeRoot });
   if (!loadedUser.text.includes('# User Global Preferred Skill')) {
     throw new Error(`name-only load did not choose the user winner: ${loadedUser.skill.path}`);
+  }
+
+  const loadedLinkedSkill = await loadSkill(workspace, { name: 'linked-skill', maxSkills: 50, homeDir: homeRoot });
+  if (!loadedLinkedSkill.text.includes('# Symlinked User Skill')) {
+    throw new Error(`name-only load did not follow the symlinked skill directory: ${loadedLinkedSkill.skill.path}`);
   }
 
   const loadedPluginOverride = await loadSkill(workspace, {

--- a/scripts/skill-precedence-smoke.mjs
+++ b/scripts/skill-precedence-smoke.mjs
@@ -25,8 +25,10 @@ function onlySkill(inventory, name) {
   return matches[0];
 }
 
-const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-workspace-'));
-const homeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-home-'));
+const workspaceRootRaw = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-workspace-'));
+const homeRootRaw = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-skill-home-'));
+const workspaceRoot = await fs.realpath(workspaceRootRaw);
+const homeRoot = await fs.realpath(homeRootRaw);
 
 try {
   await writeSkill(workspaceRoot, path.join('.codex', 'skills', 'smoke-skill'), 'smoke-skill', 'Preferred workspace skill.', 'Workspace Codex Skill');
@@ -37,10 +39,11 @@ try {
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'global-smoke-skill'), 'global-smoke-skill', 'Suppressed plugin global duplicate.', 'Plugin Global Duplicate');
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-a', '1.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'First plugin copy.', 'Plugin First Copy');
   await writeSkill(homeRoot, path.join('.codex', 'plugins', 'cache', 'test-plugin-b', '2.0.0', 'skills', 'plugin-only-skill'), 'plugin-only-skill', 'Second plugin copy.', 'Plugin Second Copy');
-  const linkedSkillDir = path.join(homeRoot, '.cc-switch', 'skills', 'linked-skill');
   await writeSkill(homeRoot, path.join('.cc-switch', 'skills', 'linked-skill'), 'linked-skill', 'Symlinked user skill.', 'Symlinked User Skill');
+  // Point the junction at the pre-realpath home spelling when it differs so
+  // Windows short/long path mismatches are exercised end-to-end.
   await fs.symlink(
-    linkedSkillDir,
+    path.join(homeRootRaw, '.cc-switch', 'skills', 'linked-skill'),
     path.join(homeRoot, '.codex', 'skills', 'linked-skill'),
     process.platform === 'win32' ? 'junction' : 'dir'
   );
@@ -50,7 +53,7 @@ try {
     root: workspaceRoot,
     openedAt: new Date().toISOString()
   };
-  const discoveryOptions = { includeGlobal: true, maxSkills: 50, homeDir: homeRoot };
+  const discoveryOptions = { includeGlobal: true, maxSkills: 50, homeDir: homeRootRaw };
   const inventory = await discoverSkillInventory(workspace, discoveryOptions);
 
   const workspaceWinner = onlySkill(inventory, 'smoke-skill');

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -236,7 +236,7 @@ await client.request('initialize', {
 client.notify('notifications/initialized');
 const tools = await client.request('tools/list', {});
 const toolNames = tools.tools.map((tool) => tool.name);
-for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'inspect_workspace', 'tree', 'search', 'load_skill', 'read', 'view_image', 'write', 'edit', 'apply_patch', 'bash', 'git_status', 'git_diff', 'show_changes', 'read_handoff', 'wait_for_handoff', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
+for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'inspect_workspace', 'tree', 'search', 'load_skill', 'read', 'view_image', 'write', 'edit', 'apply_patch', 'import_file', 'bash', 'git_status', 'git_diff', 'show_changes', 'read_handoff', 'wait_for_handoff', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
   if (!toolNames.includes(expected)) throw new Error(`missing tool: ${expected}`);
 }
 const toolCardUri = 'ui://widget/codexpro-tool-card-v10.html';
@@ -1198,8 +1198,8 @@ async function assertToolMode(mode, expected, hidden, extraEnv = {}) {
   modeClient.close();
 }
 
-await assertToolMode('', ['codexpro', 'server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'inspect_workspace', 'tree', 'search', 'load_skill', 'read', 'view_image', 'write', 'edit', 'apply_patch', 'bash', 'show_changes', 'read_handoff', 'wait_for_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
-await assertToolMode('minimal', ['codexpro', 'server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'apply_patch', 'bash', 'show_changes'], ['inspect_workspace', 'tree', 'search', 'load_skill', 'view_image', 'read_handoff', 'wait_for_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
+await assertToolMode('', ['codexpro', 'server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'inspect_workspace', 'tree', 'search', 'load_skill', 'read', 'view_image', 'write', 'edit', 'apply_patch', 'import_file', 'bash', 'show_changes', 'read_handoff', 'wait_for_handoff', 'export_pro_context', 'handoff_to_agent'], ['codexpro_inventory', 'workspace_snapshot', 'git_status', 'git_diff', 'codex_context', 'handoff_to_codex']);
+await assertToolMode('minimal', ['codexpro', 'server_config', 'codexpro_self_test', 'open_current_workspace', 'open_workspace', 'read', 'write', 'edit', 'apply_patch', 'import_file', 'bash', 'show_changes'], ['inspect_workspace', 'tree', 'search', 'load_skill', 'view_image', 'read_handoff', 'wait_for_handoff', 'export_pro_context', 'handoff_to_agent', 'codex_context']);
 await assertToolMode('', ['codexpro', 'server_config', 'show_changes', 'search'], ['inspect_workspace'], { CODEXPRO_ANALYSIS: '0' });
 
 const handoffWriteClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--write', 'handoff'], {
@@ -1214,20 +1214,20 @@ await handoffWriteClient.request('initialize', {
 handoffWriteClient.notify('notifications/initialized');
 const handoffWriteTools = await handoffWriteClient.request('tools/list', {});
 const handoffWriteToolNames = handoffWriteTools.tools.map((tool) => tool.name);
-for (const hiddenWriteTool of ['write', 'edit', 'apply_patch']) {
+for (const hiddenWriteTool of ['write', 'edit', 'apply_patch', 'import_file']) {
   if (handoffWriteToolNames.includes(hiddenWriteTool)) {
     throw new Error(`--write handoff should not advertise ${hiddenWriteTool} tool; got ${handoffWriteToolNames.join(', ')}`);
   }
 }
 const handoffWriteConfig = await handoffWriteClient.request('tools/call', { name: 'server_config', arguments: {} });
-if (handoffWriteConfig.structuredContent.writeMode !== 'handoff' || handoffWriteConfig.structuredContent.registeredTools?.includes?.('write') || handoffWriteConfig.structuredContent.registeredTools?.includes?.('edit') || handoffWriteConfig.structuredContent.registeredTools?.includes?.('apply_patch')) {
+if (handoffWriteConfig.structuredContent.writeMode !== 'handoff' || handoffWriteConfig.structuredContent.registeredTools?.includes?.('write') || handoffWriteConfig.structuredContent.registeredTools?.includes?.('edit') || handoffWriteConfig.structuredContent.registeredTools?.includes?.('apply_patch') || handoffWriteConfig.structuredContent.registeredTools?.includes?.('import_file')) {
   throw new Error(`server_config did not report write handoff with hidden edit tools: ${JSON.stringify(handoffWriteConfig.structuredContent)}`);
 }
 const handoffSelfTest = await handoffWriteClient.request('tools/call', { name: 'codexpro_self_test', arguments: { write_probe: false, bash_probe: false, pro_context_probe: false } });
 if (handoffSelfTest.structuredContent.status === 'fail') {
   throw new Error(`codexpro_self_test failed under --write handoff: ${JSON.stringify(handoffSelfTest.structuredContent)}`);
 }
-for (const hiddenWriteTool of ['write', 'edit', 'apply_patch']) {
+for (const hiddenWriteTool of ['write', 'edit', 'apply_patch', 'import_file']) {
   if (handoffSelfTest.structuredContent.expected_tools?.includes?.(hiddenWriteTool) || handoffSelfTest.structuredContent.registered_tools?.includes?.(hiddenWriteTool)) {
     throw new Error(`codexpro_self_test exposed ${hiddenWriteTool} under --write handoff: ${JSON.stringify(handoffSelfTest.structuredContent)}`);
   }
@@ -1267,7 +1267,7 @@ await disabledWriteClient.request('initialize', {
 disabledWriteClient.notify('notifications/initialized');
 const disabledWriteTools = await disabledWriteClient.request('tools/list', {});
 const disabledWriteToolNames = disabledWriteTools.tools.map((tool) => tool.name);
-for (const hiddenWriteTool of ['write', 'edit', 'apply_patch']) {
+for (const hiddenWriteTool of ['write', 'edit', 'apply_patch', 'import_file']) {
   if (disabledWriteToolNames.includes(hiddenWriteTool)) {
     throw new Error(`--write off should not advertise ${hiddenWriteTool} tool; got ${disabledWriteToolNames.join(', ')}`);
   }
@@ -1280,7 +1280,7 @@ const disabledSelfTest = await disabledWriteClient.request('tools/call', { name:
 if (disabledSelfTest.structuredContent.status === 'fail') {
   throw new Error(`codexpro_self_test failed under --write off: ${JSON.stringify(disabledSelfTest.structuredContent)}`);
 }
-for (const hiddenWriteTool of ['write', 'edit', 'apply_patch']) {
+for (const hiddenWriteTool of ['write', 'edit', 'apply_patch', 'import_file']) {
   if (disabledSelfTest.structuredContent.expected_tools?.includes?.(hiddenWriteTool) || disabledSelfTest.structuredContent.registered_tools?.includes?.(hiddenWriteTool)) {
     throw new Error(`codexpro_self_test exposed ${hiddenWriteTool} under --write off: ${JSON.stringify(disabledSelfTest.structuredContent)}`);
   }

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -2,8 +2,10 @@ import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const REQUEST_TIMEOUT_MS = process.platform === 'win32' ? 45_000 : 20_000;
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function assert(ok, message) {
   if (!ok) throw new Error(message);
@@ -864,6 +866,36 @@ async function runAnalysisBudgetStress() {
   }
 }
 
+async function runBashHomeEnvStress() {
+  const { resolveUsableHomeDir, makeRestrictedBashEnv } = await import(pathToFileURL(path.join(repoRoot, 'dist', 'bashOps.js')).href);
+  const { loadConfig } = await import(pathToFileURL(path.join(repoRoot, 'dist', 'config.js')).href);
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-bash-home-root-'));
+  const realHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-stress-bash-home-'));
+  try {
+    const resolved = resolveUsableHomeDir({ HOME: '=', USERPROFILE: realHome });
+    assert(path.resolve(resolved) === path.resolve(realHome), `invalid HOME was not replaced: ${resolved}`);
+    const fallback = resolveUsableHomeDir({ HOME: '=' });
+    assert(path.isAbsolute(fallback) && fallback !== '=', `invalid HOME alone did not fall back: ${fallback}`);
+    const config = loadConfig(['--root', root, '--bash', 'full', '--write', 'off']);
+    assert(config.maxBashTimeoutMs === 600_000, `default bash timeout cap drifted: ${config.maxBashTimeoutMs}`);
+    const env = makeRestrictedBashEnv(config, {
+      HOME: '=',
+      USERPROFILE: realHome,
+      PATH: process.env.PATH,
+      APPDATA: path.join(realHome, 'AppData', 'Roaming'),
+      LOCALAPPDATA: path.join(realHome, 'AppData', 'Local')
+    });
+    assert(path.resolve(env.HOME) === path.resolve(realHome), `restricted env kept invalid HOME: ${env.HOME}`);
+    assert(!String(env.HOME).includes('='), `restricted HOME still looks relative: ${env.HOME}`);
+    if (process.platform === 'win32') {
+      assert(path.resolve(env.USERPROFILE) === path.resolve(realHome), `Windows USERPROFILE was wrong: ${env.USERPROFILE}`);
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    await fs.rm(realHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+}
+
 const root = await makeFixture();
 await runFullModeStress(root);
 await runGlobalSkillStress(root);
@@ -872,6 +904,7 @@ await runMcpInventoryStress();
 await runMaxReadSearchStress();
 await runNodeFallbackSearchLimitStress();
 await runBashOutputTerminationStress();
+await runBashHomeEnvStress();
 await runGuardEdgeStress();
 await runSupertoolModeStress(root);
 await runShowChangesStatsStress();

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
@@ -173,20 +174,65 @@ function assertBashSession(config: CodexProConfig, sessionId?: string): string |
   return config.bashSessionId;
 }
 
-function makeEnv(config: CodexProConfig): NodeJS.ProcessEnv {
-  if (config.inheritEnv) {
-    return { ...process.env, NO_COLOR: "1", CI: process.env.CI ?? "1" };
+function isUsableAbsoluteDir(candidate: string | undefined): string | undefined {
+  if (!candidate) return undefined;
+  const trimmed = candidate.trim();
+  if (!trimmed) return undefined;
+  if (!path.isAbsolute(trimmed) && !path.win32.isAbsolute(trimmed)) return undefined;
+  try {
+    const resolved = path.resolve(trimmed);
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) return resolved;
+  } catch {
+    // Ignore unreadable candidates and keep searching.
   }
-  return {
-    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-    HOME: process.env.HOME ?? "",
-    USER: process.env.USER ?? "",
-    SHELL: process.env.SHELL ?? "/bin/bash",
-    TMPDIR: process.env.TMPDIR ?? "/tmp",
+  return undefined;
+}
+
+/** Resolve a usable absolute home for restricted child processes. Rejects relative junk like "=". */
+export function resolveUsableHomeDir(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    isUsableAbsoluteDir(env.USERPROFILE) ??
+    isUsableAbsoluteDir(env.HOME) ??
+    isUsableAbsoluteDir(os.homedir()) ??
+    path.resolve(os.homedir())
+  );
+}
+
+export function makeRestrictedBashEnv(
+  config: CodexProConfig,
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  if (config.inheritEnv) {
+    return { ...env, NO_COLOR: "1", CI: env.CI ?? "1" };
+  }
+  const home = resolveUsableHomeDir(env);
+  const restricted: NodeJS.ProcessEnv = {
+    PATH: env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+    HOME: home,
+    USER: env.USER ?? env.USERNAME ?? "",
+    SHELL: env.SHELL ?? "/bin/bash",
+    TMPDIR: isUsableAbsoluteDir(env.TMPDIR) ?? isUsableAbsoluteDir(env.TMP) ?? os.tmpdir(),
     TERM: "dumb",
     NO_COLOR: "1",
     CI: "1"
   };
+  if (process.platform === "win32") {
+    restricted.USERPROFILE = home;
+    const appData = isUsableAbsoluteDir(env.APPDATA);
+    const localAppData = isUsableAbsoluteDir(env.LOCALAPPDATA);
+    if (appData) restricted.APPDATA = appData;
+    if (localAppData) restricted.LOCALAPPDATA = localAppData;
+    if (env.USERNAME) restricted.USERNAME = env.USERNAME;
+    if (env.HOMEDRIVE && env.HOMEPATH && path.win32.isAbsolute(path.win32.join(env.HOMEDRIVE, env.HOMEPATH))) {
+      restricted.HOMEDRIVE = env.HOMEDRIVE;
+      restricted.HOMEPATH = env.HOMEPATH;
+    }
+  }
+  return restricted;
+}
+
+function makeEnv(config: CodexProConfig): NodeJS.ProcessEnv {
+  return makeRestrictedBashEnv(config);
 }
 
 function bashExecutable(): string {
@@ -230,7 +276,7 @@ export async function runBash(
   assertSafeCommand(config, command);
   const cwdResolved = guard.resolve(workspace, options.cwd ?? ".");
   const cwd = cwdResolved.absPath;
-  const timeoutMs = Math.max(1_000, Math.min(options.timeoutMs ?? 30_000, 180_000));
+  const timeoutMs = Math.max(1_000, Math.min(options.timeoutMs ?? 30_000, config.maxBashTimeoutMs));
   const start = Date.now();
 
   return new Promise((resolve, reject) => {

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -91,21 +91,21 @@ function realpathOrUndefined(filePath: string): string | undefined {
 }
 
 function displayPath(absPath: string, workspaceRoot: string, home = os.homedir()): string {
-  if (absPath === workspaceRoot) return "$WORKSPACE";
-  if (absPath.startsWith(`${workspaceRoot}${path.sep}`)) {
+  if (absPath === workspaceRoot || isSubpath(absPath, workspaceRoot)) {
+    if (absPath === workspaceRoot) return "$WORKSPACE";
     return `$WORKSPACE/${path.relative(workspaceRoot, absPath).split(path.sep).join("/")}`;
   }
-  if (absPath === home) return "~";
-  if (absPath.startsWith(`${home}${path.sep}`)) {
+  if (absPath === home || isSubpath(absPath, home)) {
+    if (absPath === home) return "~";
     return `~/${path.relative(home, absPath).split(path.sep).join("/")}`;
   }
   return absPath;
 }
 
 function skillSource(skillPath: string, workspaceRoot: string, home = os.homedir()): SkillInventoryItem["source"] {
-  if (skillPath.startsWith(`${workspaceRoot}${path.sep}`)) return "workspace";
+  if (skillPath === workspaceRoot || isSubpath(skillPath, workspaceRoot)) return "workspace";
   if (skillPath.includes(`${path.sep}.codex${path.sep}plugins${path.sep}`)) return "plugin";
-  if (skillPath.startsWith(`${home}${path.sep}`)) return "user";
+  if (skillPath === home || isSubpath(skillPath, home)) return "user";
   return "other";
 }
 

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -170,6 +170,17 @@ async function findSkillFiles(
     }
     if (entry.isDirectory()) {
       await findSkillFiles(abs, maxDepth - 1, out, maxItems, precedence);
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      try {
+        const target = await fsp.realpath(abs);
+        if ((await fsp.stat(target)).isDirectory()) {
+          await findSkillFiles(target, maxDepth - 1, out, maxItems, precedence);
+        }
+      } catch {
+        // Ignore broken or inaccessible skill directory links.
+      }
     }
   }
 }

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -84,9 +84,15 @@ async function safeReaddir(dir: string): Promise<fs.Dirent[]> {
 
 function realpathOrUndefined(filePath: string): string | undefined {
   try {
-    return fs.realpathSync(filePath);
+    // Prefer native realpath so Windows short/8.3 names and junctions collapse
+    // to the same canonical spelling used for ~/ display matching.
+    return fs.realpathSync.native(filePath);
   } catch {
-    return undefined;
+    try {
+      return fs.realpathSync(filePath);
+    } catch {
+      return undefined;
+    }
   }
 }
 
@@ -101,16 +107,59 @@ function uniquePaths(paths: string[]): string[] {
   return out;
 }
 
+function stripWinLongPathPrefix(value: string): string {
+  return value.replace(/^\\\\\?\\UNC\\/i, "\\\\").replace(/^\\\\\?\\/i, "");
+}
+
 function homePathCandidates(requestedHomeDir: string, homeDir: string): string[] {
   // Keep both the caller-supplied home and its realpath. On Windows, junction
   // targets often preserve the pre-realpath path form (for example long vs 8.3
-  // names), so classification and ~/ display must accept either spelling.
-  return uniquePaths([homeDir, path.resolve(requestedHomeDir)]);
+  // names), so ~/ display must accept either spelling.
+  const resolvedRequested = path.resolve(requestedHomeDir);
+  return uniquePaths(
+    [homeDir, resolvedRequested, realpathOrUndefined(resolvedRequested), realpathOrUndefined(homeDir)]
+      .filter((value): value is string => Boolean(value))
+      .map(stripWinLongPathPrefix)
+  );
 }
 
-function matchingHomeRoot(absPath: string, homes: string[]): string | undefined {
-  for (const home of homes) {
-    if (absPath === home || isSubpath(absPath, home)) return home;
+function samePath(left: string, right: string): boolean {
+  const a = stripWinLongPathPrefix(left);
+  const b = stripWinLongPathPrefix(right);
+  return process.platform === "win32" ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+function homeRelativeDisplay(absPath: string, home: string): string | undefined {
+  const candidates: Array<[string, string]> = [[absPath, home]];
+  const realAbs = realpathOrUndefined(absPath);
+  const realHome = realpathOrUndefined(home);
+  if (realAbs && realHome) candidates.push([realAbs, realHome]);
+  if (realAbs) candidates.push([realAbs, home]);
+  if (realHome) candidates.push([absPath, realHome]);
+
+  for (const [child, parent] of candidates) {
+    const normalizedChild = stripWinLongPathPrefix(child);
+    const normalizedParent = stripWinLongPathPrefix(parent);
+    if (samePath(normalizedChild, normalizedParent)) return "~";
+    if (isSubpath(normalizedChild, normalizedParent)) {
+      return `~/${path.relative(normalizedParent, normalizedChild).split(path.sep).join("/")}`;
+    }
+  }
+
+  // Windows short vs long path spellings can make path.relative walk through "..".
+  // Walk ancestors of absPath until a realpath matches home's realpath.
+  if (!realHome) return undefined;
+  let current = path.resolve(absPath);
+  const trail: string[] = [];
+  while (true) {
+    const realCurrent = realpathOrUndefined(current);
+    if (realCurrent && samePath(realCurrent, realHome)) {
+      return trail.length === 0 ? "~" : `~/${trail.reverse().join("/")}`;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    trail.push(path.basename(current).split(path.sep).join("/"));
+    current = parent;
   }
   return undefined;
 }
@@ -121,10 +170,9 @@ function displayPath(absPath: string, workspaceRoot: string, homes: string | str
     if (absPath === workspaceRoot) return "$WORKSPACE";
     return `$WORKSPACE/${path.relative(workspaceRoot, absPath).split(path.sep).join("/")}`;
   }
-  const home = matchingHomeRoot(absPath, homeList);
-  if (home) {
-    if (absPath === home) return "~";
-    return `~/${path.relative(home, absPath).split(path.sep).join("/")}`;
+  for (const home of homeList) {
+    const relative = homeRelativeDisplay(absPath, home);
+    if (relative) return relative;
   }
   return absPath;
 }
@@ -195,8 +243,8 @@ async function findSkillFiles(
     }
     if (entry.isSymbolicLink()) {
       try {
-        const target = await fsp.realpath(abs);
-        if ((await fsp.stat(target)).isDirectory()) {
+        const target = realpathOrUndefined(abs);
+        if (target && (await fsp.stat(target)).isDirectory()) {
           await findSkillFiles(target, maxDepth - 1, out, maxItems, precedence, source);
         }
       } catch {

--- a/src/capabilitiesOps.ts
+++ b/src/capabilitiesOps.ts
@@ -90,23 +90,43 @@ function realpathOrUndefined(filePath: string): string | undefined {
   }
 }
 
-function displayPath(absPath: string, workspaceRoot: string, home = os.homedir()): string {
+function uniquePaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of paths) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function homePathCandidates(requestedHomeDir: string, homeDir: string): string[] {
+  // Keep both the caller-supplied home and its realpath. On Windows, junction
+  // targets often preserve the pre-realpath path form (for example long vs 8.3
+  // names), so classification and ~/ display must accept either spelling.
+  return uniquePaths([homeDir, path.resolve(requestedHomeDir)]);
+}
+
+function matchingHomeRoot(absPath: string, homes: string[]): string | undefined {
+  for (const home of homes) {
+    if (absPath === home || isSubpath(absPath, home)) return home;
+  }
+  return undefined;
+}
+
+function displayPath(absPath: string, workspaceRoot: string, homes: string | string[] = os.homedir()): string {
+  const homeList = Array.isArray(homes) ? homes : [homes];
   if (absPath === workspaceRoot || isSubpath(absPath, workspaceRoot)) {
     if (absPath === workspaceRoot) return "$WORKSPACE";
     return `$WORKSPACE/${path.relative(workspaceRoot, absPath).split(path.sep).join("/")}`;
   }
-  if (absPath === home || isSubpath(absPath, home)) {
+  const home = matchingHomeRoot(absPath, homeList);
+  if (home) {
     if (absPath === home) return "~";
     return `~/${path.relative(home, absPath).split(path.sep).join("/")}`;
   }
   return absPath;
-}
-
-function skillSource(skillPath: string, workspaceRoot: string, home = os.homedir()): SkillInventoryItem["source"] {
-  if (skillPath === workspaceRoot || isSubpath(skillPath, workspaceRoot)) return "workspace";
-  if (skillPath.includes(`${path.sep}.codex${path.sep}plugins${path.sep}`)) return "plugin";
-  if (skillPath === home || isSubpath(skillPath, home)) return "user";
-  return "other";
 }
 
 function skillSourceRank(source: SkillInventoryItem["source"]): number {
@@ -154,9 +174,10 @@ function frontmatterValue(text: string, key: string): string | undefined {
 async function findSkillFiles(
   root: string,
   maxDepth: number,
-  out: Array<{ file: string; precedence: number }>,
+  out: Array<{ file: string; precedence: number; source: SkillInventoryItem["source"] }>,
   maxItems: number,
-  precedence: number
+  precedence: number,
+  source: SkillInventoryItem["source"]
 ): Promise<void> {
   if (out.length >= maxItems || maxDepth < 0) return;
   const entries = (await safeReaddir(root)).sort((a, b) => a.name.localeCompare(b.name));
@@ -165,18 +186,18 @@ async function findSkillFiles(
     if (entry.name === "node_modules" || entry.name === ".git") continue;
     const abs = path.join(root, entry.name);
     if (entry.isFile() && entry.name === "SKILL.md") {
-      out.push({ file: abs, precedence });
+      out.push({ file: abs, precedence, source });
       continue;
     }
     if (entry.isDirectory()) {
-      await findSkillFiles(abs, maxDepth - 1, out, maxItems, precedence);
+      await findSkillFiles(abs, maxDepth - 1, out, maxItems, precedence, source);
       continue;
     }
     if (entry.isSymbolicLink()) {
       try {
         const target = await fsp.realpath(abs);
         if ((await fsp.stat(target)).isDirectory()) {
-          await findSkillFiles(target, maxDepth - 1, out, maxItems, precedence);
+          await findSkillFiles(target, maxDepth - 1, out, maxItems, precedence, source);
         }
       } catch {
         // Ignore broken or inaccessible skill directory links.
@@ -193,6 +214,7 @@ async function discoverSkillRecords(
   const workspaceRoot = realpathOrUndefined(workspace.root) ?? path.resolve(workspace.root);
   const requestedHomeDir = options.homeDir ?? os.homedir();
   const homeDir = realpathOrUndefined(requestedHomeDir) ?? path.resolve(requestedHomeDir);
+  const homes = homePathCandidates(requestedHomeDir, homeDir);
   const workspaceRoots = [
     path.join(workspaceRoot, ".codex", "skills"),
     path.join(workspaceRoot, ".agents", "skills"),
@@ -201,25 +223,29 @@ async function discoverSkillRecords(
     const real = realpathOrUndefined(dir);
     return real && isSubpath(real, workspaceRoot) ? [real] : [];
   });
+  // Source comes from the configured scan root, not the symlink/junction target
+  // path. Windows junctions often resolve to a different spelling of the same
+  // home directory, which would otherwise misclassify user skills as "other".
   const roots = [
-    ...workspaceRoots,
+    ...workspaceRoots.map((dir) => ({ dir, source: "workspace" as const })),
     ...(options.includeGlobal
       ? [
-          path.join(homeDir, ".codex", "skills"),
-          path.join(homeDir, ".agents", "skills"),
-          path.join(homeDir, ".codex", "plugins", "cache")
+          { dir: path.join(homeDir, ".codex", "skills"), source: "user" as const },
+          { dir: path.join(homeDir, ".agents", "skills"), source: "user" as const },
+          { dir: path.join(homeDir, ".codex", "plugins", "cache"), source: "plugin" as const }
         ]
       : [])
-  ].filter((dir) => fs.existsSync(dir));
+  ].filter((root) => fs.existsSync(root.dir));
 
-  const skillFiles: Array<{ file: string; precedence: number }> = [];
+  const skillFiles: Array<{ file: string; precedence: number; source: SkillInventoryItem["source"] }> = [];
   for (const [precedence, root] of roots.entries()) {
     await findSkillFiles(
-      root,
-      root.includes(`${path.sep}plugins${path.sep}cache`) ? 9 : 3,
+      root.dir,
+      root.dir.includes(`${path.sep}plugins${path.sep}cache`) ? 9 : 3,
       skillFiles,
       maxSkills,
-      precedence
+      precedence,
+      root.source
     );
     if (skillFiles.length >= maxSkills) break;
   }
@@ -240,8 +266,8 @@ async function discoverSkillRecords(
     items.push({
       name,
       description,
-      source: skillSource(realFile, workspaceRoot, homeDir),
-      path: displayPath(realFile, workspaceRoot, homeDir),
+      source: discovered.source,
+      path: displayPath(realFile, workspaceRoot, homes),
       absPath: realFile,
       precedence: discovered.precedence
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ export interface CodexProConfig {
   maxWriteBytes: number;
   maxOutputBytes: number;
   maxBashTimeoutMs: number;
+  maxImportBytes: number;
   maxSearchResults: number;
   maxHttpSessions: number;
   httpSessionTtlMs: number;
@@ -326,6 +327,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     maxOutputBytes: numberFrom(process.env.CODEXPRO_MAX_OUTPUT_BYTES, 120_000, 4_000, 2_000_000),
     // Default hard cap is 10 minutes. Operators can raise up to 15 minutes.
     maxBashTimeoutMs: numberFrom(process.env.CODEXPRO_MAX_BASH_TIMEOUT_MS, 600_000, 1_000, 900_000),
+    maxImportBytes: numberFrom(process.env.CODEXPRO_MAX_IMPORT_BYTES, 5_000_000, 1_000, 50_000_000),
     maxSearchResults: numberFrom(process.env.CODEXPRO_MAX_SEARCH_RESULTS, 200, 5, 2_000),
     maxHttpSessions: numberFrom(process.env.CODEXPRO_MAX_HTTP_SESSIONS, 64, 1, 512),
     httpSessionTtlMs: numberFrom(process.env.CODEXPRO_HTTP_SESSION_TTL_MS, 30 * 60_000, 60_000, 24 * 60 * 60_000),

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export interface CodexProConfig {
   maxReadBytes: number;
   maxWriteBytes: number;
   maxOutputBytes: number;
+  maxBashTimeoutMs: number;
   maxSearchResults: number;
   maxHttpSessions: number;
   httpSessionTtlMs: number;
@@ -323,6 +324,8 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     maxReadBytes: numberFrom(process.env.CODEXPRO_MAX_READ_BYTES, 180_000, 4_000, 2_000_000),
     maxWriteBytes: numberFrom(process.env.CODEXPRO_MAX_WRITE_BYTES, 1_000_000, 1_000, 10_000_000),
     maxOutputBytes: numberFrom(process.env.CODEXPRO_MAX_OUTPUT_BYTES, 120_000, 4_000, 2_000_000),
+    // Default hard cap is 10 minutes. Operators can raise up to 15 minutes.
+    maxBashTimeoutMs: numberFrom(process.env.CODEXPRO_MAX_BASH_TIMEOUT_MS, 600_000, 1_000, 900_000),
     maxSearchResults: numberFrom(process.env.CODEXPRO_MAX_SEARCH_RESULTS, 200, 5, 2_000),
     maxHttpSessions: numberFrom(process.env.CODEXPRO_MAX_HTTP_SESSIONS, 64, 1, 512),
     httpSessionTtlMs: numberFrom(process.env.CODEXPRO_HTTP_SESSION_TTL_MS, 30 * 60_000, 60_000, 24 * 60 * 60_000),

--- a/src/http.ts
+++ b/src/http.ts
@@ -416,7 +416,7 @@ const LOCAL_FAVICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 6
   <rect x="8" y="8" width="48" height="48" rx="12" fill="#ffffff" fill-opacity=".12" stroke="#ffffff" stroke-opacity=".38"/>
   <path d="M38.4 40.3c-1.8 1.1-3.9 1.7-6.3 1.7-6.1 0-10.3-4.2-10.3-10s4.2-10 10.4-10c2.4 0 4.5.6 6.2 1.7l-2.1 4.1c-1.1-.7-2.3-1-3.8-1-2.9 0-4.9 2.1-4.9 5.2s2 5.2 4.9 5.2c1.5 0 2.8-.4 3.9-1.1l2 4.2Z" fill="#ffffff"/>
 </svg>`;
-const CODEXPRO_VERSION = "0.29.0";
+const CODEXPRO_VERSION = "0.30.0";
 
 function printHelp(): void {
   console.log(`CodexPro MCP HTTP server

--- a/src/importOps.ts
+++ b/src/importOps.ts
@@ -1,0 +1,403 @@
+import { createHash, randomBytes } from "node:crypto";
+import dns from "node:dns/promises";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { URL } from "node:url";
+import type { CodexProConfig } from "./config.js";
+import type { Workspace } from "./guard.js";
+import { CodexProError, PathGuard } from "./guard.js";
+import { withFileWriteLocks } from "./fsOps.js";
+
+export interface AttachmentFileReference {
+  download_url: string;
+  file_id: string;
+  mime_type?: string;
+  file_name?: string;
+}
+
+export type MimeTypeStatus = "matched" | "mismatched" | "unknown";
+
+export interface ImportFileResult {
+  path: string;
+  bytes: number;
+  declared_mime_type: string | null;
+  detected_mime_type: string | null;
+  mime_type_status: MimeTypeStatus;
+  sha256: string;
+  verified: boolean;
+  file_id: string;
+  file_name: string | null;
+  overwritten: boolean;
+}
+
+const DEFAULT_ALLOWED_IMPORT_HOSTS = [
+  "files.oaiusercontent.com",
+  "oaiusercontent.com",
+  "chatgpt.com",
+  "openai.com",
+  "cdn.openai.com",
+  "oaistatic.com"
+];
+
+const MAX_REDIRECTS = 5;
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+
+function boolFrom(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return fallback;
+}
+
+function splitHosts(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[,\s]+/)
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function importAllowedHosts(env: NodeJS.ProcessEnv = process.env): string[] {
+  return [...new Set([...DEFAULT_ALLOWED_IMPORT_HOSTS, ...splitHosts(env.CODEXPRO_IMPORT_ALLOWED_HOSTS)])];
+}
+
+export function parseAttachmentFileReference(value: unknown): AttachmentFileReference {
+  if (typeof value === "string") {
+    throw new CodexProError(
+      "Unsupported attachment reference. ChatGPT must pass an Apps SDK file object with download_url and file_id via openai/fileParams. A bare string file id or URL is not enough."
+    );
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new CodexProError("Unsupported attachment reference. Expected { download_url, file_id, mime_type?, file_name? }.");
+  }
+  const record = value as Record<string, unknown>;
+  const downloadUrl = typeof record.download_url === "string" ? record.download_url.trim() : "";
+  const fileId = typeof record.file_id === "string" ? record.file_id.trim() : "";
+  if (!downloadUrl || !fileId) {
+    throw new CodexProError("Unsupported attachment reference. Both download_url and file_id are required.");
+  }
+  if (/^file:|^data:|^javascript:/i.test(downloadUrl)) {
+    throw new CodexProError("Unsupported attachment reference scheme.");
+  }
+  return {
+    download_url: downloadUrl,
+    file_id: fileId,
+    ...(typeof record.mime_type === "string" && record.mime_type.trim() ? { mime_type: record.mime_type.trim() } : {}),
+    ...(typeof record.file_name === "string" && record.file_name.trim() ? { file_name: record.file_name.trim() } : {})
+  };
+}
+
+function isPrivateOrLocalIp(address: string): boolean {
+  if (net.isIP(address) === 0) return true;
+  const lower = address.toLowerCase();
+  if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
+  if (lower.startsWith("fe80:") || lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  if (lower.includes(".")) {
+    const parts = lower.split(".").map((part) => Number(part));
+    if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+    const [a, b] = parts;
+    if (a === 10 || a === 127 || a === 0) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a >= 224) return true;
+  }
+  return false;
+}
+
+function hostAllowed(hostname: string, allowedHosts: string[]): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  return allowedHosts.some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
+}
+
+export async function assertSafeImportUrl(
+  rawUrl: string,
+  options: { allowLoopback?: boolean; allowedHosts?: string[]; env?: NodeJS.ProcessEnv } = {}
+): Promise<URL> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new CodexProError("Attachment download_url is not a valid URL.");
+  }
+  if (parsed.protocol !== "https:" && !(options.allowLoopback && parsed.protocol === "http:")) {
+    throw new CodexProError("Attachment download_url must use HTTPS.");
+  }
+  if (parsed.username || parsed.password) {
+    throw new CodexProError("Attachment download_url must not include credentials.");
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!host) throw new CodexProError("Attachment download_url is missing a hostname.");
+  const allowLoopback = options.allowLoopback ?? boolFrom((options.env ?? process.env).CODEXPRO_IMPORT_ALLOW_LOOPBACK, false);
+  const allowedHosts = options.allowedHosts ?? importAllowedHosts(options.env);
+  const isLoopbackHost = host === "localhost" || host === "127.0.0.1" || host === "::1";
+  if (isLoopbackHost) {
+    if (!allowLoopback) throw new CodexProError("Attachment download_url points to a blocked host.");
+  } else if (!hostAllowed(host, allowedHosts)) {
+    throw new CodexProError("Attachment download_url host is not an approved ChatGPT file origin.");
+  }
+
+  if (net.isIP(host)) {
+    if (isPrivateOrLocalIp(host) && !(allowLoopback && isLoopbackHost)) {
+      throw new CodexProError("Attachment download_url resolves to a blocked address.");
+    }
+    return parsed;
+  }
+
+  let records: Array<{ address: string; family: number }>;
+  try {
+    records = await dns.lookup(host, { all: true, verbatim: true });
+  } catch {
+    throw new CodexProError("Attachment download_url hostname could not be resolved.");
+  }
+  if (!records.length) throw new CodexProError("Attachment download_url hostname could not be resolved.");
+  for (const record of records) {
+    if (isPrivateOrLocalIp(record.address) && !(allowLoopback && isLoopbackHost)) {
+      throw new CodexProError("Attachment download_url resolves to a blocked address.");
+    }
+  }
+  return parsed;
+}
+
+export function detectMimeType(buffer: Buffer): string | null {
+  if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))) return "image/png";
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return "image/jpeg";
+  if (buffer.length >= 6) {
+    const header = buffer.subarray(0, 6).toString("ascii");
+    if (header === "GIF87a" || header === "GIF89a") return "image/gif";
+  }
+  if (buffer.length >= 12 && buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP") {
+    return "image/webp";
+  }
+  if (buffer.length >= 5 && buffer.subarray(0, 5).toString("ascii") === "%PDF-") return "application/pdf";
+  if (buffer.length >= 4 && buffer[0] === 0x50 && buffer[1] === 0x4b && (buffer[2] === 0x03 || buffer[2] === 0x05 || buffer[2] === 0x07) && buffer[3] === 0x04) {
+    return "application/zip";
+  }
+  if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) return "application/gzip";
+  return null;
+}
+
+export function mimeTypeStatus(declared: string | null | undefined, detected: string | null): MimeTypeStatus {
+  if (!detected) return "unknown";
+  if (!declared) return "unknown";
+  const left = declared.trim().toLowerCase();
+  const right = detected.trim().toLowerCase();
+  if (!left) return "unknown";
+  return left === right ? "matched" : "mismatched";
+}
+
+async function downloadToTempFile(
+  url: URL,
+  maxBytes: number,
+  options: { allowLoopback: boolean; allowedHosts: string[]; env: NodeJS.ProcessEnv }
+): Promise<{ tempPath: string; bytes: number; contentType: string | null }> {
+  const tempPath = path.join(os.tmpdir(), `codexpro-import-${process.pid}-${randomBytes(8).toString("hex")}.bin`);
+  let current = url;
+  for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect += 1) {
+    await assertSafeImportUrl(current.href, options);
+    const result = await new Promise<{
+      statusCode: number;
+      headers: http.IncomingHttpHeaders;
+      bytes: number;
+      redirectedTo?: string;
+    }>((resolve, reject) => {
+      const transport = current.protocol === "http:" ? http : https;
+      const request = transport.get(
+        current,
+        {
+          timeout: DOWNLOAD_TIMEOUT_MS,
+          headers: {
+            Accept: "*/*",
+            "User-Agent": "codexpro-import/0.30"
+          }
+        },
+        (response) => {
+          const statusCode = response.statusCode ?? 0;
+          if ([301, 302, 303, 307, 308].includes(statusCode)) {
+            response.resume();
+            const location = response.headers.location;
+            if (!location) {
+              reject(new CodexProError("Attachment download redirected without a Location header."));
+              return;
+            }
+            resolve({ statusCode, headers: response.headers, bytes: 0, redirectedTo: new URL(location, current).href });
+            return;
+          }
+          if (statusCode < 200 || statusCode >= 300) {
+            response.resume();
+            reject(new CodexProError(`Attachment download failed with HTTP ${statusCode}.`));
+            return;
+          }
+          const contentLength = Number(response.headers["content-length"] ?? "");
+          if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+            response.destroy();
+            reject(new CodexProError(`Attachment is too large. Limit: ${maxBytes} bytes.`));
+            return;
+          }
+          const output = fs.createWriteStream(tempPath, { flags: "wx" });
+          let bytes = 0;
+          let settled = false;
+          const fail = (error: Error) => {
+            if (settled) return;
+            settled = true;
+            response.destroy();
+            output.destroy();
+            void fsp.rm(tempPath, { force: true }).finally(() => reject(error));
+          };
+          response.on("data", (chunk: Buffer | string) => {
+            const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            bytes += buffer.byteLength;
+            if (bytes > maxBytes) {
+              fail(new CodexProError(`Attachment exceeded import size limit (${maxBytes} bytes).`));
+            }
+          });
+          response.on("error", (error) => fail(error instanceof Error ? error : new Error(String(error))));
+          output.on("error", (error) => fail(error instanceof Error ? error : new Error(String(error))));
+          response.pipe(output);
+          output.on("finish", () => {
+            if (settled) return;
+            settled = true;
+            resolve({ statusCode, headers: response.headers, bytes });
+          });
+        }
+      );
+      request.on("timeout", () => {
+        request.destroy(new CodexProError("Attachment download timed out."));
+      });
+      request.on("error", (error) => reject(error instanceof Error ? error : new Error(String(error))));
+    });
+
+    if (result.redirectedTo) {
+      current = new URL(result.redirectedTo);
+      continue;
+    }
+    const contentType = typeof result.headers["content-type"] === "string"
+      ? result.headers["content-type"].split(";")[0]?.trim() || null
+      : null;
+    return { tempPath, bytes: result.bytes, contentType };
+  }
+  throw new CodexProError("Attachment download exceeded redirect limit.");
+}
+
+async function finalizeImportFile(tempPath: string, destinationAbs: string, overwrite: boolean): Promise<boolean> {
+  const parent = path.dirname(destinationAbs);
+  await fsp.mkdir(parent, { recursive: true });
+  if (!overwrite) {
+    try {
+      await fsp.link(tempPath, destinationAbs);
+      await fsp.rm(tempPath, { force: true });
+      return false;
+    } catch (error) {
+      const code = error && typeof error === "object" && "code" in error ? String(error.code) : "";
+      if (code === "EEXIST") {
+        throw new CodexProError(`Destination already exists and overwrite=false: ${path.basename(destinationAbs)}`);
+      }
+      // Windows junctions/filesystems may not support hard links; fall back to exclusive create copy.
+      try {
+        await fsp.copyFile(tempPath, destinationAbs, fs.constants.COPYFILE_EXCL);
+        await fsp.rm(tempPath, { force: true });
+        return false;
+      } catch (copyError) {
+        const copyCode = copyError && typeof copyError === "object" && "code" in copyError ? String(copyError.code) : "";
+        if (copyCode === "EEXIST") {
+          throw new CodexProError(`Destination already exists and overwrite=false: ${path.basename(destinationAbs)}`);
+        }
+        throw copyError;
+      }
+    }
+  }
+  await fsp.rename(tempPath, destinationAbs);
+  return true;
+}
+
+export async function importAttachmentFile(
+  config: CodexProConfig,
+  guard: PathGuard,
+  workspace: Workspace,
+  options: {
+    file: unknown;
+    destination: string;
+    overwrite?: boolean;
+    expectedSha256?: string;
+    env?: NodeJS.ProcessEnv;
+  }
+): Promise<ImportFileResult> {
+  const env = options.env ?? process.env;
+  const reference = parseAttachmentFileReference(options.file);
+  const destination = String(options.destination ?? "").trim();
+  if (!destination) throw new CodexProError("destination is required.");
+  const overwrite = options.overwrite === true;
+  const resolved = guard.resolve(workspace, destination, { forWrite: true });
+  const maxBytes = config.maxImportBytes;
+  const allowLoopback = boolFrom(env.CODEXPRO_IMPORT_ALLOW_LOOPBACK, false);
+  const allowedHosts = importAllowedHosts(env);
+
+  let tempPath = "";
+  try {
+    const downloaded = await downloadToTempFile(new URL(reference.download_url), maxBytes, {
+      allowLoopback,
+      allowedHosts,
+      env
+    });
+    tempPath = downloaded.tempPath;
+    const handle = await fsp.open(tempPath, "r");
+    let hash = "";
+    let detected: string | null = null;
+    try {
+      const probe = Buffer.alloc(Math.min(64, downloaded.bytes));
+      if (probe.length) {
+        const { bytesRead } = await handle.read(probe, 0, probe.length, 0);
+        detected = detectMimeType(probe.subarray(0, bytesRead));
+      }
+      const hasher = createHash("sha256");
+      const stream = handle.createReadStream();
+      await new Promise<void>((resolve, reject) => {
+        stream.on("data", (chunk) => hasher.update(chunk));
+        stream.on("error", reject);
+        stream.on("end", () => resolve());
+      });
+      hash = hasher.digest("hex");
+    } finally {
+      await handle.close();
+    }
+
+    if (options.expectedSha256 && options.expectedSha256.toLowerCase() !== hash) {
+      throw new CodexProError(`Attachment SHA-256 mismatch for ${resolved.relPath}.`);
+    }
+
+    const declared = reference.mime_type ?? downloaded.contentType;
+    const status = mimeTypeStatus(declared, detected);
+    const existedBefore = fs.existsSync(resolved.absPath);
+    const replaced = await withFileWriteLocks([resolved.absPath], async () => {
+      if (!overwrite && existedBefore) {
+        throw new CodexProError(`Destination already exists and overwrite=false: ${resolved.relPath}`);
+      }
+      return finalizeImportFile(tempPath, resolved.absPath, overwrite);
+    });
+    tempPath = "";
+
+    return {
+      path: resolved.relPath,
+      bytes: downloaded.bytes,
+      declared_mime_type: declared ?? null,
+      detected_mime_type: detected,
+      mime_type_status: status,
+      sha256: hash,
+      verified: Boolean(options.expectedSha256),
+      file_id: reference.file_id,
+      file_name: reference.file_name ?? null,
+      overwritten: Boolean(existedBefore && replaced)
+    };
+  } finally {
+    if (tempPath) {
+      await fsp.rm(tempPath, { force: true }).catch(() => undefined);
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -926,7 +926,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
   const workspaces = new WorkspaceManager(config);
   const reviewCheckpoints = new Map<string, string>();
   const guard = new PathGuard(config);
-  const server = new McpServer({ name: "CodexPro", version: "0.29.0" }, { instructions: serverInstructions(config) });
+  const server = new McpServer({ name: "CodexPro", version: "0.30.0" }, { instructions: serverInstructions(config) });
   registeredToolNamesByServer.set(server as object, []);
   registerToolCardResource(server, config);
 
@@ -1964,7 +1964,13 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         command: z.string().describe("Command to run."),
         session_id: z.string().optional().describe(config.requireBashSession && config.bashSessionId ? `Required bash session id for this server: ${config.bashSessionId}.` : "Optional bash session id. If configured on the server, a provided value must match it."),
         cwd: z.string().optional().describe("Working directory relative to workspace root. Default: ."),
-        timeout_ms: z.number().int().min(1000).max(180000).optional().describe("Timeout in milliseconds. Default: 30000.")
+        timeout_ms: z
+          .number()
+          .int()
+          .min(1000)
+          .max(config.maxBashTimeoutMs)
+          .optional()
+          .describe(`Timeout in milliseconds. Default: 30000. Max: ${config.maxBashTimeoutMs}.`)
       },
       annotations: BASH_ANNOTATIONS,
       _meta: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import type { CodexProConfig } from "./config.js";
 import { WorkspaceManager, PathGuard, CodexProError, type Workspace } from "./guard.js";
 import { repoTree, readTextFile, writeTextFile, editTextFile, ensureAiBridge, withFileWriteLocks } from "./fsOps.js";
 import { viewWorkspaceImage } from "./imageOps.js";
+import { importAttachmentFile } from "./importOps.js";
 import { searchWorkspace } from "./searchOps.js";
 import { runBash } from "./bashOps.js";
 import { gitDiff, gitDiffStatus, gitLog, gitStatus } from "./gitOps.js";
@@ -324,6 +325,7 @@ const MINIMAL_TOOL_NAMES = [
   "write",
   "edit",
   "apply_patch",
+  "import_file",
   "bash",
   "show_changes"
 ] as const;
@@ -359,6 +361,7 @@ const FULL_TOOL_NAMES = [
   "write",
   "edit",
   "apply_patch",
+  "import_file",
   "bash",
   "git_status",
   "git_diff",
@@ -377,6 +380,7 @@ const CONNECTION_TEST_HIDDEN_TOOLS = new Set<string>([
   "write",
   "edit",
   "apply_patch",
+  "import_file",
   "bash",
   "export_pro_context",
   "handoff_to_agent",
@@ -402,7 +406,7 @@ function toolNamesForMode(config: CodexProConfig): string[] {
     if (bashIndex !== -1) names.splice(bashIndex, 1);
   }
   if (config.writeMode !== "workspace") {
-    for (const writeTool of ["write", "edit", "apply_patch"]) {
+    for (const writeTool of ["write", "edit", "apply_patch", "import_file"]) {
       const toolIndex = names.indexOf(writeTool);
       if (toolIndex !== -1) names.splice(toolIndex, 1);
     }
@@ -442,7 +446,7 @@ function registeredToolNames(server: McpServer): string[] {
 function shouldRegisterTool(config: CodexProConfig, name: string): boolean {
   if (config.connectionTest && CONNECTION_TEST_HIDDEN_TOOLS.has(name)) return false;
   if (name === "bash" && config.bashMode === "off") return false;
-  if ((name === "write" || name === "edit" || name === "apply_patch") && config.writeMode !== "workspace") return false;
+  if ((name === "write" || name === "edit" || name === "apply_patch" || name === "import_file") && config.writeMode !== "workspace") return false;
   if (name === "codex_sessions") return config.codexSessions !== "off";
   if (name === "read_codex_session") return config.codexSessions === "read";
   if (name === "inspect_workspace" && !config.analysisEnabled) return false;
@@ -1053,6 +1057,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         contextDir: config.contextDir,
         maxReadBytes: config.maxReadBytes,
         maxWriteBytes: config.maxWriteBytes,
+        maxImportBytes: config.maxImportBytes,
         maxOutputBytes: config.maxOutputBytes,
         maxSearchResults: config.maxSearchResults,
         blockedGlobs: config.blockedGlobs,
@@ -1947,6 +1952,76 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         deletions: result.deletions,
         changed: result.changed,
         diff: result.diff
+      });
+    }
+  );
+
+  registerCodexTool(
+    config,
+    server,
+    "import_file",
+    {
+      title: "Import Attachment File",
+      description:
+        "Import a ChatGPT Apps SDK attachment into the workspace. Accepts only a platform file object with download_url and file_id. Not a general URL downloader. Overwrite is off by default.",
+      inputSchema: {
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        file: z
+          .object({
+            download_url: z.string().describe("Temporary HTTPS download URL provided by ChatGPT."),
+            file_id: z.string().describe("ChatGPT file id for this attachment."),
+            mime_type: z.string().optional().describe("Optional MIME type declared by ChatGPT."),
+            file_name: z.string().optional().describe("Optional original file name declared by ChatGPT.")
+          })
+          .describe("ChatGPT Apps SDK file reference from openai/fileParams."),
+        destination: z.string().describe("Destination path relative to the workspace root."),
+        overwrite: z.boolean().optional().describe("Replace an existing destination file. Default: false."),
+        expected_sha256: z.string().regex(/^[a-f0-9]{64}$/i).optional().describe("Optional SHA-256 of the attachment bytes. Import fails on mismatch.")
+      },
+      annotations: LOCAL_WRITE_ANNOTATIONS,
+      _meta: {
+        ...toolCardMeta(),
+        "openai/fileParams": ["file"],
+        "openai/toolInvocation/invoking": "Importing attachment...",
+        "openai/toolInvocation/invoked": "Attachment imported"
+      }
+    },
+    async (args) => {
+      const workspace = workspaces.getWorkspace(args.workspace_id);
+      const resolved = guard.resolve(workspace, args.destination, { forWrite: true });
+      assertWriteToolAllowed(config, resolved.relPath);
+      const result = await importAttachmentFile(config, guard, workspace, {
+        file: args.file,
+        destination: String(args.destination ?? ""),
+        overwrite: args.overwrite === true,
+        expectedSha256: args.expected_sha256
+      });
+      invalidateWorkspaceAnalysis(workspace.id);
+      const text = [
+        "# Import File",
+        "",
+        `Path: ${result.path}`,
+        `Bytes: ${result.bytes}`,
+        `SHA-256: ${result.sha256}`,
+        `Declared MIME: ${result.declared_mime_type ?? "unknown"}`,
+        `Detected MIME: ${result.detected_mime_type ?? "unknown"}`,
+        `MIME status: ${result.mime_type_status}`,
+        `Verified: ${result.verified}`,
+        `Overwritten: ${result.overwritten}`
+      ].join("\n");
+      return textResult(text, {
+        workspace_id: workspace.id,
+        root: workspace.root,
+        path: result.path,
+        bytes: result.bytes,
+        declared_mime_type: result.declared_mime_type,
+        detected_mime_type: result.detected_mime_type,
+        mime_type_status: result.mime_type_status,
+        sha256: result.sha256,
+        verified: result.verified,
+        file_id: result.file_id,
+        file_name: result.file_name,
+        overwritten: result.overwritten
       });
     }
   );

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { loadConfig } from "./config.js";
 import { createCodexProServer } from "./server.js";
 
-const CODEXPRO_VERSION = "0.29.0";
+const CODEXPRO_VERSION = "0.30.0";
 
 function printHelp(): void {
   console.log(`CodexPro MCP stdio server


### PR DESCRIPTION
## Summary
- Fixes the real #86 gap: multi-project `--project` / `--clear-projects` already worked on `main`, but npm `0.29.0` never published those commits. This release bumps to `0.30.0` and documents update + restart steps.
- Fixes #81: restricted bash env rejects relative junk `HOME` values like `=` and prefers a usable absolute `USERPROFILE`/`HOME`, plus valid Windows `APPDATA`/`LOCALAPPDATA`.
- Fixes #83: bash `timeout_ms` hard cap rises from 180s to 10 minutes by default (max 15 minutes via `CODEXPRO_MAX_BASH_TIMEOUT_MS`). Default per-command timeout stays 30s. No remote Codex bus.
- Lands #84: follow directory symlinks under skill roots (thanks @yuczzzzz), with Windows junction path classification.
- Adds #82: workspace-gated `import_file` for ChatGPT Apps SDK attachments (`openai/fileParams`), with approved-host HTTPS downloads, redirect revalidation, streaming size limits, SHA-256/MIME checks.
- FAQ/FAQ_ZH: update command, web Agent vs CodexPro (#64/#85), dual-account/dual-tunnel guidance, attachment import.

## Test plan
- [x] `npm run build`
- [x] `npm run smoke` (includes `import-smoke`)
- [x] `npm run stress` (prior commit)
- [x] `npm audit --audit-level=high` (0 vulnerabilities after lockfile update)
- [x] `git diff --check`
- [ ] CI green on Ubuntu + Windows
- [ ] After merge: `npm run release:publish` so users can `npm install -g codexpro@latest`

Closes #81
Closes #82
Closes #83
Closes #64
Closes #85
Closes #86