### PR TITLE
Add configurable Tailscale Funnel public ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added configurable Tailscale Funnel public HTTPS ports through `--tailscale-port` and `CODEXPRO_TAILSCALE_PORT`; it defaults to `443`, accepts `443`, `8443`, or `10000`, and remains separate from the local CodexPro port.
 - Added saved additional projects with `codexpro settings set --project <path>`, session-local workspace selection through the existing `open_workspace` tool, and `--clear-projects` for removing the saved allowlist.
 - Isolated workspace selection between HTTP MCP sessions while preserving explicit workspace-id access for configured roots, with stdio, HTTP, profile, and regression coverage.
 - Added native workspace image inspection for PNG, JPEG, GIF, and WebP files through `view_image`.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ChatGPT web needs a public HTTPS Server URL. CodexPro supports:
 - Fast demo URL: `codexpro start --tunnel cloudflare`
 - Stable ngrok domain: `codexpro ngrok --hostname your-domain.ngrok-free.dev`
 - Stable Cloudflare route: `codexpro stable --hostname codexpro.example.com --tunnel-name codexpro`
-- Tailscale Funnel: `codexpro tailscale --hostname your-device.your-tailnet.ts.net`
+- Tailscale Funnel: `codexpro tailscale --hostname your-device.your-tailnet.ts.net --tailscale-port 8443`
 - Local only: `codexpro start --tunnel none`
 
 Cloudflare quick tunnels honor `HTTPS_PROXY`, `ALL_PROXY`, or `HTTP_PROXY` when those env vars are set.
@@ -176,19 +176,20 @@ chmod 600 ~/.codexpro/http-token
 
 codexpro tailscale \
   --hostname your-device.your-tailnet.ts.net \
+  --tailscale-port 8443 \
   --token-file ~/.codexpro/http-token
 ```
 
-Tailscale Funnel must already be allowed for your tailnet. It requires MagicDNS, HTTPS certificates, and Funnel policy support. CodexPro runs:
+`--tailscale-port` chooses the public HTTPS port for Tailscale Funnel. It defaults to `443`; the only allowed values are `443`, `8443`, and `10000`. It is separate from local `--port` (default `8787`), which controls only where CodexPro listens. Tailscale Funnel must already be allowed for your tailnet. It requires MagicDNS, HTTPS certificates, and Funnel policy support. With the example above, CodexPro runs:
 
 ```bash
-tailscale funnel http://127.0.0.1:8787
+tailscale funnel --https=8443 http://127.0.0.1:8787
 ```
 
 Then ChatGPT uses:
 
 ```text
