### PR TITLE
fix(http): preserve workspace IDs across MCP sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserved explicitly opened descendant workspace IDs across HTTP MCP sessions with a process-level registry, while keeping implicit workspace selection session-local.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -205,7 +205,9 @@ function postToolsListWithSession(baseUrl, token, sessionId) {
 }
 
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-smoke-'));
-const alternateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-alternate-'));
+const alternateParent = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-alternate-parent-'));
+const alternateRoot = path.join(alternateParent, 'descendant-workspace');
+await fs.mkdir(alternateRoot);
 await fs.writeFile(path.join(alternateRoot, 'selected.txt'), 'http alternate workspace\n', 'utf8');
 const profileHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-profile-home-'));
 await fs.mkdir(path.join(root, '.codex', 'skills', 'http-smoke-skill'), { recursive: true });
@@ -252,7 +254,7 @@ const child = spawn('node', ['dist/http.js'], {
     HOST: '0.0.0.0',
     PORT: String(genericPort),
     CODEXPRO_ROOT: root,
-    CODEXPRO_ALLOWED_ROOTS: [root, alternateRoot].join(path.delimiter),
+    CODEXPRO_ALLOWED_ROOTS: [root, alternateParent].join(path.delimiter),
     CODEXPRO_HOST: '127.0.0.1',
     CODEXPRO_PORT: String(port),
     CODEXPRO_HTTP_TOKEN: token,
@@ -684,6 +686,20 @@ try {
         || secondList.structuredContent.workspaces.some((workspace) => workspace.root === alternateRoot)
       ) {
         throw new Error(`HTTP workspace selection leaked between MCP sessions: ${JSON.stringify(secondList.structuredContent)}`);
+      }
+
+      const secondRead = await callTool(secondClient, 'read', {
+        workspace_id: alternate.structuredContent.workspace_id,
+        path: 'selected.txt'
+      });
+      const secondText = secondRead.content?.find?.((part) => part.type === 'text')?.text ?? '';
+      if (!secondText.includes('http alternate workspace')) {
+        throw new Error(`second HTTP session could not resolve the first session workspace id: ${secondText}`);
+      }
+
+      const secondListAfterExplicitAccess = await callTool(secondClient, 'list_workspaces');
+      if (secondListAfterExplicitAccess.structuredContent.selected_workspace_id === alternate.structuredContent.workspace_id) {
+        throw new Error(`explicit cross-session workspace id changed the second session selection: ${JSON.stringify(secondListAfterExplicitAccess.structuredContent)}`);
       }
     });
 

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -13,6 +13,25 @@ export interface Workspace {
   openedAt: string;
 }
 
