### PR TITLE
fix(windows): decode Windows bash output encodings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
+        "chardet": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "iconv-lite": "^0.7.3",
         "minimatch": "^10.0.1",
         "zod": "^3.25.76"
       },
@@ -775,6 +777,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -1258,9 +1266,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "start:http": "node dist/http.js",
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
-    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/import-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
+    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/bash-encoding-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/import-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
     "stress": "npm run build && node scripts/stress.mjs",
     "analysis:smoke": "npm run build && node scripts/analysis-smoke.mjs",
     "analysis:cli-smoke": "npm run build && node scripts/analysis-cli-smoke.mjs",
@@ -98,8 +98,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4",
+    "chardet": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "iconv-lite": "^0.7.3",
     "minimatch": "^10.0.1",
     "zod": "^3.25.76"
   },

--- a/scripts/bash-encoding-smoke.mjs
+++ b/scripts/bash-encoding-smoke.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import iconv from 'iconv-lite';
+import { PathGuard } from '../dist/guard.js';
+import { decodeBashOutput, runBash } from '../dist/bashOps.js';
+
+function mustNotDetect() {
+  throw new Error('encoding detection must not run');
+}
+
+const ascii = Buffer.from('plain ASCII output');
+const utf8 = Buffer.from('UTF-8 中文输出');
+assert.equal(decodeBashOutput(ascii, 'win32', false, mustNotDetect), 'plain ASCII output');
+assert.equal(decodeBashOutput(utf8, 'win32', false, mustNotDetect), 'UTF-8 中文输出');
+
+const gb18030Text = 'Windows GB18030 中文编码检测，重复内容用于提高置信度。'.repeat(8);
+const gb18030 = iconv.encode(gb18030Text, 'gb18030');
+assert.equal(decodeBashOutput(gb18030, 'win32'), gb18030Text, 'real chardet GB18030 decode failed');
+const gbkText = 'Windows GBK 中文编码检测，重复内容用于提高置信度。'.repeat(8);
+const gbk = iconv.encode(gbkText, 'gbk');
+assert.equal(decodeBashOutput(gbk, 'win32'), gbkText, 'real chardet GBK decode failed');
+
+const legacy = Buffer.from([0x80]);
+assert.equal(
+  decodeBashOutput(legacy, 'win32', false, () => [{ name: 'windows-1252', confidence: 80 }]),
+  '€',
+  'high-confidence supported encoding was not accepted'
+);
+assert.equal(
+  decodeBashOutput(legacy, 'win32', false, () => [{ name: 'windows-1252', confidence: 79 }]),
+  legacy.toString('utf8'),
+  'low-confidence encoding did not fall back to UTF-8'
+);
+assert.equal(
+  decodeBashOutput(legacy, 'win32', false, () => [{ name: 'not-a-real-encoding', confidence: 100 }]),
+  legacy.toString('utf8'),
+  'unsupported encoding did not fall back to UTF-8'
+);
+assert.equal(decodeBashOutput(legacy, 'win32', false, () => []), legacy.toString('utf8'), 'empty detection did not fall back');
+assert.equal(
+  decodeBashOutput(legacy, 'win32', false, () => { throw new Error('detector failure'); }),
+  legacy.toString('utf8'),
+  'detector failure did not fall back'
+);
+assert.equal(decodeBashOutput(legacy, 'linux', false, mustNotDetect), legacy.toString('utf8'), 'non-Windows invoked detection');
+assert.equal(decodeBashOutput(Buffer.alloc(0), 'win32', false, mustNotDetect), '', 'empty output invoked detection');
+assert.equal(
+  decodeBashOutput(Buffer.concat([Buffer.from('split '), Buffer.from('中文')]), 'win32', false, mustNotDetect),
+  'split 中文',
+  'combined multi-byte chunks were not decoded as UTF-8'
+);
+assert.equal(
+  decodeBashOutput(Buffer.from([0xe4, 0xb8]), 'win32', true, mustNotDetect),
+  '�',
+  'truncated UTF-8 tail did not retain UTF-8 fallback behavior'
+);
+
+if (process.platform === 'win32') {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'codexpro-bash-encoding-'));
+  const config = { bashMode: 'full', maxBashTimeoutMs: 10_000, maxOutputBytes: 100_000, inheritEnv: true, blockedGlobs: [] };
+  const workspace = { id: 'encoding-smoke', root, openedAt: new Date().toISOString() };
+  const gbkPayload = iconv.encode('GBK stdout 中文', 'gbk').toString('base64');
+  const childScript = [
+    `process.stdout.write(Buffer.from(${JSON.stringify(gbkPayload)}, 'base64'));`,
+    "process.stderr.write('UTF-8 stderr 中文');"
+  ].join('');
+  const result = await runBash(config, new PathGuard(config), workspace, `${JSON.stringify(process.execPath)} -e ${JSON.stringify(childScript)}`);
+  assert.equal(result.stdout, 'GBK stdout 中文', `Windows stdout decoding failed: ${JSON.stringify(result)}`);
+  assert.equal(result.stderr, 'UTF-8 stderr 中文', `Windows stderr decoding failed: ${JSON.stringify(result)}`);
+}
+
+console.log('bash encoding smoke passed');

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -2,6 +2,8 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { analyse } from "chardet";
+import iconv from "iconv-lite";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
@@ -246,6 +248,36 @@ function trimOutput(value: string, maxBytes: number): { value: string; truncated
   return { value: `${sliced}\n...[output truncated to ${maxBytes} bytes]`, truncated: true };
 }
 