-https://your-device.your-tailnet.ts.net/mcp?codexpro_token=keep-this-token-stable
+https://your-device.your-tailnet.ts.net:8443/mcp?codexpro_token=keep-this-token-stable
 ```
 
 The URL token is a personal-use compatibility fallback for connector forms that cannot set

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -148,6 +148,30 @@ npx codexpro@latest start --root /absolute/path/to/your/repo
 
 但普通用户更推荐全局安装，这样命令就是固定的 `codexpro setup` 和 `codexpro start`。
 
+## Tailscale Funnel 公网端口
+
+如果 tailnet 已允许 Funnel HTTPS，可以用这台设备的 `.ts.net` hostname 提供稳定的 ChatGPT Server URL：
+
+```bash
+codexpro tailscale \
+  --hostname your-device.your-tailnet.ts.net \
+  --tailscale-port 8443
+```
+
+`--tailscale-port` 控制的是 Tailscale Funnel 的公网 HTTPS 端口，默认是 `443`，只允许 `443`、`8443` 或 `10000`。它和本地 `--port`（默认 `8787`）是两回事：`--port` 只决定 CodexPro 在本机监听的端口。上面的示例会运行：
+
+```bash
+tailscale funnel --https=8443 http://127.0.0.1:8787
+```
+
+对应的 ChatGPT Server URL 是：
+
+```text
+https://your-device.your-tailnet.ts.net:8443/mcp
+```
+
+Funnel 必须已获 tailnet 允许，并需要 MagicDNS、HTTPS 证书和 Funnel policy 支持。
+
 ## ChatGPT 中的 App 设置
 
 先在 ChatGPT 打开 Developer Mode：

--- a/config.example.env
+++ b/config.example.env
@@ -24,6 +24,9 @@ CODEXPRO_CONTEXT_DIR=.ai-bridge
 # Optional stable public URL mode. Quick tunnels do not keep the same hostname.
 # CODEXPRO_TUNNEL=cloudflare-named
 # CODEXPRO_PUBLIC_HOSTNAME=codexpro.example.com
+# Optional Tailscale Funnel public HTTPS port for the CLI launcher. Default: 443; allowed: 443, 8443, 10000.
+# This is separate from CODEXPRO_PORT, which is the local CodexPro server port.
+# CODEXPRO_TAILSCALE_PORT=8443
 # CLOUDFLARE_TUNNEL_NAME=codexpro
 # Or use a dashboard-managed tunnel token:
 # CLOUDFLARE_TUNNEL_TOKEN_FILE=/Users/you/.codexpro/cloudflare-tunnel-token

--- a/docs/index.html
+++ b/docs/index.html
@@ -293,8 +293,9 @@ codexpro setup</code>
           <article>
             <span class="tag">Tailnet</span>
             <h3>Tailscale Funnel</h3>
-            <p>Use your device's <code>.ts.net</code> hostname when your tailnet already allows public Funnel HTTPS.</p>
-            <pre><code>codexpro tailscale --hostname your-device.your-tailnet.ts.net</code></pre>
+            <p>Use your device's <code>.ts.net</code> hostname when your tailnet already allows public Funnel HTTPS. <code>--tailscale-port</code> selects the public port: <code>443</code> by default, or <code>8443</code>/<code>10000</code>; it is separate from local <code>--port</code>.</p>
+            <pre><code>codexpro tailscale --hostname your-device.your-tailnet.ts.net --tailscale-port 8443
+# https://your-device.your-tailnet.ts.net:8443/mcp</code></pre>
           </article>
         </div>
       </section>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -259,8 +259,9 @@ codexpro start</code></pre>
           <article>
             <span class="tag">Tailnet</span>
             <h3>Tailscale Funnel</h3>
-            <p>适合已经允许 Funnel HTTPS 的 tailnet。使用这台设备的 <code>.ts.net</code> hostname。</p>
-            <pre><code>codexpro tailscale --hostname your-device.your-tailnet.ts.net</code></pre>
+            <p>适合已经允许 Funnel HTTPS 的 tailnet。使用这台设备的 <code>.ts.net</code> hostname。<code>--tailscale-port</code> 选择公网端口：默认 <code>443</code>，也可用 <code>8443</code>/<code>10000</code>；它和本地 <code>--port</code> 相互独立。</p>
+            <pre><code>codexpro tailscale --hostname your-device.your-tailnet.ts.net --tailscale-port 8443
+# https://your-device.your-tailnet.ts.net:8443/mcp</code></pre>
           </article>
         </div>
       </section>

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -284,12 +284,17 @@ function statusLine(status, detail = '') {
   const marker = status === 'ok' ? paint('green', 'OK') : status === 'warn' ? paint('yellow', 'WARN') : paint('cyan', '..');
   console.log(`${marker} ${detail}`);
 }
+function profilePublicHostname(profile) {
+  if (!profile?.hostname) return '';
+  if (profile.tunnel === 'tailscale' && profile.tailscalePort && profile.tailscalePort !== '443') return `${profile.hostname}:${profile.tailscalePort}`;
+  return profile.hostname;
+}
 
 function profileSummary(profile) {
   if (!profile?.tunnel) return '';
   if (profile.tunnel === 'ngrok' && profile.hostname) return `Saved ngrok URL: ${profile.hostname}`;
   if (profile.tunnel === 'cloudflare-named' && profile.hostname) return `Saved Cloudflare URL: ${profile.hostname}`;
-  if (profile.tunnel === 'tailscale' && profile.hostname) return `Saved Tailscale Funnel URL: ${profile.hostname}`;
+  if (profile.tunnel === 'tailscale' && profile.hostname) return `Saved Tailscale Funnel URL: ${profilePublicHostname(profile)}`;
   if (profile.tunnel === 'cloudflare') return 'Saved Cloudflare quick-tunnel setup';
   if (profile.tunnel === 'none') return 'Saved local-only setup';
   return '';
@@ -298,8 +303,8 @@ function profileSummary(profile) {
 function profileOneLine(profile, index = 0) {
   const prefix = index ? `${index}. ` : '';
   const tunnel = profile.tunnel ?? 'cloudflare';
-  const host = profile.hostname ? ` -> ${profile.hostname}` : '';
-  const port = profile.port ? ` :${profile.port}` : '';
+  const host = profile.hostname ? ` -> ${profilePublicHostname(profile)}` : '';
+  const port = profile.port ? `  local :${profile.port}` : '';
   return `${prefix}${profile.root}  ${tunnel}${host}${port}`;
 }
 

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -3118,6 +3118,17 @@ async function ask(rl, question, fallback = '') {
   return answer.trim() || fallback;
 }
 
+async function askTailscalePort(rl, fallback) {
+  for (;;) {
+    const answer = await ask(rl, 'Tailscale Funnel public HTTPS port: 443, 8443, or 10000?', fallback);
+    try {
+      return normalizeTailscaleFunnelPort(answer);
+    } catch {
+      statusLine('warn', `${answer} is not a Funnel port. Choose 443, 8443, or 10000.`);
+    }
+  }
+}
+
 function tunnelChoiceFromProfile(profile, fallback = 'cloudflare') {
   if (profile?.tunnel === 'ngrok') return 'ngrok';
   if (profile?.tunnel === 'cloudflare-named') return 'stable';
@@ -3183,9 +3194,9 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
       defaultEndpoint.hostname
     );
     if (!hostname) throw new Error('Tailscale setup needs your Funnel hostname, for example machine.tailnet.ts.net.');
-    const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', defaultEndpoint.port), 'guided setup');
-    hostname = endpoint.hostname;
-    tailscalePort = endpoint.port;
+    const typed = normalizeTailscaleEndpoint(hostname, '', 'guided setup');
+    hostname = typed.hostname;
+    tailscalePort = await askTailscalePort(rl, typed.port || defaultEndpoint.port);
   }
 
   return {
@@ -3436,9 +3447,9 @@ async function runSetupWizard(argv) {
         defaultEndpoint.hostname
       );
       if (!hostname) throw new Error('Tailscale setup needs your Funnel hostname, for example machine.tailnet.ts.net.');
-      const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', defaultEndpoint.port), 'guided setup');
-      profileHostname = endpoint.hostname;
-      profileTailscalePort = endpoint.port;
+      const typed = normalizeTailscaleEndpoint(hostname, '', 'guided setup');
+      profileHostname = typed.hostname;
+      profileTailscalePort = await askTailscalePort(rl, typed.port || defaultEndpoint.port);
       args.push('--tunnel', 'tailscale', '--hostname', profileHostname, '--tailscale-port', profileTailscalePort);
     } else {
       profileTunnel = 'cloudflare';
@@ -3974,6 +3985,9 @@ async function main() {
   if (!['none', 'cloudflare', 'cloudflare-named', 'ngrok', 'tailscale'].includes(tunnel)) {
     throw new Error('--tunnel must be none, cloudflare, cloudflare-named, ngrok, or tailscale');
   }
+  if (args.tailscalePort !== undefined && tunnel !== 'tailscale') {
+    throw new Error(`--tailscale-port only applies to --tunnel tailscale, not ${tunnel}.`);
+  }
   let stableHostname = args.hostname
     ?? args.url
     ?? process.env.CODEXPRO_PUBLIC_HOSTNAME
@@ -4079,7 +4093,7 @@ async function main() {
           : tunnel === 'ngrok'
             ? `ngrok endpoint for ${stableHostname}`
             : tunnel === 'tailscale'
-              ? `Tailscale Funnel endpoint for ${publicBaseFromTailscaleEndpoint(stableHostname, tailscaleEndpoint.port)}`
+              ? `Tailscale Funnel for ${publicBaseFromTailscaleEndpoint(stableHostname, tailscaleEndpoint.port).replace('https://', '')}`
               : 'none'
     )
   ]);
@@ -4200,7 +4214,18 @@ async function main() {
       await waitForPublicHealth(publicBase, token, cloudflared, 'Tailscale Funnel');
     } catch (error) {
       const tail = typeof cloudflared.codexproLogTail === 'function' ? cloudflared.codexproLogTail() : '';
-      const hint = [
+      const takenPort = /listener already exists for port (\d+)/.exec(tail)?.[1];
+      const hint = takenPort ? [
+        '',
+        `Public port ${takenPort} already has a Tailscale listener, so Funnel could not claim it.`,
+        '',
+        `  ${'tailscale serve status'.padEnd(34)}see what holds that port`,
+        `  ${`tailscale funnel --https=${takenPort} off`.padEnd(34)}release it`,
+        '',
+        'Or start CodexPro on a free port. Allowed public ports are 443, 8443, and 10000:',
+        '',
+        '  codexpro tailscale --hostname your-device.your-tailnet.ts.net --tailscale-port 8443'
+      ].join('\n') : [
         '',
         'Tailscale Funnel needs one-time setup before this can succeed:',
         '',

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1336,7 +1336,7 @@ function canonicalProfileForSave(profile) {
 function tailscaleEndpointOptions(args, profile = {}) {
   const cli = normalizeTailscaleEndpoint(args.hostname ?? args.url ?? '', args.tailscalePort, 'CLI options');
   const env = normalizeTailscaleEndpoint(
-    process.env.CODEXPRO_PUBLIC_HOSTNAME ?? process.env.CODEXPRO_HOSTNAME ?? process.env.NGROK_DOMAIN ?? '',
+    process.env.CODEXPRO_PUBLIC_HOSTNAME ?? process.env.CODEXPRO_HOSTNAME ?? process.env.TAILSCALE_FUNNEL_HOSTNAME ?? process.env.NGROK_DOMAIN ?? '',
     process.env.CODEXPRO_TAILSCALE_PORT,
     'environment variables'
   );

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -1309,18 +1309,36 @@ function normalizeTailscaleFunnelPort(value) {
   return port;
 }
 
-function normalizeTailscaleEndpoint(hostname, dedicatedPort = '', source = 'settings') {
-  const rawHostname = String(hostname ?? '').trim();
+function explicitHostnamePort(value) {
+  const raw = String(value ?? '').trim().replace(/\/+$/, '');
+  if (!raw) return '';
+  const authorityStart = raw.includes('://') ? raw.indexOf('://') + 3 : 0;
+  const authority = raw.slice(authorityStart).split(/[/?#]/, 1)[0];
+  return authority.match(/:(\d+)$/)?.[1] ?? '';
+}
+
+function normalizeTailscaleHostname(value) {
+  const normalized = normalizePublicHostname(String(value ?? '').trim());
+  return normalized ? new URL(`https://${normalized}`).hostname : '';
+}
+
+function normalizeTailscalePortPair(dedicatedPort = '', suffixPort = '', source = 'settings') {
   const requestedPort = String(dedicatedPort ?? '').trim();
-  const normalizedHostname = rawHostname ? normalizePublicHostname(rawHostname) : '';
-  const parsed = normalizedHostname ? new URL(`https://${normalizedHostname}`) : null;
-  const suffixPort = parsed?.port ?? '';
+  const requestedSuffixPort = String(suffixPort ?? '').trim();
   const canonicalPort = requestedPort ? normalizeTailscaleFunnelPort(requestedPort) : '';
-  const legacyPort = suffixPort ? normalizeTailscaleFunnelPort(suffixPort) : '';
+  const legacyPort = requestedSuffixPort ? normalizeTailscaleFunnelPort(requestedSuffixPort) : '';
   if (canonicalPort && legacyPort && canonicalPort !== legacyPort) {
     throw new Error(`Conflicting Tailscale Funnel ports in ${source}: --tailscale-port is ${canonicalPort}, but the hostname uses ${legacyPort}.`);
   }
-  return { hostname: parsed?.hostname ?? '', port: canonicalPort || legacyPort || '' };
+  return canonicalPort || legacyPort || '';
+}
+
+function normalizeTailscaleEndpoint(hostname, dedicatedPort = '', source = 'settings') {
+  const rawHostname = String(hostname ?? '').trim();
+  return {
+    hostname: normalizeTailscaleHostname(rawHostname),
+    port: normalizeTailscalePortPair(dedicatedPort, explicitHostnamePort(rawHostname), source)
+  };
 }
 
 function canonicalProfileForSave(profile) {
@@ -1334,17 +1352,26 @@ function canonicalProfileForSave(profile) {
 }
 
 function tailscaleEndpointOptions(args, profile = {}) {
-  const cli = normalizeTailscaleEndpoint(args.hostname ?? args.url ?? '', args.tailscalePort, 'CLI options');
-  const env = normalizeTailscaleEndpoint(
-    process.env.CODEXPRO_PUBLIC_HOSTNAME ?? process.env.CODEXPRO_HOSTNAME ?? process.env.TAILSCALE_FUNNEL_HOSTNAME ?? process.env.NGROK_DOMAIN ?? '',
-    process.env.CODEXPRO_TAILSCALE_PORT,
-    'environment variables'
+  const candidates = [
+    { hostname: args.hostname ?? args.url ?? '', port: args.tailscalePort, source: 'CLI options' },
+    {
+      hostname: process.env.CODEXPRO_PUBLIC_HOSTNAME ?? process.env.CODEXPRO_HOSTNAME ?? process.env.TAILSCALE_FUNNEL_HOSTNAME ?? process.env.NGROK_DOMAIN ?? '',
+      port: process.env.CODEXPRO_TAILSCALE_PORT,
+      source: 'environment variables'
+    },
+    { hostname: profile.hostname ?? '', port: profile.tailscalePort, source: 'saved profile' }
+  ];
+  const hostnameIndex = candidates.findIndex((candidate) => String(candidate.hostname ?? '').trim());
+  const portIndex = candidates.findIndex((candidate) =>
+    String(candidate.port ?? '').trim() || explicitHostnamePort(candidate.hostname)
   );
-  const saved = normalizeTailscaleEndpoint(profile.hostname ?? '', profile.tailscalePort, 'saved profile');
-  return {
-    hostname: cli.hostname || env.hostname || saved.hostname || '',
-    port: cli.port || env.port || saved.port || '443'
-  };
+  const hostname = hostnameIndex >= 0 ? normalizeTailscaleHostname(candidates[hostnameIndex].hostname) : '';
+  let port = '';
+  if (portIndex >= 0) {
+    const candidate = candidates[portIndex];
+    port = normalizeTailscalePortPair(candidate.port, explicitHostnamePort(candidate.hostname), candidate.source);
+  }
+  return { hostname, port: port || '443' };
 }
 
 function publicBaseFromTailscaleEndpoint(hostname, port) {
@@ -3568,6 +3595,9 @@ function saveSettingsFromArgs(root, args, profile) {
   if (!['none', 'cloudflare', 'cloudflare-named', 'ngrok', 'tailscale'].includes(tunnel)) {
     throw new Error('--tunnel must be none, cloudflare, cloudflare-named, ngrok, or tailscale');
   }
+  if (args.tailscalePort !== undefined && tunnel !== 'tailscale') {
+    throw new Error(`--tailscale-port only applies to --tunnel tailscale, not ${tunnel}.`);
+  }
   const needsHostname = tunnel === 'ngrok' || tunnel === 'cloudflare-named' || tunnel === 'tailscale';
   const rawHostname = needsHostname ? (args.hostname ?? args.url ?? profile.hostname ?? '') : '';
   const tailscaleEndpoint = tunnel === 'tailscale' ? tailscaleEndpointOptions(args, profile) : null;
@@ -3975,18 +4005,28 @@ async function main() {
   let profile = args.noProfile ? {} : loadWorkspaceProfile(root);
   profile = await maybeConfigureFirstRun(root, args, profile);
   const effectiveArgs = { ...profile, ...args };
-  if (profile.profilePath && !args.noProfile) {
-    statusLine('ok', `Using saved profile: ${profile.profilePath}`);
-    const summary = profileSummary(profile);
-    if (summary) statusLine('ok', `${summary}. Future launches from this folder only need: codexpro start`);
-  }
-
   const tunnel = optionValue(args, profile, 'tunnel', ['CODEXPRO_TUNNEL'], 'cloudflare');
   if (!['none', 'cloudflare', 'cloudflare-named', 'ngrok', 'tailscale'].includes(tunnel)) {
     throw new Error('--tunnel must be none, cloudflare, cloudflare-named, ngrok, or tailscale');
   }
   if (args.tailscalePort !== undefined && tunnel !== 'tailscale') {
     throw new Error(`--tailscale-port only applies to --tunnel tailscale, not ${tunnel}.`);
+  }
+  if (profile.profilePath && !args.noProfile) {
+    statusLine('ok', `Using saved profile: ${profile.profilePath}`);
+    const tailscaleEndpointOverridden = [
+      args.hostname,
+      args.url,
+      args.tailscalePort,
+      process.env.CODEXPRO_PUBLIC_HOSTNAME,
+      process.env.CODEXPRO_HOSTNAME,
+      process.env.TAILSCALE_FUNNEL_HOSTNAME,
+      process.env.NGROK_DOMAIN,
+      process.env.CODEXPRO_TAILSCALE_PORT
+    ].some((value) => String(value ?? '').trim());
+    const hideTailscaleSummary = profile.tunnel === 'tailscale' && (tunnel !== 'tailscale' || tailscaleEndpointOverridden);
+    const summary = hideTailscaleSummary ? '' : profileSummary(profile);
+    if (summary) statusLine('ok', `${summary}. Future launches from this folder only need: codexpro start`);
   }
   let stableHostname = args.hostname
     ?? args.url

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -113,6 +113,8 @@ Options:
   --ngrok <path>            ngrok executable. Default: PATH.
   --ngrok-config <path>     Optional ngrok config file path.
   --tailscale <path>        tailscale executable. Default: PATH.
+  --tailscale-port <443|8443|10000>
+                             Tailscale Funnel public HTTPS port. Default: 443.
   --no-profile              Do not load a saved ~/.codexpro workspace profile.
   --save-config             Save setup choices for this workspace when using setup.
   --no-save-config          Do not save setup choices when using setup.
@@ -1289,12 +1291,45 @@ function publicBaseFromHostname(hostname) {
   return `https://${normalizePublicHostname(hostname)}`;
 }
 
-function tailscaleFunnelHttpsPort(publicBase) {
-  const port = new URL(publicBase).port || '443';
+function normalizeTailscaleFunnelPort(value) {
+  const port = String(value ?? '').trim();
   if (!['443', '8443', '10000'].includes(port)) {
     throw new Error('Tailscale Funnel HTTPS port must be 443, 8443, or 10000.');
   }
   return port;
+}
+
+function normalizeTailscaleEndpoint(hostname, dedicatedPort = '', source = 'settings') {
+  const rawHostname = String(hostname ?? '').trim();
+  const requestedPort = String(dedicatedPort ?? '').trim();
+  const normalizedHostname = rawHostname ? normalizePublicHostname(rawHostname) : '';
+  const parsed = normalizedHostname ? new URL(`https://${normalizedHostname}`) : null;
+  const suffixPort = parsed?.port ?? '';
+  const canonicalPort = requestedPort ? normalizeTailscaleFunnelPort(requestedPort) : '';
+  const legacyPort = suffixPort ? normalizeTailscaleFunnelPort(suffixPort) : '';
+  if (canonicalPort && legacyPort && canonicalPort !== legacyPort) {
+    throw new Error(`Conflicting Tailscale Funnel ports in ${source}: --tailscale-port is ${canonicalPort}, but the hostname uses ${legacyPort}.`);
+  }
+  return { hostname: parsed?.hostname ?? '', port: canonicalPort || legacyPort || '' };
+}
+
+function tailscaleEndpointOptions(args, profile = {}) {
+  const cli = normalizeTailscaleEndpoint(args.hostname ?? args.url ?? '', args.tailscalePort, 'CLI options');
+  const env = normalizeTailscaleEndpoint(
+    process.env.CODEXPRO_PUBLIC_HOSTNAME ?? process.env.CODEXPRO_HOSTNAME ?? process.env.NGROK_DOMAIN ?? '',
+    process.env.CODEXPRO_TAILSCALE_PORT,
+    'environment variables'
+  );
+  const saved = normalizeTailscaleEndpoint(profile.hostname ?? '', profile.tailscalePort, 'saved profile');
+  return {
+    hostname: cli.hostname || env.hostname || saved.hostname || '',
+    port: cli.port || env.port || saved.port || '443'
+  };
+}
+
+function publicBaseFromTailscaleEndpoint(hostname, port) {
+  const normalizedPort = normalizeTailscaleFunnelPort(port);
+  return `https://${hostname}${normalizedPort === '443' ? '' : `:${normalizedPort}`}`;
 }
 
 function readTokenFile(filePath) {
@@ -3094,6 +3129,7 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
   const tunnelChoice = normalizeSetupChoice(tunnelAnswer, ['cloudflare', 'quick', 'ngrok', 'tailscale', 'stable', 'local'], defaultTunnel);
   const tunnel = tunnelModeFromChoice(tunnelChoice);
   let hostname = '';
+  let tailscalePort = '';
   let tunnelName = '';
   let ngrokConfig = '';
   let cloudflareConfig = '';
@@ -3126,10 +3162,13 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
       optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'TAILSCALE_FUNNEL_HOSTNAME'], '')
     );
     if (!hostname) throw new Error('Tailscale setup needs your Funnel hostname, for example machine.tailnet.ts.net.');
-    hostname = normalizePublicHostname(hostname);
+    const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', optionValue(defaults, profile, 'tailscalePort', ['CODEXPRO_TAILSCALE_PORT'], '443')), 'guided setup');
+    hostname = endpoint.hostname;
+    tailscalePort = endpoint.port;
   }
 
   return {
+    tailscalePort,
     tunnel,
     hostname,
     tunnelName,
@@ -3141,6 +3180,7 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
 
 function applyTunnelPreferenceToArgs(args, preference) {
   args.tunnel = preference.tunnel;
+  if (preference.tailscalePort) args.tailscalePort = preference.tailscalePort;
   if (preference.hostname) args.hostname = preference.hostname;
   if (preference.tunnelName) args.tunnelName = preference.tunnelName;
   if (preference.ngrokConfig) args.ngrokConfig = preference.ngrokConfig;
@@ -3163,6 +3203,7 @@ function profileFromPreference(root, args, profile, preference) {
   const token = preference.tunnel === 'none' ? existingToken : stableToken(existingToken);
   const allowedRoots = configuredProjectRoots(root, args, profile);
   return {
+    ...(preference.tailscalePort ? { tailscalePort: preference.tailscalePort } : {}),
     port,
     mode,
     tunnel: preference.tunnel,
@@ -3323,6 +3364,7 @@ async function runSetupWizard(argv) {
     let profileTunnel = 'cloudflare';
     let profileHostname = '';
     let profileTunnelName = '';
+    let profileTailscalePort = '';
     let profileNgrokConfig = '';
     let profileCloudflareConfig = '';
     let profileCloudflareTokenFile = '';
@@ -3372,9 +3414,10 @@ async function runSetupWizard(argv) {
         optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'TAILSCALE_FUNNEL_HOSTNAME'], '')
       );
       if (!hostname) throw new Error('Tailscale setup needs your Funnel hostname, for example machine.tailnet.ts.net.');
-      hostname = normalizePublicHostname(hostname);
-      profileHostname = hostname;
-      args.push('--tunnel', 'tailscale', '--hostname', hostname);
+      const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', optionValue(defaults, profile, 'tailscalePort', ['CODEXPRO_TAILSCALE_PORT'], '443')), 'guided setup');
+      profileHostname = endpoint.hostname;
+      profileTailscalePort = endpoint.port;
+      args.push('--tunnel', 'tailscale', '--hostname', profileHostname, '--tailscale-port', profileTailscalePort);
     } else {
       profileTunnel = 'cloudflare';
       args.push('--tunnel', 'cloudflare');
@@ -3394,6 +3437,7 @@ async function runSetupWizard(argv) {
         port,
         mode,
         tunnel: profileTunnel,
+        ...(profileTailscalePort ? { tailscalePort: profileTailscalePort } : {}),
         ...(profileHostname ? { hostname: profileHostname } : {}),
         ...(profileTunnelName ? { tunnelName: profileTunnelName } : {}),
         ...(profileNgrokConfig ? { ngrokConfig: profileNgrokConfig } : {}),
@@ -3447,6 +3491,7 @@ function printProfile(root, profile) {
     labelValue('Profile', profile.profilePath),
     labelValue('Tunnel', safe.tunnel ?? 'cloudflare'),
     ...(safe.hostname ? [labelValue('Hostname', safe.hostname)] : []),
+    ...(safe.tailscalePort ? [labelValue('Tailscale port', safe.tailscalePort)] : []),
     ...(safe.tunnelName ? [labelValue('Tunnel name', safe.tunnelName)] : []),
     ...(safe.ngrokConfig ? [labelValue('Ngrok config', safe.ngrokConfig)] : []),
     ...(safe.cloudflareConfig ? [labelValue('Cloudflare cfg', safe.cloudflareConfig)] : []),
@@ -3492,7 +3537,10 @@ function saveSettingsFromArgs(root, args, profile) {
   }
   const needsHostname = tunnel === 'ngrok' || tunnel === 'cloudflare-named' || tunnel === 'tailscale';
   const rawHostname = needsHostname ? (args.hostname ?? args.url ?? profile.hostname ?? '') : '';
-  const hostname = needsHostname ? normalizePublicHostname(rawHostname) : String(rawHostname ?? '').trim();
+  const tailscaleEndpoint = tunnel === 'tailscale' ? tailscaleEndpointOptions(args, profile) : null;
+  const hostname = tailscaleEndpoint
+    ? tailscaleEndpoint.hostname
+    : needsHostname ? normalizePublicHostname(rawHostname) : String(rawHostname ?? '').trim();
   if (needsHostname && !hostname) {
     throw new Error('--hostname is required for ngrok, cloudflare-named, and tailscale settings.');
   }
@@ -3528,6 +3576,7 @@ function saveSettingsFromArgs(root, args, profile) {
     mode,
     tunnel,
     ...(hostname ? { hostname } : {}),
+    ...(tailscaleEndpoint ? { tailscalePort: tailscaleEndpoint.port } : {}),
     ...(tunnelName ? { tunnelName } : {}),
     ...(ngrokConfig ? { ngrokConfig } : {}),
     ...(cloudflareConfig ? { cloudflareConfig } : {}),
@@ -3903,13 +3952,15 @@ async function main() {
   if (!['none', 'cloudflare', 'cloudflare-named', 'ngrok', 'tailscale'].includes(tunnel)) {
     throw new Error('--tunnel must be none, cloudflare, cloudflare-named, ngrok, or tailscale');
   }
-  const stableHostname = args.hostname
+  let stableHostname = args.hostname
     ?? args.url
     ?? process.env.CODEXPRO_PUBLIC_HOSTNAME
     ?? process.env.CODEXPRO_HOSTNAME
     ?? process.env.NGROK_DOMAIN
     ?? profile.hostname
     ?? '';
+  const tailscaleEndpoint = tunnel === 'tailscale' ? tailscaleEndpointOptions(args, profile) : null;
+  if (tailscaleEndpoint) stableHostname = tailscaleEndpoint.hostname;
   if (tunnel === 'cloudflare-named' && !stableHostname) {
     printStableUrlHelp();
     throw new Error('--hostname is required with stable URL mode.');
@@ -4006,7 +4057,7 @@ async function main() {
           : tunnel === 'ngrok'
             ? `ngrok endpoint for ${stableHostname}`
             : tunnel === 'tailscale'
-              ? `Tailscale Funnel endpoint for ${stableHostname}`
+              ? `Tailscale Funnel endpoint for ${publicBaseFromTailscaleEndpoint(stableHostname, tailscaleEndpoint.port)}`
               : 'none'
     )
   ]);
@@ -4116,8 +4167,8 @@ async function main() {
 
   if (tunnel === 'tailscale') {
     const tailscalePath = resolveTailscale(effectiveArgs);
-    const publicBase = publicBaseFromHostname(stableHostname);
-    const httpsPort = tailscaleFunnelHttpsPort(publicBase);
+    const publicBase = publicBaseFromTailscaleEndpoint(stableHostname, tailscaleEndpoint.port);
+    const httpsPort = tailscaleEndpoint.port;
     const tailscaleArgs = ['funnel'];
     if (httpsPort !== '443') tailscaleArgs.push(`--https=${httpsPort}`);
     tailscaleArgs.push(localBase);

--- a/scripts/codexpro.mjs
+++ b/scripts/codexpro.mjs
@@ -286,7 +286,11 @@ function statusLine(status, detail = '') {
 }
 function profilePublicHostname(profile) {
   if (!profile?.hostname) return '';
-  if (profile.tunnel === 'tailscale' && profile.tailscalePort && profile.tailscalePort !== '443') return `${profile.hostname}:${profile.tailscalePort}`;
+  if (profile.tunnel === 'tailscale') {
+    const endpoint = normalizeTailscaleEndpoint(profile.hostname, profile.tailscalePort, 'saved profile');
+    if (endpoint.port && endpoint.port !== '443') return `${endpoint.hostname}:${endpoint.port}`;
+    return endpoint.hostname;
+  }
   return profile.hostname;
 }
 
@@ -703,12 +707,13 @@ function deleteWorkspaceProfile(root) {
 function saveWorkspaceProfile(root, profile) {
   const dir = profileDir();
   const filePath = profilePathForRoot(root);
+  const canonicalProfile = canonicalProfileForSave(profile);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const payload = {
     version: 1,
     root,
     updatedAt: new Date().toISOString(),
-    ...profile
+    ...canonicalProfile
   };
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
   try {
@@ -1316,6 +1321,16 @@ function normalizeTailscaleEndpoint(hostname, dedicatedPort = '', source = 'sett
     throw new Error(`Conflicting Tailscale Funnel ports in ${source}: --tailscale-port is ${canonicalPort}, but the hostname uses ${legacyPort}.`);
   }
   return { hostname: parsed?.hostname ?? '', port: canonicalPort || legacyPort || '' };
+}
+
+function canonicalProfileForSave(profile) {
+  if (profile?.tunnel !== 'tailscale') return profile;
+  const endpoint = normalizeTailscaleEndpoint(profile.hostname, profile.tailscalePort, 'saved profile');
+  return {
+    ...profile,
+    hostname: endpoint.hostname,
+    tailscalePort: endpoint.port || '443'
+  };
 }
 
 function tailscaleEndpointOptions(args, profile = {}) {
@@ -3161,13 +3176,14 @@ async function collectTunnelPreference(rl, defaults, profile, options = {}) {
     cloudflareConfig = optionValue(defaults, profile, 'cloudflareConfig', ['CODEXPRO_CLOUDFLARE_CONFIG', 'CLOUDFLARE_TUNNEL_CONFIG'], '');
     cloudflareTokenFile = optionValue(defaults, profile, 'cloudflareTokenFile', ['CODEXPRO_CLOUDFLARE_TUNNEL_TOKEN_FILE', 'CLOUDFLARE_TUNNEL_TOKEN_FILE'], '');
   } else if (tunnel === 'tailscale') {
+    const defaultEndpoint = tailscaleEndpointOptions(defaults, profile);
     hostname = await ask(
       rl,
       'Tailscale Funnel hostname, without /mcp',
-      optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'TAILSCALE_FUNNEL_HOSTNAME'], '')
+      defaultEndpoint.hostname
     );
     if (!hostname) throw new Error('Tailscale setup needs your Funnel hostname, for example machine.tailnet.ts.net.');
-    const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', optionValue(defaults, profile, 'tailscalePort', ['CODEXPRO_TAILSCALE_PORT'], '443')), 'guided setup');
+    const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', defaultEndpoint.port), 'guided setup');
     hostname = endpoint.hostname;
     tailscalePort = endpoint.port;
   }
@@ -3413,13 +3429,14 @@ async function runSetupWizard(argv) {
       }
     } else if (tunnelChoice === 'tailscale') {
       profileTunnel = 'tailscale';
+      const defaultEndpoint = tailscaleEndpointOptions(defaults, profile);
       let hostname = await ask(
         rl,
         'Tailscale Funnel hostname, without /mcp',
-        optionValue(defaults, profile, 'hostname', ['CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'TAILSCALE_FUNNEL_HOSTNAME'], '')
+        defaultEndpoint.hostname
       );
       if (!hostname) throw new Error('Tailscale setup needs your Funnel hostname, for example machine.tailnet.ts.net.');
-      const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', optionValue(defaults, profile, 'tailscalePort', ['CODEXPRO_TAILSCALE_PORT'], '443')), 'guided setup');
+      const endpoint = normalizeTailscaleEndpoint(hostname, await ask(rl, 'Tailscale Funnel public HTTPS port', defaultEndpoint.port), 'guided setup');
       profileHostname = endpoint.hostname;
       profileTailscalePort = endpoint.port;
       args.push('--tunnel', 'tailscale', '--hostname', profileHostname, '--tailscale-port', profileTailscalePort);

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -371,10 +371,13 @@ try {
   if (!homeText.includes('history.replaceState') || !homeText.includes('initialUrl.searchParams.delete("codexpro_token")')) {
     throw new Error('onboarding page did not remove query credentials from browser history');
   }
-  for (const fieldName of ['tunnelName', 'ngrokConfig', 'cloudflareConfig', 'cloudflareTokenFile', 'toolCards', 'noInstallCloudflared']) {
+  for (const fieldName of ['tunnelName', 'ngrokConfig', 'cloudflareConfig', 'cloudflareTokenFile', 'tailscalePort', 'toolCards', 'noInstallCloudflared']) {
     if (!homeText.includes(`name="${fieldName}"`)) {
       throw new Error(`onboarding page did not include profile field ${fieldName}`);
     }
+  }
+  if (!homeText.includes('<label data-tailscale-port-wrap hidden>') || !homeText.includes('tailscalePortInput.hidden = tunnel !== "tailscale"')) {
+    throw new Error('onboarding page did not restrict the Tailscale public-port selector to Tailscale Funnel');
   }
   if (homeText.includes(token)) {
     throw new Error('onboarding page leaked the raw auth token');
@@ -471,6 +474,75 @@ try {
     allowedRoots: [realAlternateRoot]
   }, null, 2), 'utf8');
 
+  const invalidTailscalePort = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tunnel: 'tailscale',
+      hostname: 'codexpro-http-smoke.tailnet.ts.net',
+      tailscalePort: '9999'
+    })
+  });
+  const invalidTailscalePortJson = await invalidTailscalePort.json();
+  if (invalidTailscalePort.status !== 400 || !invalidTailscalePortJson.error?.issues?.fieldErrors?.tailscalePort?.length) {
+    throw new Error(`expected invalid Tailscale Funnel port to be rejected, got ${invalidTailscalePort.status} ${JSON.stringify(invalidTailscalePortJson)}`);
+  }
+
+  const tailscaleProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tunnel: 'tailscale',
+      hostname: 'https://codexpro-http-smoke.tailnet.ts.net/mcp',
+      tailscalePort: '8443'
+    })
+  });
+  const tailscaleProfileJson = await tailscaleProfile.json();
+  const savedTailscaleProfile = JSON.parse(await fs.readFile(tailscaleProfileJson.profile_path, 'utf8'));
+  if (
+    tailscaleProfile.status !== 200 ||
+    savedTailscaleProfile.version !== 1 ||
+    savedTailscaleProfile.hostname !== 'codexpro-http-smoke.tailnet.ts.net' ||
+    savedTailscaleProfile.tailscalePort !== '8443' ||
+    tailscaleProfileJson.profile?.tailscalePort !== '8443' ||
+    tailscaleProfileJson.effective?.tailscalePort !== '8443'
+  ) {
+    throw new Error(`expected Tailscale selector port to persist independently from local port, got ${tailscaleProfile.status} ${JSON.stringify(tailscaleProfileJson)} ${JSON.stringify(savedTailscaleProfile)}`);
+  }
+
+  await fs.writeFile(path.join(profileHome, 'runtime', `${runtimeId}.json`), JSON.stringify({ version: 1, root, tunnel: 'tailscale' }), 'utf8');
+  const tailscaleHome = await fetch(`${baseUrl}/?codexpro_token=${encodeURIComponent(token)}`);
+  const tailscaleHomeText = await tailscaleHome.text();
+  if (
+    tailscaleHome.status !== 200 ||
+    !tailscaleHomeText.includes('<select name="tailscalePort" data-tailscale-port><option value="443">443</option><option value="8443" selected>8443</option><option value="10000">10000</option></select>') ||
+    !tailscaleHomeText.includes('https://codexpro-http-smoke.tailnet.ts.net:8443/mcp') ||
+    !tailscaleHomeText.includes('serverPreviewFor(hostnameInput.value, tunnel === "tailscale" ? tailscalePortInput?.value : "")') ||
+    !tailscaleHomeText.includes('tailscalePort: data.tailscalePort')
+  ) {
+    throw new Error('Tailscale profile page did not render or submit the selected non-default public port');
+  }
+
+  const { tailscalePort: _savedTailscalePort, ...legacyTailscaleProfileSeed } = savedTailscaleProfile;
+  await fs.writeFile(tailscaleProfileJson.profile_path, JSON.stringify({
+    ...legacyTailscaleProfileSeed,
+    hostname: 'legacy-http-smoke.tailnet.ts.net:8443'
+  }, null, 2), 'utf8');
+  const legacyTailscaleProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ tunnel: 'tailscale' })
+  });
+  const legacyTailscaleProfileJson = await legacyTailscaleProfile.json();
+  const savedLegacyTailscaleProfile = JSON.parse(await fs.readFile(legacyTailscaleProfileJson.profile_path, 'utf8'));
+  if (
+    legacyTailscaleProfile.status !== 200 ||
+    savedLegacyTailscaleProfile.hostname !== 'legacy-http-smoke.tailnet.ts.net' ||
+    savedLegacyTailscaleProfile.tailscalePort !== '8443'
+  ) {
+    throw new Error(`expected legacy Tailscale hostname port to canonicalize on save, got ${legacyTailscaleProfile.status} ${JSON.stringify(savedLegacyTailscaleProfile)}`);
+  }
+
   const localProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -486,15 +558,18 @@ try {
     localSavedProfile.cloudflareConfig ||
     localSavedProfile.cloudflareToken ||
     localSavedProfile.cloudflareTokenFile ||
+    localSavedProfile.tailscalePort ||
     JSON.stringify(localSavedProfile.allowedRoots) !== JSON.stringify([realAlternateRoot]) ||
     localProfileJson.profile?.hostname ||
     localProfileJson.profile?.ngrokConfig ||
     localProfileJson.profile?.cloudflareToken ||
     localProfileJson.profile?.cloudflareTokenFile ||
+    localProfileJson.profile?.tailscalePort ||
     localProfileJson.effective?.hostname ||
     localProfileJson.effective?.ngrokConfig ||
     localProfileJson.effective?.cloudflareToken ||
-    localProfileJson.effective?.cloudflareTokenFile
+    localProfileJson.effective?.cloudflareTokenFile ||
+    localProfileJson.effective?.tailscalePort
   ) {
     throw new Error(`admin profile local-only save kept stale tunnel config: ${JSON.stringify(localProfileJson)} ${JSON.stringify(localSavedProfile)}`);
   }

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -488,6 +488,25 @@ try {
     throw new Error(`expected invalid Tailscale Funnel port to be rejected, got ${invalidTailscalePort.status} ${JSON.stringify(invalidTailscalePortJson)}`);
   }
 
+  const conflictingDefaultTailscalePort = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tunnel: 'tailscale',
+      hostname: 'codexpro-http-smoke.tailnet.ts.net:443',
+      tailscalePort: '8443'
+    })
+  });
+  const conflictingDefaultTailscalePortJson = await conflictingDefaultTailscalePort.json();
+  if (
+    conflictingDefaultTailscalePort.status !== 400
+    || !/conflicting Tailscale Funnel ports/i.test(conflictingDefaultTailscalePortJson.error?.message ?? '')
+  ) {
+    throw new Error(
+      `expected explicit :443 to conflict with dedicated port 8443, got ${conflictingDefaultTailscalePort.status} ${JSON.stringify(conflictingDefaultTailscalePortJson)}`
+    );
+  }
+
   const tailscaleProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -73,6 +73,19 @@ async function readProfile(root, home) {
   return JSON.parse(await fs.readFile(path.join(home, 'profiles', `${id}.json`), 'utf8'));
 }
 