+export class WorkspaceRegistry {
+  private readonly workspaces = new Map<string, Workspace>();
+
+  findByRoot(root: string): Workspace | undefined {
+    return [...this.workspaces.values()].find((workspace) => workspace.root === root);
+  }
+
+  get(id: string): Workspace | undefined {
+    return this.workspaces.get(id);
+  }
+
+  register(workspace: Workspace): Workspace {
+    const existing = this.workspaces.get(workspace.id);
+    if (existing) return existing;
+    this.workspaces.set(workspace.id, workspace);
+    return workspace;
+  }
+}
+
 export class CodexProError extends Error {
   constructor(message: string) {
     super(message);
@@ -62,7 +81,10 @@ export class WorkspaceManager {
   private readonly workspaces = new Map<string, Workspace>();
   private selectedWorkspaceId?: string;
 
-  constructor(private readonly config: CodexProConfig) {}
+  constructor(
+    private readonly config: CodexProConfig,
+    private readonly registry = new WorkspaceRegistry()
+  ) {}
 
   defaultWorkspace(): Workspace {
     const existing = [...this.workspaces.values()].find((workspace) => workspace.root === this.config.defaultRoot);
@@ -93,14 +115,15 @@ export class WorkspaceManager {
       );
     }
 
-    const existing = [...this.workspaces.values()].find((workspace) => workspace.root === realRoot);
+    const existing = this.registry.findByRoot(realRoot);
     if (existing) {
+      this.workspaces.set(existing.id, existing);
       if (options.select !== false) this.selectedWorkspaceId = existing.id;
       return existing;
     }
 
     const id = workspaceIdForRoot(realRoot);
-    const workspace = { id, root: realRoot, openedAt: new Date().toISOString() };
+    const workspace = this.registry.register({ id, root: realRoot, openedAt: new Date().toISOString() });
     this.workspaces.set(id, workspace);
     if (options.select !== false) this.selectedWorkspaceId = id;
     return workspace;
@@ -114,7 +137,8 @@ export class WorkspaceManager {
       }
       return this.selectDefaultWorkspace();
     }
-    const workspace = this.workspaces.get(id);
+    const workspace = this.workspaces.get(id) ?? this.registry.get(id);
+    if (workspace) this.workspaces.set(id, workspace);
     if (!workspace) {
       const configuredRoot = this.config.allowedRoots.find((allowedRoot) => workspaceIdForRoot(allowedRoot) === id);
       if (configuredRoot) return this.openWorkspace(configuredRoot, { select: false });

--- a/src/http.ts
+++ b/src/http.ts
@@ -20,6 +20,7 @@ import {
 } from "./profileStore.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
 import { createCodexProServer } from "./server.js";
+import { WorkspaceRegistry } from "./guard.js";
 
 function escapeHtml(value: unknown): string {
   return String(value ?? "")
@@ -1562,6 +1563,7 @@ async function main(): Promise<void> {
   };
 
   const transports = new Map<string, TransportRecord>();
+  const workspaceRegistry = new WorkspaceRegistry();
   const sessionIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   function requestSessionId(req: Request): string | undefined {
@@ -1699,7 +1701,7 @@ async function main(): Promise<void> {
           if (closedSessionId) transports.delete(closedSessionId);
         };
 
-        const server = createCodexProServer(config);
+        const server = createCodexProServer(config, { workspaceRegistry });
         await server.connect(transport);
       } else {
         sendSessionError(res, sessionId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CodexProConfig } from "./config.js";
-import { WorkspaceManager, PathGuard, CodexProError, type Workspace } from "./guard.js";
+import { WorkspaceManager, PathGuard, CodexProError, type Workspace, type WorkspaceRegistry } from "./guard.js";
 import { repoTree, readTextFile, writeTextFile, editTextFile, ensureAiBridge, withFileWriteLocks } from "./fsOps.js";
 import { viewWorkspaceImage } from "./imageOps.js";
 import { importAttachmentFile } from "./importOps.js";
@@ -926,8 +926,11 @@ const LOCAL_WRITE_ANNOTATIONS = { readOnlyHint: false, openWorldHint: false, des
 const BASH_ANNOTATIONS = { readOnlyHint: false, openWorldHint: true, destructiveHint: true, idempotentHint: false };
 const HANDOFF_WRITE_ANNOTATIONS = { readOnlyHint: false, openWorldHint: false, destructiveHint: false, idempotentHint: false };
 
-export function createCodexProServer(config: CodexProConfig): McpServer {
-  const workspaces = new WorkspaceManager(config);
+export function createCodexProServer(
+  config: CodexProConfig,
+  options: { workspaceRegistry?: WorkspaceRegistry } = {}
+): McpServer {
+  const workspaces = new WorkspaceManager(config, options.workspaceRegistry);
   const reviewCheckpoints = new Map<string, string>();
   const guard = new PathGuard(config);
   const server = new McpServer({ name: "CodexPro", version: "0.30.0" }, { instructions: serverInstructions(config) });


### PR DESCRIPTION
## What

Share the HTTP server workspace registry across MCP sessions. An explicitly supplied workspace_id opened by one HTTP session can now be adopted by another session, while implicit selected-workspace state remains session-local. The regression smoke covers two descendant worktrees in parallel sessions.

## Why

ChatGPT and other MCP clients can keep a workspace_id from an earlier tool call and send it through a later MCP session. Without this change, valid descendant repository or worktree IDs fail with Unknown workspace_id or fall back to a default root.

## Root cause

Each Streamable HTTP initialize created a new CodexPro server and WorkspaceManager. The workspace map was therefore session-local, and the old fallback only recognized exact configured roots rather than descendants that had been opened previously.

## Impact

Explicit workspace IDs are resolved through a process-lifetime registry and then adopted into the current session. Implicit selection is unchanged and remains isolated per session. The registry is intentionally in-memory; after a process restart, clients must call open_workspace again.

## Security

This does not expand allowedRoots, authentication, or path permissions. The registry only records canonical roots already accepted by PathGuard, and explicit IDs still go through the existing validation. No credentials, tokens, local paths, or tunnel configuration are included.

## Tests

- npm ci
- npm run build
- npm run smoke
- git diff --check

Related to #91.