+export type BashEncodingCandidate = { name: string; confidence: number };
+export type BashEncodingDetector = (input: Buffer) => BashEncodingCandidate[];
+
+/** Decode one completed bash output stream without allowing a detected encoding to affect another stream. */
+export function decodeBashOutput(
+  bytes: Buffer,
+  platform: NodeJS.Platform = process.platform,
+  allowTrailingIncompleteUtf8 = false,
+  detect: BashEncodingDetector = analyse
+): string {
+  const utf8Fallback = () => bytes.toString("utf8");
+  if (platform !== "win32" || bytes.length === 0) return utf8Fallback();
+
+  try {
+    // Streaming validation accepts only an unfinished final sequence when the process was stopped mid-write.
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes, { stream: allowTrailingIncompleteUtf8 });
+    return utf8Fallback();
+  } catch {
+    // A non-UTF-8 stream may still be decodable using a high-confidence supported encoding.
+  }
+
+  try {
+    const candidate = detect(bytes)[0];
+    if (!candidate || candidate.confidence < 80 || !iconv.encodingExists(candidate.name)) return utf8Fallback();
+    return iconv.decode(bytes, candidate.name);
+  } catch {
+    return utf8Fallback();
+  }
+}
+
 function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
   if (!child.pid) return;
   if (process.platform === "win32") {
@@ -288,9 +320,10 @@ export async function runBash(
       windowsHide: true
     });
 
-    let stdout = "";
-    let stderr = "";
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     let killedByTimeout = false;
+    let killedByOutputLimit = false;
     let closed = false;
     let terminationStarted = false;
     let killTimer: NodeJS.Timeout | undefined;
@@ -308,12 +341,14 @@ export async function runBash(
       killTimer = setTimeout(() => terminate("SIGKILL"), 1_500);
       killTimer.unref();
     };
-    const appendBounded = (current: string, chunk: unknown) => {
-      const bytes = Buffer.from(String(chunk), "utf8");
-      observedOutputBytes += bytes.byteLength;
-      const remaining = retainedOutputBytes - Buffer.byteLength(stdout, "utf8") - Buffer.byteLength(stderr, "utf8");
-      if (remaining <= 0) return current;
-      return current + bytes.subarray(0, remaining).toString("utf8");
+    let retainedBytes = 0;
+    const appendBounded = (chunks: Buffer[], chunk: Buffer) => {
+      observedOutputBytes += chunk.byteLength;
+      const remaining = retainedOutputBytes - retainedBytes;
+      if (remaining <= 0) return;
+      const retained = chunk.subarray(0, remaining);
+      chunks.push(retained);
+      retainedBytes += retained.byteLength;
     };
 
     const timer = setTimeout(() => {
@@ -323,18 +358,27 @@ export async function runBash(
     timer.unref();
 
     child.stdout.on("data", (chunk) => {
-      stdout = appendBounded(stdout, chunk);
-      if (observedOutputBytes > config.maxOutputBytes) terminateWithEscalation();
+      appendBounded(stdoutChunks, Buffer.from(chunk));
+      if (observedOutputBytes > config.maxOutputBytes) {
+        killedByOutputLimit = true;
+        terminateWithEscalation();
+      }
     });
     child.stderr.on("data", (chunk) => {
-      stderr = appendBounded(stderr, chunk);
-      if (observedOutputBytes > config.maxOutputBytes) terminateWithEscalation();
+      appendBounded(stderrChunks, Buffer.from(chunk));
+      if (observedOutputBytes > config.maxOutputBytes) {
+        killedByOutputLimit = true;
+        terminateWithEscalation();
+      }
     });
     child.on("error", reject);
     child.on("close", (exitCode, signal) => {
       closed = true;
       clearTimeout(timer);
       if (killTimer) clearTimeout(killTimer);
+      const allowTrailingIncompleteUtf8 = killedByTimeout || killedByOutputLimit;
+      const stdout = decodeBashOutput(Buffer.concat(stdoutChunks), process.platform, allowTrailingIncompleteUtf8);
+      let stderr = decodeBashOutput(Buffer.concat(stderrChunks), process.platform, allowTrailingIncompleteUtf8);
       if (killedByTimeout) {
         stderr += `\n[codexpro] Command timed out after ${timeoutMs} ms.`;
       }


### PR DESCRIPTION
### Why
On Windows, some bash commands produce output bytes in a non-UTF-8 encoding. Decoding those bytes as UTF-8 produces garbled text, making command output difficult to read and use.

### Goal
Ensure bash output on Windows is correctly decoded as Unicode text when it uses a supported non-UTF-8 encoding, while preserving existing UTF-8 behavior and non-Windows behavior.

### Summary
- Preserve raw byte chunks from bash stdout and stderr, then decode each stream independently after the process exits.
- On Windows, validate UTF-8 strictly before attempting encoding detection. For invalid UTF-8, accept only chardet's first candidate when confidence is at least 80 and iconv-lite supports it.
- Fall back to tolerant UTF-8 decoding when detection is absent, low-confidence, unsupported, or throws.
- Keep the existing combined raw-byte output limit, timeout handling, redaction, UTF-8 truncation, and external bash tool interface.
- Add direct runtime dependencies for `chardet` and `iconv-lite`.
- Add encoding smoke coverage for UTF-8, GBK, GB18030, fallback paths, split multi-byte output, truncated UTF-8, and Windows mixed stdout/stderr encoding.

### Security Impact
This change affects shell-output decoding only. It does not change bash command permissions, execution modes, MCP parameters, environment variables, or result fields. Output retention remains bounded by the existing raw-byte limit. Low-confidence or unsupported encoding detection falls back to the existing UTF-8 behavior.

### Validation
- [x] `npm run build`
- [x] `npm run smoke`
- [x] `npm run stress`
- [ ] Update `README.md` or `CHANGELOG.md` for this behavior change.
