### PR TITLE
fix: drop permissive CORS, add security headers and same-origin guard on POST /admin/profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
-        "cors": "^2.8.5",
         "express": "^5.1.0",
         "minimatch": "^10.0.1",
         "zod": "^3.25.76"
@@ -21,7 +20,6 @@
         "codexpro-mcp-http": "dist/http.js"
       },
       "devDependencies": {
-        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.0",
         "tsx": "^4.20.3",
@@ -540,16 +538,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -98,13 +98,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4",
-    "cors": "^2.8.5",
     "express": "^5.1.0",
     "minimatch": "^10.0.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.0",
     "tsx": "^4.20.3",

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -395,6 +395,41 @@ try {
     if (JSON.stringify(profileBeforeJson).includes(leaked)) throw new Error(`admin profile GET leaked runtime secret: ${leaked}`);
   }
 
+  const securityHeaders = profileBefore.headers;
+  for (const [header, expected] of [
+    ['cache-control', 'no-store'],
+    ['referrer-policy', 'no-referrer'],
+    ['x-content-type-options', 'nosniff'],
+    ['x-frame-options', 'DENY'],
+    ['permissions-policy', 'camera=(), microphone=(), geolocation=()']
+  ]) {
+    if (securityHeaders.get(header) !== expected) {
+      throw new Error(`missing or wrong ${header} header: ${securityHeaders.get(header)}`);
+    }
+  }
+  if (securityHeaders.get('access-control-allow-origin')) {
+    throw new Error('permissive CORS is still enabled on admin responses');
+  }
+
+  const crossOriginProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: 'https://attacker.example' },
+    body: JSON.stringify({ tunnel: 'none' })
+  });
+  const crossOriginJson = await crossOriginProfile.json().catch(() => ({}));
+  if (crossOriginProfile.status !== 403 || crossOriginJson.error?.code !== 'origin_denied') {
+    throw new Error(`cross-origin admin POST was not rejected: ${crossOriginProfile.status} ${JSON.stringify(crossOriginJson)}`);
+  }
+
+  const sameOriginProbe = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: baseUrl },
+    body: JSON.stringify({ tunnel: 'nonsense-value' })
+  });
+  if (sameOriginProbe.status === 403) {
+    throw new Error('same-origin admin POST was rejected by the origin guard');
+  }
+
   const invalidProfile = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import express, { type NextFunction, type Request, type Response } from "express";
-import cors from "cors";
 import { z } from "zod";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
@@ -1493,6 +1492,33 @@ async function main(): Promise<void> {
     next();
   }
 
+  // The admin endpoint is reachable from any page the operator's browser visits, so a
+  // browser-issued cross-origin write is rejected outright. Requests without an Origin
+  // header (curl, the CLI, other non-browser clients) are still allowed; a browser cannot
+  // forge a JSON body through a simple form post, so those cannot reach the JSON parser.
+  function sameOriginAdminRequest(req: Request, res: Response, next: NextFunction): void {
+    const origin = req.headers.origin;
+    if (!origin) {
+      next();
+      return;
+    }
+    const host = req.get("host");
+    let originHost: string;
+    try {
+      originHost = new URL(origin).host;
+    } catch {
+      jsonError(res, 403, "origin_denied", "Cross-origin admin requests are not allowed.");
+      return;
+    }
+    // Compare hosts rather than full origins: behind a tunnel the request arrives over
+    // plain HTTP while the browser's Origin says https, but the Host header is forwarded.
+    if (!host || originHost !== host) {
+      jsonError(res, 403, "origin_denied", "Cross-origin admin requests are not allowed.");
+      return;
+    }
+    next();
+  }
+
   app.use((req, res, next) => {
     if (!logRequests) {
       next();
@@ -1505,7 +1531,6 @@ async function main(): Promise<void> {
     });
     next();
   });