+async function writeRawProfile(root, home, profile) {
+  const realRoot = await fs.realpath(root);
+  const id = createHash('sha256').update(realRoot).digest('hex').slice(0, 24);
+  const profilesDir = path.join(home, 'profiles');
+  await fs.mkdir(profilesDir, { recursive: true });
+  await fs.writeFile(path.join(profilesDir, `${id}.json`), `${JSON.stringify({
+    version: 1,
+    ...profile,
+    root: realRoot,
+    updatedAt: new Date().toISOString()
+  }, null, 2)}\n`, 'utf8');
+}
+
 async function runtimeStatusPath(root, home) {
   const realRoot = await fs.realpath(root);
   const id = createHash('sha256').update(realRoot).digest('hex').slice(0, 24);
@@ -165,6 +178,76 @@ function findPythonForPty() {
     if (result.status === 0) return command;
   }
   return '';
+}
+
+function runInteractiveAnswers(args, env, answers) {
+  const python = findPythonForPty();
+  if (!python) return null;
+  const payload = JSON.stringify({
+    cmd: process.execPath,
+    args: ['scripts/codexpro.mjs', ...args],
+    cwd: path.resolve('.'),
+    answers
+  });
+  const code = `
+import json, os, pty, select, subprocess, sys, time
+payload = json.loads(sys.argv[1])
+master, slave = pty.openpty()
+proc = subprocess.Popen([payload["cmd"]] + payload["args"], cwd=payload["cwd"], env=os.environ.copy(), stdin=slave, stdout=slave, stderr=slave, close_fds=True)
+os.close(slave)
+out = bytearray()
+pending = bytearray()
+answer_index = 0
+deadline = time.time() + 20
+while time.time() < deadline:
+    if proc.poll() is not None:
+        break
+    ready, _, _ = select.select([master], [], [], 0.1)
+    if not ready:
+        continue
+    try:
+        chunk = os.read(master, 4096)
+    except OSError:
+        break
+    if not chunk:
+        break
+    out.extend(chunk)
+    pending.extend(chunk)
+    if answer_index < len(payload["answers"]) and pending.endswith(b"\\n> "):
+        os.write(master, (payload["answers"][answer_index] + "\\n").encode())
+        answer_index += 1
+        pending.clear()
+if proc.poll() is None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    sys.stderr.write(out.decode(errors="replace"))
+    raise SystemExit(124)
+while True:
+    ready, _, _ = select.select([master], [], [], 0)
+    if not ready:
+        break
+    try:
+        chunk = os.read(master, 4096)
+    except OSError:
+        break
+    if not chunk:
+        break
+    out.extend(chunk)
+os.close(master)
+sys.stdout.write(out.decode(errors="replace"))
+raise SystemExit(proc.returncode or 0)
+`;
+  const result = spawnSync(python, ['-c', code, payload], {
+    cwd: path.resolve('.'),
+    env: { ...env, NO_COLOR: '1' },
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024
+  });
+  return { status: result.status, output: `${result.stdout}\n${result.stderr}` };
 }
 
 function runInteractiveQuit(args, env) {
@@ -1002,5 +1085,100 @@ run([
 const localTailscaleSettingsProfile = await readProfile(tailscaleSettingsRoot, home);
 if (localTailscaleSettingsProfile.tailscalePort !== undefined) {
   throw new Error(`non-Tailscale settings kept a stale Tailscale public port: ${JSON.stringify(localTailscaleSettingsProfile)}`);
+}
+
+const guidedLegacyHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-legacy-home-'));
+const guidedLegacyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-legacy-root-'));
+await writeRawProfile(guidedLegacyRoot, guidedLegacyHome, {
+  tunnel: 'tailscale',
+  hostname: 'guided-legacy.tailnet.ts.net:8443',
+  port: '8787',
+  mode: 'agent',
+  token: 'guided-legacy-token'
+});
+const guidedLegacyEnv = { ...process.env, CODEXPRO_HOME: guidedLegacyHome };
+delete guidedLegacyEnv.CI;
+const guidedLegacy = runInteractiveAnswers([
+  'setup', '--root', guidedLegacyRoot
+], guidedLegacyEnv, ['', '', '', '', '', '', '', '', 'no']);
+if (guidedLegacy && guidedLegacy.status !== 0) {
+  throw new Error(`guided setup rejected defaults from a legacy saved Tailscale hostname\n${guidedLegacy.output}`);
+}
+if (guidedLegacy) {
+  const guidedLegacyProfile = await readProfile(guidedLegacyRoot, guidedLegacyHome);
+  if (guidedLegacyProfile.hostname !== 'guided-legacy.tailnet.ts.net' || guidedLegacyProfile.tailscalePort !== '8443') {
+    throw new Error(`guided setup did not canonicalize legacy saved Tailscale defaults: ${JSON.stringify(guidedLegacyProfile)}`);
+  }
+}
+
+const guidedEnvHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-env-home-'));
+const guidedEnvRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-env-root-'));
+const guidedEnv = {
+  ...process.env,
+  CODEXPRO_HOME: guidedEnvHome,
+  CODEXPRO_TUNNEL: 'tailscale',
+  CODEXPRO_HOSTNAME: 'guided-env.tailnet.ts.net:8443',
+  CODEXPRO_HTTP_TOKEN: 'guided-env-token'
+};
+delete guidedEnv.CI;
+const guidedFromEnv = runInteractiveAnswers([
+  'setup', '--root', guidedEnvRoot
+], guidedEnv, ['', '', '', '', '', '', '', '', 'no']);
+if (guidedFromEnv && guidedFromEnv.status !== 0) {
+  throw new Error(`guided setup rejected defaults from a legacy environment Tailscale hostname\n${guidedFromEnv.output}`);
+}
+if (guidedFromEnv) {
+  const guidedEnvProfile = await readProfile(guidedEnvRoot, guidedEnvHome);
+  if (guidedEnvProfile.hostname !== 'guided-env.tailnet.ts.net' || guidedEnvProfile.tailscalePort !== '8443') {
+    throw new Error(`guided setup did not canonicalize legacy environment Tailscale defaults: ${JSON.stringify(guidedEnvProfile)}`);
+  }
+}
+
+const legacyReuseHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-reuse-home-'));
+const legacyReuseSource = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-reuse-source-'));
+const legacyFirstRunTarget = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-first-run-target-'));
+const legacySettingsTarget = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-settings-target-'));
+await writeRawProfile(legacyReuseSource, legacyReuseHome, {
+  tunnel: 'tailscale',
+  hostname: 'reused-legacy.tailnet.ts.net:8443',
+  port: '8787',
+  mode: 'agent',
+  token: 'reused-legacy-token'
+});
+const legacyReuseEnv = { ...process.env, CODEXPRO_HOME: legacyReuseHome };
+delete legacyReuseEnv.CI;
+const firstRunReuse = runInteractiveAnswers([
+  'start', '--root', legacyFirstRunTarget, '--port', 'invalid'
+], legacyReuseEnv, ['']);
+if (firstRunReuse && (firstRunReuse.status === 0 || !/Invalid port: invalid/i.test(firstRunReuse.output))) {
+  throw new Error(`first-run profile reuse did not reach the expected post-save validation\n${firstRunReuse.output}`);
+}
+if (firstRunReuse) {
+  const firstRunReusedProfile = await readProfile(legacyFirstRunTarget, legacyReuseHome);
+  if (firstRunReusedProfile.hostname !== 'reused-legacy.tailnet.ts.net' || firstRunReusedProfile.tailscalePort !== '8443') {
+    throw new Error(`first-run profile reuse did not canonicalize legacy Tailscale settings: ${JSON.stringify(firstRunReusedProfile)}`);
+  }
+}
+
+run([
+  'settings', 'use', '--root', legacySettingsTarget, '--from-root', legacyReuseSource
+], legacyReuseEnv);
+const settingsReusedProfile = await readProfile(legacySettingsTarget, legacyReuseHome);
+if (settingsReusedProfile.hostname !== 'reused-legacy.tailnet.ts.net' || settingsReusedProfile.tailscalePort !== '8443') {
+  throw new Error(`settings use did not canonicalize legacy Tailscale settings: ${JSON.stringify(settingsReusedProfile)}`);
+}
+
+const legacyDisplayHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-display-home-'));
+const legacyDisplayRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-display-root-'));
+await writeRawProfile(legacyDisplayRoot, legacyDisplayHome, {
+  tunnel: 'tailscale',
+  hostname: 'display-legacy.tailnet.ts.net:8443',
+  tailscalePort: '8443',
+  port: '8787',
+  mode: 'agent'
+});
+const legacyDisplay = run(['settings', 'list'], { ...process.env, CODEXPRO_HOME: legacyDisplayHome });
+if (!legacyDisplay.includes('display-legacy.tailnet.ts.net:8443') || legacyDisplay.includes('display-legacy.tailnet.ts.net:8443:8443')) {
+  throw new Error(`settings list did not normalize a matching legacy suffix and dedicated Tailscale port\n${legacyDisplay}`);
 }
 console.log('✓ settings smoke test passed');

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -888,7 +888,6 @@ if (!afterDelete.includes('No saved settings')) {
   throw new Error(`expected empty settings after delete, got:\n${afterDelete}`);
 }
 
-console.log('✓ settings smoke test passed');
 const tailscaleSettingsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-tailscale-config-'));
 run([
   'settings',
@@ -904,6 +903,15 @@ const tailscaleSettingsProfile = await readProfile(tailscaleSettingsRoot, home);
 if (tailscaleSettingsProfile.hostname !== 'codexpro-config.tailnet.ts.net' || tailscaleSettingsProfile.tailscalePort !== '8443') {
   throw new Error(`tailscale settings did not canonicalize legacy hostname port: ${JSON.stringify(tailscaleSettingsProfile)}`);
 }
+const tailscaleSettingsShown = run(['settings', 'show', '--root', tailscaleSettingsRoot], env);
+if (!tailscaleSettingsShown.includes('Tailscale port') || !tailscaleSettingsShown.includes('8443')) {
+  throw new Error(`tailscale settings show did not display the dedicated public port\n${tailscaleSettingsShown}`);
+}
+const tailscaleSettingsListed = run(['settings', 'list'], env);
+if (!tailscaleSettingsListed.includes('codexpro-config.tailnet.ts.net:8443') || !tailscaleSettingsListed.includes('local :8787')) {
+  throw new Error(`tailscale settings list did not distinguish public and local ports\n${tailscaleSettingsListed}`);
+}
+
 
 const tailscaleEnvPort = await getFreePort();
 const tailscaleEnvFailure = runFail([
@@ -995,3 +1003,4 @@ const localTailscaleSettingsProfile = await readProfile(tailscaleSettingsRoot, h
 if (localTailscaleSettingsProfile.tailscalePort !== undefined) {
   throw new Error(`non-Tailscale settings kept a stale Tailscale public port: ${JSON.stringify(localTailscaleSettingsProfile)}`);
 }
+console.log('✓ settings smoke test passed');

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -889,3 +889,109 @@ if (!afterDelete.includes('No saved settings')) {
 }
 
 console.log('✓ settings smoke test passed');
+const tailscaleSettingsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-tailscale-config-'));
+run([
+  'settings',
+  'set',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tunnel',
+  'tailscale',
+  '--hostname',
+  'https://codexpro-config.tailnet.ts.net:8443/mcp'
+], env);
+const tailscaleSettingsProfile = await readProfile(tailscaleSettingsRoot, home);
+if (tailscaleSettingsProfile.hostname !== 'codexpro-config.tailnet.ts.net' || tailscaleSettingsProfile.tailscalePort !== '8443') {
+  throw new Error(`tailscale settings did not canonicalize legacy hostname port: ${JSON.stringify(tailscaleSettingsProfile)}`);
+}
+
+const tailscaleEnvPort = await getFreePort();
+const tailscaleEnvFailure = runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  fakeTailscale,
+  '--port',
+  String(tailscaleEnvPort),
+  '--token',
+  'codexpro-tailscale-env-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_TAILSCALE_PORT: '10000' }, /Recent tailscale output/);
+if (!tailscaleEnvFailure.includes(`funnel|--https=10000|http://127.0.0.1:${tailscaleEnvPort}`)) {
+  throw new Error(`tailscale environment public port did not override the saved profile\n${tailscaleEnvFailure}`);
+}
+
+const tailscaleCliPort = await getFreePort();
+const tailscaleCliFailure = runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  fakeTailscale,
+  '--port',
+  String(tailscaleCliPort),
+  '--tailscale-port',
+  '443',
+  '--token',
+  'codexpro-tailscale-cli-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_TAILSCALE_PORT: '10000' }, /Recent tailscale output/);
+if (!tailscaleCliFailure.includes(`funnel|http://127.0.0.1:${tailscaleCliPort}`) || tailscaleCliFailure.includes('--https=')) {
+  throw new Error(`tailscale CLI public port did not override environment without changing the local port\n${tailscaleCliFailure}`);
+}
+
+const invalidTailscaleMarker = path.join(home, 'invalid-tailscale-started');
+const invalidTailscale = await writeNodeExecutable(path.join(home, 'invalid-tailscale.mjs'), [
+  '#!/usr/bin/env node',
+  "import fs from 'node:fs';",
+  "fs.writeFileSync(process.env.CODEXPRO_INVALID_TAILSCALE_MARKER, 'started');",
+  'process.exit(2);',
+  ''
+]);
+runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  invalidTailscale,
+  '--tailscale-port',
+  '9999',
+  '--token',
+  'codexpro-tailscale-invalid-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_INVALID_TAILSCALE_MARKER: invalidTailscaleMarker }, /Tailscale Funnel HTTPS port must be 443, 8443, or 10000/i);
+try {
+  await fs.access(invalidTailscaleMarker);
+  throw new Error('invalid Tailscale public port started a child process');
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error;
+}
+
+runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  invalidTailscale,
+  '--hostname',
+  'codexpro-config.tailnet.ts.net:8443',
+  '--tailscale-port',
+  '10000',
+  '--token',
+  'codexpro-tailscale-conflict-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_INVALID_TAILSCALE_MARKER: invalidTailscaleMarker }, /conflicting Tailscale Funnel ports/i);
+
+run([
+  'settings',
+  'set',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tunnel',
+  'none'
+], env);
+const localTailscaleSettingsProfile = await readProfile(tailscaleSettingsRoot, home);
+if (localTailscaleSettingsProfile.tailscalePort !== undefined) {
+  throw new Error(`non-Tailscale settings kept a stale Tailscale public port: ${JSON.stringify(localTailscaleSettingsProfile)}`);
+}

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -1087,6 +1087,19 @@ if (localTailscaleSettingsProfile.tailscalePort !== undefined) {
   throw new Error(`non-Tailscale settings kept a stale Tailscale public port: ${JSON.stringify(localTailscaleSettingsProfile)}`);
 }
 
+runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tunnel',
+  'cloudflare',
+  '--tailscale-port',
+  '10000',
+  '--token',
+  'codexpro-tailscale-misapplied-token',
+  '--no-copy-url'
+], env, /--tailscale-port only applies to --tunnel tailscale/i);
+
 const guidedLegacyHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-legacy-home-'));
 const guidedLegacyRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-legacy-root-'));
 await writeRawProfile(guidedLegacyRoot, guidedLegacyHome, {
@@ -1161,6 +1174,47 @@ if (guidedFromTailscaleEnv) {
     throw new Error(
       `guided setup did not canonicalize TAILSCALE_FUNNEL_HOSTNAME defaults: ${JSON.stringify(guidedTailscaleEnvProfile)}`
     );
+  }
+}
+
+const guidedRetryHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-retry-home-'));
+const guidedRetryRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-retry-root-'));
+const guidedRetryEnv = { ...process.env, CODEXPRO_HOME: guidedRetryHome, CODEXPRO_HTTP_TOKEN: 'guided-retry-token' };
+for (const name of ['CI', 'CODEXPRO_TUNNEL', 'CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'NGROK_DOMAIN', 'TAILSCALE_FUNNEL_HOSTNAME', 'CODEXPRO_TAILSCALE_PORT']) {
+  delete guidedRetryEnv[name];
+}
+const guidedRetry = runInteractiveAnswers([
+  'setup', '--root', guidedRetryRoot
+], guidedRetryEnv, ['', '', '', 'tailscale', 'guided-retry.tailnet.ts.net', '8080', '10000', '', '', 'no']);
+if (guidedRetry && guidedRetry.status !== 0) {
+  throw new Error(`guided setup aborted instead of re-asking for a valid Tailscale port\n${guidedRetry.output}`);
+}
+if (guidedRetry) {
+  if (!/is not a Funnel port/i.test(guidedRetry.output)) {
+    throw new Error(`guided setup accepted an invalid Tailscale port without complaining\n${guidedRetry.output}`);
+  }
+  const guidedRetryProfile = await readProfile(guidedRetryRoot, guidedRetryHome);
+  if (guidedRetryProfile.hostname !== 'guided-retry.tailnet.ts.net' || guidedRetryProfile.tailscalePort !== '10000') {
+    throw new Error(`guided setup did not save the re-asked Tailscale port: ${JSON.stringify(guidedRetryProfile)}`);
+  }
+}
+
+const guidedTypedHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-typed-home-'));
+const guidedTypedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-typed-root-'));
+const guidedTypedEnv = { ...process.env, CODEXPRO_HOME: guidedTypedHome, CODEXPRO_HTTP_TOKEN: 'guided-typed-token' };
+for (const name of ['CI', 'CODEXPRO_TUNNEL', 'CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'NGROK_DOMAIN', 'TAILSCALE_FUNNEL_HOSTNAME', 'CODEXPRO_TAILSCALE_PORT']) {
+  delete guidedTypedEnv[name];
+}
+const guidedTyped = runInteractiveAnswers([
+  'setup', '--root', guidedTypedRoot
+], guidedTypedEnv, ['', '', '', 'tailscale', 'guided-typed.tailnet.ts.net:8443', '', '', '', 'no']);
+if (guidedTyped && guidedTyped.status !== 0) {
+  throw new Error(`guided setup rejected a typed Tailscale hostname carrying a port suffix\n${guidedTyped.output}`);
+}
+if (guidedTyped) {
+  const guidedTypedProfile = await readProfile(guidedTypedRoot, guidedTypedHome);
+  if (guidedTypedProfile.hostname !== 'guided-typed.tailnet.ts.net' || guidedTypedProfile.tailscalePort !== '8443') {
+    throw new Error(`guided setup did not prefill the port from a typed hostname suffix: ${JSON.stringify(guidedTypedProfile)}`);
   }
 }
 

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -190,7 +190,7 @@ function runInteractiveAnswers(args, env, answers) {
     answers
   });
   const code = `
-import json, os, pty, select, subprocess, sys, time
+import json, os, pty, re, select, subprocess, sys, time
 payload = json.loads(sys.argv[1])
 master, slave = pty.openpty()
 proc = subprocess.Popen([payload["cmd"]] + payload["args"], cwd=payload["cwd"], env=os.environ.copy(), stdin=slave, stdout=slave, stderr=slave, close_fds=True)
@@ -213,7 +213,7 @@ while time.time() < deadline:
         break
     out.extend(chunk)
     pending.extend(chunk)
-    if answer_index < len(payload["answers"]) and pending.endswith(b"\\n> "):
+    if answer_index < len(payload["answers"]) and re.sub(rb"\\x1b\\[[0-9;?]*[A-Za-z]", b"", bytes(pending)).endswith(b"\\n> "):
         os.write(master, (payload["answers"][answer_index] + "\\n").encode())
         answer_index += 1
         pending.clear()

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -198,6 +198,7 @@ os.close(slave)
 out = bytearray()
 pending = bytearray()
 answer_index = 0
+pty_closed = False
 deadline = time.time() + 20
 while time.time() < deadline:
     if proc.poll() is not None:
@@ -208,8 +209,10 @@ while time.time() < deadline:
     try:
         chunk = os.read(master, 4096)
     except OSError:
+        pty_closed = True
         break
     if not chunk:
+        pty_closed = True
         break
     out.extend(chunk)
     pending.extend(chunk)
@@ -217,6 +220,11 @@ while time.time() < deadline:
         os.write(master, (payload["answers"][answer_index] + "\\n").encode())
         answer_index += 1
         pending.clear()
+if pty_closed and proc.poll() is None:
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
 if proc.poll() is None:
     proc.terminate()
     try:

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -1040,6 +1040,80 @@ if (!tailscaleCliFailure.includes(`funnel|http://127.0.0.1:${tailscaleCliPort}`)
   throw new Error(`tailscale CLI public port did not override environment without changing the local port\n${tailscaleCliFailure}`);
 }
 
+const tailscaleHostname443Port = await getFreePort();
+const tailscaleHostname443Failure = runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  fakeTailscale,
+  '--hostname',
+  'codexpro-config.tailnet.ts.net:443',
+  '--port',
+  String(tailscaleHostname443Port),
+  '--token',
+  'codexpro-tailscale-hostname-port-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_TAILSCALE_PORT: '10000' }, /Recent tailscale output/);
+if (
+  !tailscaleHostname443Failure.includes(`funnel|http://127.0.0.1:${tailscaleHostname443Port}`)
+  || tailscaleHostname443Failure.includes('--https=')
+) {
+  throw new Error(`explicit CLI hostname port did not override the environment port\n${tailscaleHostname443Failure}`);
+}
+
+const tailscaleShadowedEnvPort = await getFreePort();
+const tailscaleShadowedEnvFailure = runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  fakeTailscale,
+  '--port',
+  String(tailscaleShadowedEnvPort),
+  '--tailscale-port',
+  '8443',
+  '--token',
+  'codexpro-tailscale-shadowed-env-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_TAILSCALE_PORT: '9999' }, /Recent tailscale output/);
+if (!tailscaleShadowedEnvFailure.includes(`funnel|--https=8443|http://127.0.0.1:${tailscaleShadowedEnvPort}`)) {
+  throw new Error(`valid CLI port did not shadow an invalid environment port\n${tailscaleShadowedEnvFailure}`);
+}
+
+const tailscaleShadowedSavedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-tailscale-shadowed-saved-'));
+await writeRawProfile(tailscaleShadowedSavedRoot, home, {
+  tunnel: 'tailscale',
+  hostname: 'shadowed-saved.tailnet.ts.net',
+  tailscalePort: '9999',
+  port: '8787',
+  mode: 'agent',
+  token: 'codexpro-tailscale-shadowed-saved-token'
+});
+const tailscaleShadowedSavedPort = await getFreePort();
+const tailscaleShadowedSavedFailure = runFail([
+  'start',
+  '--root',
+  tailscaleShadowedSavedRoot,
+  '--tailscale',
+  fakeTailscale,
+  '--port',
+  String(tailscaleShadowedSavedPort),
+  '--token',
+  'codexpro-tailscale-shadowed-saved-token',
+  '--no-copy-url'
+], {
+  ...env,
+  CODEXPRO_PUBLIC_HOSTNAME: '',
+  CODEXPRO_HOSTNAME: '',
+  TAILSCALE_FUNNEL_HOSTNAME: '',
+  NGROK_DOMAIN: '',
+  CODEXPRO_TAILSCALE_PORT: '8443'
+}, /Recent tailscale output/);
+if (!tailscaleShadowedSavedFailure.includes(`funnel|--https=8443|http://127.0.0.1:${tailscaleShadowedSavedPort}`)) {
+  throw new Error(`valid environment port did not shadow an invalid saved port\n${tailscaleShadowedSavedFailure}`);
+}
+
 const invalidTailscaleMarker = path.join(home, 'invalid-tailscale-started');
 const invalidTailscale = await writeNodeExecutable(path.join(home, 'invalid-tailscale.mjs'), [
   '#!/usr/bin/env node',
@@ -1081,6 +1155,56 @@ runFail([
   'codexpro-tailscale-conflict-token',
   '--no-copy-url'
 ], { ...env, CODEXPRO_INVALID_TAILSCALE_MARKER: invalidTailscaleMarker }, /conflicting Tailscale Funnel ports/i);
+
+runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  invalidTailscale,
+  '--hostname',
+  'codexpro-config.tailnet.ts.net:443',
+  '--tailscale-port',
+  '8443',
+  '--token',
+  'codexpro-tailscale-default-port-conflict-token',
+  '--no-copy-url'
+], { ...env, CODEXPRO_INVALID_TAILSCALE_MARKER: invalidTailscaleMarker }, /conflicting Tailscale Funnel ports/i);
+
+runFail([
+  'start',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tailscale',
+  invalidTailscale,
+  '--hostname',
+  'cli-hostname.tailnet.ts.net',
+  '--token',
+  'codexpro-tailscale-environment-conflict-token',
+  '--no-copy-url'
+], {
+  ...env,
+  CODEXPRO_PUBLIC_HOSTNAME: 'environment-hostname.tailnet.ts.net:8443',
+  CODEXPRO_TAILSCALE_PORT: '10000',
+  CODEXPRO_INVALID_TAILSCALE_MARKER: invalidTailscaleMarker
+}, /conflicting Tailscale Funnel ports/i);
+try {
+  await fs.access(invalidTailscaleMarker);
+  throw new Error('conflicting Tailscale public ports started a child process');
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error;
+}
+
+runFail([
+  'settings',
+  'set',
+  '--root',
+  tailscaleSettingsRoot,
+  '--tunnel',
+  'none',
+  '--tailscale-port',
+  '8443'
+], env, /--tailscale-port only applies to --tunnel tailscale/i);
 
 run([
   'settings',

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -1134,6 +1134,36 @@ if (guidedFromEnv) {
   }
 }
 
+const guidedTailscaleEnvHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-tailscale-env-home-'));
+const guidedTailscaleEnvRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-guided-tailscale-env-root-'));
+const guidedTailscaleEnv = {
+  ...process.env,
+  CODEXPRO_HOME: guidedTailscaleEnvHome,
+  CODEXPRO_TUNNEL: 'tailscale',
+  TAILSCALE_FUNNEL_HOSTNAME: 'guided-tailscale-env.tailnet.ts.net:8443',
+  CODEXPRO_HTTP_TOKEN: 'guided-tailscale-env-token'
+};
+for (const name of ['CI', 'CODEXPRO_PUBLIC_HOSTNAME', 'CODEXPRO_HOSTNAME', 'NGROK_DOMAIN', 'CODEXPRO_TAILSCALE_PORT']) {
+  delete guidedTailscaleEnv[name];
+}
+const guidedFromTailscaleEnv = runInteractiveAnswers([
+  'setup', '--root', guidedTailscaleEnvRoot
+], guidedTailscaleEnv, ['', '', '', '', '', '', '', '', 'no']);
+if (guidedFromTailscaleEnv && guidedFromTailscaleEnv.status !== 0) {
+  throw new Error(`guided setup rejected TAILSCALE_FUNNEL_HOSTNAME defaults\n${guidedFromTailscaleEnv.output}`);
+}
+if (guidedFromTailscaleEnv) {
+  const guidedTailscaleEnvProfile = await readProfile(guidedTailscaleEnvRoot, guidedTailscaleEnvHome);
+  if (
+    guidedTailscaleEnvProfile.hostname !== 'guided-tailscale-env.tailnet.ts.net'
+    || guidedTailscaleEnvProfile.tailscalePort !== '8443'
+  ) {
+    throw new Error(
+      `guided setup did not canonicalize TAILSCALE_FUNNEL_HOSTNAME defaults: ${JSON.stringify(guidedTailscaleEnvProfile)}`
+    );
+  }
+}
+
 const legacyReuseHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-reuse-home-'));
 const legacyReuseSource = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-reuse-source-'));
 const legacyFirstRunTarget = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-settings-legacy-first-run-target-'));

--- a/src/http.ts
+++ b/src/http.ts
@@ -135,10 +135,18 @@ function normalizePublicHostname(value: string | undefined): string {
   return url.host;
 }
 
+function explicitHostnamePort(value: string | undefined): string {
+  const raw = value?.trim().replace(/\/+$/, "") ?? "";
+  if (!raw) return "";
+  const authorityStart = raw.includes("://") ? raw.indexOf("://") + 3 : 0;
+  const authority = raw.slice(authorityStart).split(/[/?#]/, 1)[0];
+  return authority.match(/:(\d+)$/)?.[1] ?? "";
+}
+
 function normalizeTailscaleEndpoint(hostname: string | undefined, tailscalePort: string | undefined): { hostname: string; tailscalePort: string } {
   const normalizedHostname = normalizePublicHostname(hostname);
   const parsed = normalizedHostname ? new URL(`https://${normalizedHostname}`) : null;
-  const legacyPort = parsed?.port ?? "";
+  const legacyPort = explicitHostnamePort(hostname);
   const requestedPort = tailscalePort ?? "";
   if (requestedPort && !TAILSCALE_PORTS.includes(requestedPort as (typeof TAILSCALE_PORTS)[number])) {
     throw new Error("Tailscale Funnel HTTPS port must be 443, 8443, or 10000.");

--- a/src/http.ts
+++ b/src/http.ts
@@ -48,6 +48,7 @@ function copyCommand(title: string, description: string, command: string, displa
 }
 
 const TUNNELS = ["cloudflare", "ngrok", "cloudflare-named", "tailscale", "none"] as const;
+const TAILSCALE_PORTS = ["443", "8443", "10000"] as const;
 const MODES = ["agent", "handoff", "pro"] as const;
 const BASH_MODES = ["safe", "off", "full"] as const;
 const BASH_TRANSCRIPTS = ["compact", "full"] as const;
@@ -57,10 +58,15 @@ const TOOL_MODES = ["standard", "minimal", "full"] as const;
 
 const textField = (max: number) =>
   z.preprocess((value) => (typeof value === "string" ? value.trim() : value), z.string().max(max).optional());
+const tailscalePortField = z.preprocess(
+  (value) => (typeof value === "number" ? String(value) : typeof value === "string" ? value.trim() : value),
+  z.enum(TAILSCALE_PORTS).optional()
+);
 
 const AdminProfilePatch = z.object({
   tunnel: z.enum(TUNNELS).optional(),
   hostname: textField(253),
+  tailscalePort: tailscalePortField,
   port: z.coerce.number().int().min(1).max(65535).optional(),
   mode: z.enum(MODES).optional(),
   bash: z.enum(BASH_MODES).optional(),
@@ -90,6 +96,7 @@ interface ProfileFormValues {
   mode: ConnectorMode;
   tunnel: TunnelMode;
   hostname: string;
+  tailscalePort: string;
   tunnelName: string;
   ngrokConfig: string;
   cloudflareConfig: string;
@@ -128,6 +135,29 @@ function normalizePublicHostname(value: string | undefined): string {
   return url.host;
 }
 
+function normalizeTailscaleEndpoint(hostname: string | undefined, tailscalePort: string | undefined): { hostname: string; tailscalePort: string } {
+  const normalizedHostname = normalizePublicHostname(hostname);
+  const parsed = normalizedHostname ? new URL(`https://${normalizedHostname}`) : null;
+  const legacyPort = parsed?.port ?? "";
+  const requestedPort = tailscalePort ?? "";
+  if (requestedPort && !TAILSCALE_PORTS.includes(requestedPort as (typeof TAILSCALE_PORTS)[number])) {
+    throw new Error("Tailscale Funnel HTTPS port must be 443, 8443, or 10000.");
+  }
+  if (legacyPort && !TAILSCALE_PORTS.includes(legacyPort as (typeof TAILSCALE_PORTS)[number])) {
+    throw new Error("Tailscale Funnel HTTPS port must be 443, 8443, or 10000.");
+  }
+  if (requestedPort && legacyPort && requestedPort !== legacyPort) {
+    throw new Error(`Conflicting Tailscale Funnel ports: tailscalePort is ${requestedPort}, but hostname uses ${legacyPort}.`);
+  }
+  return { hostname: parsed?.hostname ?? "", tailscalePort: requestedPort || legacyPort || "443" };
+}
+
+function publicEndpoint(tunnel: TunnelMode, hostname: string, tailscalePort: string): string {
+  if (!hostname) return "";
+  const publicHostname = tunnel === "tailscale" && tailscalePort !== "443" ? `${hostname}:${tailscalePort}` : hostname;
+  return `https://${publicHostname}/mcp`;
+}
+
 function normalizeWidgetDomain(value: string | undefined): string {
   const raw = value?.trim() ?? "";
   if (!raw) return "";
@@ -154,19 +184,22 @@ function normalizeProfilePath(root: string, value: string | undefined): string {
 }
 
 function profileValues(config: CodexProConfig, profile = readWorkspaceProfile(config.defaultRoot)): ProfileFormValues {
-  const hostname =
+  const rawHostname =
     profile.hostname ??
     process.env.CODEXPRO_PUBLIC_HOSTNAME ??
     process.env.CODEXPRO_HOSTNAME ??
     process.env.NGROK_DOMAIN ??
     "";
   const mode = oneOf(profile.mode ?? process.env.CODEXPRO_MODE, MODES, "agent");
+  const tunnel = oneOf(profile.tunnel, TUNNELS, runtimeTunnelFallback());
+  const tailscaleEndpoint = tunnel === "tailscale" ? normalizeTailscaleEndpoint(String(rawHostname), profile.tailscalePort) : null;
   const write = effectiveWriteMode(mode, oneOf(profile.write ?? config.writeMode, WRITE_MODES, config.writeMode));
   return {
     port: String(profile.port ?? config.port),
     mode,
-    tunnel: oneOf(profile.tunnel, TUNNELS, runtimeTunnelFallback()),
-    hostname: String(hostname),
+    tunnel,
+    hostname: tailscaleEndpoint?.hostname ?? String(rawHostname),
+    tailscalePort: tailscaleEndpoint?.tailscalePort ?? "",
     tunnelName: String(profile.tunnelName ?? ""),
     ngrokConfig: String(profile.ngrokConfig ?? ""),
     cloudflareConfig: String(profile.cloudflareConfig ?? ""),
@@ -247,7 +280,7 @@ function profileForm(config: CodexProConfig): string {
   const runtimeEndpoint = typeof runtime.endpoint === "string" ? runtime.endpoint : "";
   const runtimeTunnel = oneOf(runtime.tunnel ?? values.tunnel, TUNNELS, values.tunnel);
   const runtimeUrl = serverUrlDisplay(runtimeEndpoint, Boolean(config.authToken));
-  const savedEndpoint = values.hostname ? `https://${values.hostname}/mcp` : "";
+  const savedEndpoint = publicEndpoint(values.tunnel, values.hostname, values.tailscalePort);
   const savedUrl = serverUrlDisplay(savedEndpoint, Boolean(config.authToken));
   const ngrokHostname = process.env.NGROK_DOMAIN ?? (values.tunnel === "ngrok" ? values.hostname : "");
   const cloudflareHostname =
@@ -287,6 +320,7 @@ function profileForm(config: CodexProConfig): string {
           <div class="form-grid">
             <label><span>Tunnel</span><select name="tunnel" data-tunnel-select data-ngrok-hostname="${escapeHtml(ngrokHostname)}" data-cloudflare-hostname="${escapeHtml(cloudflareHostname)}">${selectOptions(TUNNELS, values.tunnel)}</select></label>
             <label><span>Public hostname</span><input name="hostname" value="${escapeHtml(values.hostname)}" data-hostname-input data-autofilled="0"></label>
+            <label data-tailscale-port-wrap${values.tunnel === "tailscale" ? "" : " hidden"}><span>Tailscale public port</span><select name="tailscalePort" data-tailscale-port${values.tunnel === "tailscale" ? "" : " hidden"}>${selectOptions(TAILSCALE_PORTS, values.tailscalePort)}</select></label>
             <label><span>Port</span><input name="port" type="number" min="1" max="65535" value="${escapeHtml(values.port)}"></label>
             <label><span>Mode</span><select name="mode">${selectOptions(MODES, values.mode)}</select></label>
             <label><span>Cloudflare tunnel name</span><input name="tunnelName" value="${escapeHtml(values.tunnelName)}"></label>
@@ -336,8 +370,15 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
     requireBashSession: input.requireBashSession ?? current.requireBashSession,
     noInstallCloudflared: input.noInstallCloudflared ?? current.noInstallCloudflared
   };
-  next.hostname = normalizePublicHostname(next.hostname);
-  if (next.tunnel !== "ngrok" && next.tunnel !== "cloudflare-named" && next.tunnel !== "tailscale") next.hostname = "";
+  if (next.tunnel === "tailscale") {
+    const endpoint = normalizeTailscaleEndpoint(next.hostname, next.tailscalePort);
+    next.hostname = endpoint.hostname;
+    next.tailscalePort = endpoint.tailscalePort;
+  } else {
+    next.hostname = normalizePublicHostname(next.hostname);
+    next.tailscalePort = "";
+    if (next.tunnel !== "ngrok" && next.tunnel !== "cloudflare-named") next.hostname = "";
+  }
   next.widgetDomain = normalizeWidgetDomain(next.widgetDomain);
   if ((next.tunnel === "ngrok" || next.tunnel === "cloudflare-named" || next.tunnel === "tailscale") && !next.hostname) {
     throw new Error("hostname is required for ngrok, cloudflare-named, and tailscale profiles.");
@@ -358,6 +399,7 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
     mode: next.mode,
     tunnel: next.tunnel,
     ...(next.hostname ? { hostname: next.hostname } : {}),
+    ...(next.tunnel === "tailscale" ? { tailscalePort: next.tailscalePort } : {}),
     ...(tunnelName ? { tunnelName } : {}),
     ...(ngrokConfig ? { ngrokConfig } : {}),
     ...(cloudflareConfig ? { cloudflareConfig } : {}),
@@ -1345,16 +1387,23 @@ function onboardingPage(config: CodexProConfig): string {
     const profileForm = document.querySelector("[data-profile-form]");
     const tunnelSelect = document.querySelector("[data-tunnel-select]");
     const hostnameInput = document.querySelector("[data-hostname-input]");
+    const tailscalePortInput = document.querySelector("[data-tailscale-port]");
     const hostnameHelp = document.querySelector("[data-hostname-help]");
     const tokenEnabled = ${config.authToken ? "true" : "false"};
-    function serverPreviewFor(hostname) {
+    function serverPreviewFor(hostname, tailscalePort) {
       const clean = String(hostname || "").trim().replace(/^https?:\\/\\//, "").replace(/\\/mcp\\/?$/, "").replace(/\\/+$/, "");
       if (!clean) return "";
-      return "https://" + clean + "/mcp" + (tokenEnabled ? "?codexpro_token=<redacted>" : "");
+      const parsed = new URL("https://" + clean);
+      const publicHostname = tailscalePort ? parsed.hostname + (tailscalePort === "443" ? "" : ":" + tailscalePort) : parsed.host;
+      return "https://" + publicHostname + "/mcp" + (tokenEnabled ? "?codexpro_token=<redacted>" : "");
     }
     function updateTunnelHelp() {
       if (!tunnelSelect || !hostnameInput || !hostnameHelp) return;
       const tunnel = tunnelSelect.value;
+      if (tailscalePortInput) {
+        tailscalePortInput.hidden = tunnel !== "tailscale";
+        tailscalePortInput.closest("label")?.toggleAttribute("hidden", tunnel !== "tailscale");
+      }
       const ngrokHost = tunnelSelect.getAttribute("data-ngrok-hostname") || "";
       const cloudflareHost = tunnelSelect.getAttribute("data-cloudflare-hostname") || "";
       if (tunnel === "ngrok" && !hostnameInput.value && ngrokHost) {
@@ -1369,7 +1418,7 @@ function onboardingPage(config: CodexProConfig): string {
         hostnameInput.value = "";
         hostnameInput.setAttribute("data-autofilled", "0");
       }
-      const preview = serverPreviewFor(hostnameInput.value);
+      const preview = serverPreviewFor(hostnameInput.value, tunnel === "tailscale" ? tailscalePortInput?.value : "");
       if (tunnel === "cloudflare") {
         hostnameHelp.textContent = "Cloudflare quick tunnel generates the public URL at launch and this page shows it when the launcher reports it.";
       } else if (tunnel === "ngrok") {
@@ -1383,6 +1432,7 @@ function onboardingPage(config: CodexProConfig): string {
       }
     }
     tunnelSelect?.addEventListener("change", updateTunnelHelp);
+    tailscalePortInput?.addEventListener("change", updateTunnelHelp);
     hostnameInput?.addEventListener("input", () => {
       hostnameInput.setAttribute("data-autofilled", "0");
       updateTunnelHelp();
@@ -1397,6 +1447,7 @@ function onboardingPage(config: CodexProConfig): string {
         const payload = {
           tunnel: data.tunnel,
           hostname: data.hostname,
+          tailscalePort: data.tailscalePort,
           tunnelName: data.tunnelName,
           ngrokConfig: data.ngrokConfig,
           cloudflareConfig: data.cloudflareConfig,

--- a/src/profileStore.ts
+++ b/src/profileStore.ts
@@ -17,6 +17,7 @@ export interface WorkspaceProfile {
   mode?: ConnectorMode | string;
   tunnel?: TunnelMode | string;
   hostname?: string;
+  tailscalePort?: string;
   tunnelName?: string;
   ngrokConfig?: string;
   cloudflareConfig?: string;


### PR DESCRIPTION
## Summary
- add configurable Tailscale Funnel public HTTPS ports (443, 8443, and 10000) across the CLI, environment, saved profiles, TUI, and admin settings
- preserve and canonicalize legacy hostname port suffixes, including explicit `:443`, while enforcing CLI > environment > saved-profile precedence and same-source conflict checks
- keep the local listener port independent, update user-facing documentation, expand smoke coverage, and make Node 20 PTY exit handling reliable

## Why
Tailscale Funnel supports a small set of public HTTPS ports, but CodexPro previously could not configure that public port independently from its local listener. Existing legacy `hostname:port` values also need deterministic migration and validation.

## Impact
Users can select a supported Funnel port without changing the local MCP server port. Existing default-port profiles remain compatible, and legacy saved/environment hostnames are canonicalized.

## Security
No authentication or authorization behavior changes. Funnel port input is restricted to 443, 8443, or 10000, and invalid or conflicting values fail before Tailscale launches.

## Validation
- Node 20.19.4 / npm 10.9.4: `npm ci`
- `npm run build`
- `npm run smoke` (all 12 suites)
- `npm run stress` (using an rg-free local fallback fixture; the tracked test file was restored and verified unchanged)
- `npm pack --dry-run` (101 files)
- independent code review: no Critical or Important findings