### PR TITLE
fix: honour max_results in ripgrep search instead of a hardcoded per-file cap

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -496,6 +496,28 @@ const workspaceAnalysis = await client.request('tools/call', { name: 'inspect_wo
 if (!workspaceAnalysis.structuredContent.languages?.includes('typescript') || !workspaceAnalysis.structuredContent.coverage) {
   throw new Error(`inspect_workspace omitted analysis: ${JSON.stringify(workspaceAnalysis.structuredContent)}`);
 }
+// One file holding more than ripgrep's old hardcoded per-file cap of 50: a fixed --max-count
+// silently truncated here regardless of the requested max_results.
+await fs.writeFile(path.join(tmp, 'many-matches.txt'), Array.from({ length: 120 }, (_, i) => `needle-${i}`).join('\n') + '\n', 'utf8');
+const denseSearch = await client.request('tools/call', {
+  name: 'search',
+  arguments: { workspace_id: ws, query: 'needle-', path: 'many-matches.txt', max_results: 120 }
+});
+if (denseSearch.isError || denseSearch.structuredContent.matches?.length !== 120) {
+  throw new Error(`search capped matches below the requested max_results: ${JSON.stringify(denseSearch.structuredContent?.matches?.length)}`);
+}
+if (denseSearch.structuredContent.truncated !== false) {
+  throw new Error('search reported truncation despite returning every match');
+}
+const denseSearchCapped = await client.request('tools/call', {
+  name: 'search',
+  arguments: { workspace_id: ws, query: 'needle-', path: 'many-matches.txt', max_results: 10 }
+});
+if (denseSearchCapped.structuredContent.matches?.length !== 10 || denseSearchCapped.structuredContent.truncated !== true) {
+  throw new Error(`search did not report truncation at a lower max_results: ${JSON.stringify(denseSearchCapped.structuredContent)}`);
+}
+await fs.rm(path.join(tmp, 'many-matches.txt'));
+
 const legacySearch = await client.request('tools/call', { name: 'search', arguments: { workspace_id: ws, query: 'authenticate', path: 'src' } });
 for (const key of ['matches', 'truncated', 'used']) {
   if (!(key in legacySearch.structuredContent)) throw new Error(`legacy search lost ${key}`);

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -45,7 +45,21 @@ function truncateLine(line: string, max = 400): string {
 
 async function runRipgrep(config: CodexProConfig, guard: PathGuard, workspace: Workspace, options: SearchOptions): Promise<SearchResult> {
   const target = guard.resolve(workspace, options.root ?? ".");
-  const args = ["--json", "--line-number", "--with-filename", "--no-heading", "--color=never", "--max-columns", "500", "--max-count", "50", "--max-filesize", String(textScanByteLimit(config))];
+  const args = [
+    "--json",
+    "--line-number",
+    "--with-filename",
+    "--no-heading",
+    "--color=never",
+    "--max-columns",
+    "500",
+    // One more than the requested cap so the caller can still tell the result was truncated.
+    // A hardcoded value here silently drops matches whenever maxResults is larger.
+    "--max-count",
+    String(options.maxResults + 1),
+    "--max-filesize",
+    String(textScanByteLimit(config))
+  ];
   if (!options.regex) args.push("--fixed-strings");
   if (options.includeHidden) args.push("--hidden");
   for (const glob of config.blockedGlobs) args.push("-g", `!${glob}`);


### PR DESCRIPTION
## What breaks

`search` silently drops matches. `runRipgrep` passes a hardcoded `--max-count 50` while honouring `options.maxResults` (bounded by `CODEXPRO_MAX_SEARCH_RESULTS`, default 200, up to 2000) everywhere else:

```ts
const args = ["--json", ..., "--max-count", "50", "--max-filesize", ...];
```

Any single file with more than 50 matches is truncated by ripgrep before CodexPro ever sees the results, no matter what `max_results` the caller asked for.

Worse, the truncation is invisible. It is reported as `visibleMatches > matches.length`, but `visibleMatches` only counts what ripgrep emitted — so when ripgrep did the cutting, `visibleMatches === matches.length` and the result comes back `truncated: false`. The model receives a partial result presented as complete, which is the failure mode that matters: it will reason as though it has seen every occurrence.

The Node fallback (`runNodeSearch`) has no equivalent per-file cap, so results also differ depending on whether `rg` is installed.

## The fix

Pass the caller's limit instead of a constant:

```ts
"--max-count",
String(options.maxResults + 1),
```

`+ 1` so ripgrep still emits one match beyond the cap, which is what lets the existing `visibleMatches > matches.length` check report `truncated: true` correctly. `maxResults` is already clamped before this call, so no new limit is introduced — ripgrep is simply told the same number the rest of the function already respects.

## Verification

`npm run build` and the full `npm run smoke` suite pass.

Added a regression case to `scripts/smoke.mjs` over a single file containing 120 matches:

- `max_results: 120` must return 120 matches and `truncated: false`
- `max_results: 10` must return 10 matches and `truncated: true`

Confirmed the test fails against the current code, reporting exactly the bug:

```
Error: search capped matches below the requested max_results: 50
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