-  app.use(cors({ exposedHeaders: ["Mcp-Session-Id"] }));
   app.get("/favicon.ico", (_req, res) => {
     res.setHeader("Cache-Control", "public, max-age=86400");
     res.type("image/svg+xml").send(LOCAL_FAVICON);
@@ -1514,7 +1539,9 @@ async function main(): Promise<void> {
     res.setHeader("Cache-Control", "no-store");
     res.setHeader("Pragma", "no-cache");
     res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
     res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
     next();
   });
   app.use((req, res, next) => {
@@ -1647,7 +1674,7 @@ async function main(): Promise<void> {
     res.json(profileResponse(config));
   });
 
-  app.post("/admin/profile", adminRateLimit, adminBodyLimit, express.json({ limit: "32kb" }), (req, res) => {
+  app.post("/admin/profile", sameOriginAdminRequest, adminRateLimit, adminBodyLimit, express.json({ limit: "32kb" }), (req, res) => {
     const parsed = AdminProfilePatch.safeParse(req.body ?? {});
     if (!parsed.success) {
       jsonError(res, 400, "invalid_profile", "Invalid profile settings.", parsed.error.flatten());


### PR DESCRIPTION
## What breaks

`POST /admin/profile` rewrites the saved connector profile — tunnel, port, bash mode, write mode, tool mode, allowed roots — and it has no CSRF protection. At the same time the server runs a fully permissive CORS policy:

```ts
app.use(cors({ exposedHeaders: ["Mcp-Session-Id"] }));
```

`cors()` with no options reflects any origin. So while CodexPro is running, any page the operator's browser happens to visit can `fetch()` the admin endpoint cross-origin and change the connector's safety posture for the next launch. The token in the query string does not help: it is in the URL the operator pasted into ChatGPT, and it is not a CSRF defence in any case.

The blast radius is a local dev connector's guardrails, and it grows the moment the HTTP transport is bound to anything other than loopback.

The permissive CORS is also unnecessary. Nothing reaches this server from browser JavaScript — ChatGPT calls `/mcp` server-side, and the onboarding page at `/` is same-origin with the admin form it posts to. `exposedHeaders: ["Mcp-Session-Id"]` only matters for a browser-based MCP client, which is not a supported topology here.

## The fix

**Remove the CORS middleware** and drop the direct `cors` / `@types/cors` dependency pair. (`cors` remains in the tree transitively via `@modelcontextprotocol/sdk`; only the direct dependency goes.)

**Add two missing security headers** next to the existing `no-store` / `no-referrer` / `nosniff` block:

```
X-Frame-Options: DENY
Permissions-Policy: camera=(), microphone=(), geolocation=()
```

No page served by this server is meant to be framed, and the widget is served from `widgetDomain`, not from here.

**Reject cross-origin admin writes** with `403 origin_denied` via a `sameOriginAdminRequest` guard on `POST /admin/profile`.

Two deliberate details:

*Requests with no `Origin` header pass.* That keeps `curl`, the CLI, and other non-browser clients working. It is safe because `express.json()` is the only body parser on this route: a browser cannot produce an `application/json` body through a simple form post (form enctypes are limited to urlencoded / multipart / text-plain), and anything that can set the content type is a fetch/XHR, which always sends `Origin` cross-origin.

*The guard compares hosts, not full origins.* The obvious implementation is:

```ts
const expected = `${req.protocol}://${req.get("host")}`;
if (origin !== expected) { /* 403 */ }
```

That misfires behind a proxy. CodexPro is routinely reached through a Cloudflare or ngrok tunnel, where TLS terminates at the edge and the request arrives at Express over plain HTTP. Without `trust proxy`, `req.protocol` is `"http"` while the browser correctly reports `Origin: https://<tunnel-host>` — so every legitimate admin save through a tunnel would 403. The `Host` header, by contrast, is forwarded intact by every tunnel provider, so comparing `new URL(origin).host` against `req.get("host")` is both correct behind a proxy and sufficient: a cross-site attacker cannot forge `Origin`, and same-host-different-scheme is not a meaningful attacker position for a locally bound dev server.

A malformed `Origin` that fails to parse is treated as cross-origin and rejected.

## Verification

`npm run build` and the full `npm run smoke` suite pass.

Added assertions to `scripts/http-smoke.mjs`:

- all five security headers present with the expected values
- no `Access-Control-Allow-Origin` on responses
- `POST /admin/profile` with `Origin: https://attacker.example` returns `403` / `origin_denied`
- the same POST with a matching `Origin` is *not* rejected by the guard, so the onboarding form still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
