### PR TITLE
feat: redact absolute local paths from server responses by default

### DIFF
--- a/config.example.env
+++ b/config.example.env
@@ -16,6 +16,9 @@ CODEXPRO_BASH_MODE=safe
 # CODEXPRO_REQUIRE_BASH_SESSION=1
 CODEXPRO_WRITE_MODE=handoff
 CODEXPRO_TOOL_MODE=standard
+# Local absolute paths are replaced with labels ([workspace:...], [project:...],
+# [home]) in MCP tool results by default. Enable only for trusted local debugging.
+# CODEXPRO_EXPOSE_ABSOLUTE_PATHS=1
 # Dedicated HTTPS origin for ChatGPT widget iframes. Required for app submission.
 CODEXPRO_WIDGET_DOMAIN=https://rebel0789.github.io
 

--- a/scripts/analysis-cli-smoke.mjs
+++ b/scripts/analysis-cli-smoke.mjs
@@ -5,6 +5,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const cli = path.join(projectRoot, 'scripts', 'codexpro.mjs');
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-cli-'));

--- a/scripts/analysis-smoke.mjs
+++ b/scripts/analysis-smoke.mjs
@@ -4,6 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const importBuilt = (relativePath) => import(pathToFileURL(path.join(projectRoot, 'dist', relativePath)).href);
 const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-analysis-'));

--- a/scripts/doctor-smoke.mjs
+++ b/scripts/doctor-smoke.mjs
@@ -5,6 +5,11 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 async function getFreePort() {
   return new Promise((resolve, reject) => {
     const server = net.createServer();

--- a/scripts/execute-handoff-smoke.mjs
+++ b/scripts/execute-handoff-smoke.mjs
@@ -3,6 +3,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 function run(args, options = {}) {
   const result = spawnSync(process.execPath, ['scripts/codexpro.mjs', ...args], {
     cwd: path.resolve('.'),

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -7,6 +7,11 @@ import path from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 async function getFreePort() {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
@@ -237,6 +242,7 @@ const runtimeCloudflareSecret = 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJodHRwLXNtb2
 const staleCloudflareToken = 'eyJhbGciOiJIUzI1NiJ9.eyJ0dW5uZWwiOiJzdGFsZS1odHRwLXNtb2tlIn0.signature1234567890';
 const runtimeId = createHash('sha256').update(root).digest('hex').slice(0, 24);
 const realAlternateRoot = await fs.realpath(alternateRoot);
+const realRoot = await fs.realpath(root);
 await fs.mkdir(path.join(profileHome, 'runtime'), { recursive: true });
 await fs.writeFile(path.join(profileHome, 'runtime', `${runtimeId}.json`), JSON.stringify({
   version: 1,
@@ -896,6 +902,122 @@ try {
 } finally {
   connectionTestChild.kill('SIGTERM');
   await waitForExit(connectionTestChild).catch(() => {});
+}
+
+// --- authenticated HTTP diagnostics honour path redaction --------------------
+// /healthz and GET /admin/profile are reachable with the same bearer token an MCP
+// client holds, so they must not echo absolute local paths when redaction is on.
+// This server deliberately runs without the file-level CODEXPRO_EXPOSE_ABSOLUTE_PATHS
+// opt-out that the rest of this harness uses.
+const redactionPort = await getFreePort();
+// Mirror the real deployment layout, where the Codex data dir (<h>/.codex) is a
+// string prefix of the CodexPro home (<h>/.codexpro). A non-boundary-aware
+// replacement mangles the profile path into "[codex-data]pro/profiles/...".
+const redactionHomeBase = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-redaction-home-'));
+const redactionCodexDir = path.join(redactionHomeBase, '.codex');
+const redactionProfileHome = path.join(redactionHomeBase, '.codexpro');
+await fs.mkdir(redactionCodexDir, { recursive: true });
+await fs.mkdir(redactionProfileHome, { recursive: true });
+const redactionChild = spawn('node', ['dist/http.js'], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_EXPOSE_ABSOLUTE_PATHS: '0',
+    CODEXPRO_ROOT: root,
+    CODEXPRO_ALLOWED_ROOTS: [root, alternateRoot].join(path.delimiter),
+    CODEXPRO_HOST: '127.0.0.1',
+    CODEXPRO_PORT: String(redactionPort),
+    CODEXPRO_HTTP_TOKEN: token,
+    CODEXPRO_BASH_MODE: 'safe',
+    CODEXPRO_WRITE_MODE: 'handoff',
+    CODEXPRO_TOOL_MODE: 'full',
+    CODEXPRO_CODEX_DIR: redactionCodexDir,
+    CODEXPRO_HOME: redactionProfileHome
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+
+try {
+  await waitForListening(redactionChild);
+  const redactionBase = `http://127.0.0.1:${redactionPort}`;
+  const leakCandidates = [realRoot, root, realAlternateRoot, alternateRoot, profileHome, redactionHomeBase, os.homedir()];
+
+  for (const endpoint of ['/healthz', '/admin/profile']) {
+    const response = await fetch(`${redactionBase}${endpoint}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (response.status !== 200) {
+      throw new Error(`expected authenticated ${endpoint} to return 200, got ${response.status}`);
+    }
+    const body = await response.text();
+    for (const leaked of leakCandidates) {
+      if (!body.includes(leaked)) continue;
+      const offenders = [];
+      const findLeaks = (value, trail) => {
+        if (typeof value === 'string') {
+          if (value.includes(leaked)) offenders.push(`${trail} = ${value}`);
+        } else if (Array.isArray(value)) {
+          value.forEach((child, index) => findLeaks(child, `${trail}[${index}]`));
+        } else if (value && typeof value === 'object') {
+          for (const [key, child] of Object.entries(value)) findLeaks(child, `${trail}.${key}`);
+        }
+      };
+      findLeaks(JSON.parse(body), endpoint);
+      throw new Error(`${endpoint} leaked an absolute local path (${leaked}) with redaction enabled:\n  ${offenders.join('\n  ')}`);
+    }
+    // A label immediately followed by more path characters means a registered path
+    // matched mid-segment, e.g. /home/u/.codex rewriting /home/u/.codexpro into
+    // "[codex-data]pro". Not a leak, but misleading, so fail on it.
+    const malformed = body.match(/\[[a-z-]+(?::[^\]]+)?\][A-Za-z0-9_-]/);
+    if (malformed) {
+      throw new Error(`${endpoint} produced a label that swallowed part of a path segment: ${malformed[0]}`);
+    }
+  }
+
+  const redactedHealth = await (await fetch(`${redactionBase}/healthz`, {
+    headers: { Authorization: `Bearer ${token}` }
+  })).json();
+  if (redactedHealth.ok !== true || redactedHealth.authRequired !== true) {
+    throw new Error(`redacted healthz lost its diagnostics: ${JSON.stringify(redactedHealth)}`);
+  }
+  if (!String(redactedHealth.defaultRoot).startsWith('[')) {
+    throw new Error(`redacted healthz did not label defaultRoot: ${redactedHealth.defaultRoot}`);
+  }
+  if (!Array.isArray(redactedHealth.allowedRoots) || !redactedHealth.allowedRoots.every((entry) => String(entry).startsWith('['))) {
+    throw new Error(`redacted healthz did not label allowedRoots: ${JSON.stringify(redactedHealth.allowedRoots)}`);
+  }
+} finally {
+  redactionChild.kill('SIGTERM');
+  await waitForExit(redactionChild).catch(() => {});
+}
+
+const exposedPort = await getFreePort();
+const exposedChild = spawn('node', ['dist/http.js'], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_EXPOSE_ABSOLUTE_PATHS: '1',
+    CODEXPRO_ROOT: root,
+    CODEXPRO_ALLOWED_ROOTS: root,
+    CODEXPRO_HOST: '127.0.0.1',
+    CODEXPRO_PORT: String(exposedPort),
+    CODEXPRO_HTTP_TOKEN: token,
+    CODEXPRO_HOME: profileHome
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+
+try {
+  await waitForListening(exposedChild);
+  const exposedHealth = await (await fetch(`http://127.0.0.1:${exposedPort}/healthz`, {
+    headers: { Authorization: `Bearer ${token}` }
+  })).json();
+  if (await fs.realpath(exposedHealth.defaultRoot) !== realRoot) {
+    throw new Error(`CODEXPRO_EXPOSE_ABSOLUTE_PATHS=1 did not return the real healthz root: ${exposedHealth.defaultRoot}`);
+  }
+} finally {
+  exposedChild.kill('SIGTERM');
+  await waitForExit(exposedChild).catch(() => {});
 }
 
 console.log('✓ http smoke test passed');

--- a/scripts/import-smoke.mjs
+++ b/scripts/import-smoke.mjs
@@ -6,6 +6,11 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 const png = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
   'base64'

--- a/scripts/pro-smoke.mjs
+++ b/scripts/pro-smoke.mjs
@@ -3,6 +3,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 function run(args, options = {}) {
   const result = spawnSync(process.execPath, args, {
     cwd: path.resolve('.'),

--- a/scripts/release-guard-smoke.mjs
+++ b/scripts/release-guard-smoke.mjs
@@ -5,6 +5,11 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 const root = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
 const npmCli = process.env.npm_execpath;

--- a/scripts/settings-smoke.mjs
+++ b/scripts/settings-smoke.mjs
@@ -4,6 +4,11 @@ import fs from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
+
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
 import {
   CLOUDFLARED_VERSION,
   cloudflaredReleaseAsset,

--- a/scripts/skill-precedence-smoke.mjs
+++ b/scripts/skill-precedence-smoke.mjs
@@ -3,6 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { discoverSkillInventory, loadSkill } from '../dist/capabilitiesOps.js';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 async function writeSkill(root, relativeDir, name, description, heading) {
   const dir = path.join(root, relativeDir);
   await fs.mkdir(dir, { recursive: true });

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -3,6 +3,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 function encode(message) {
   return `${JSON.stringify(message)}\n`;
 }
@@ -1683,4 +1688,72 @@ if (!lowerContext.content?.[0]?.text?.includes('Lowercase instruction file loade
   throw new Error('codex_context did not include lowercase agents.md content');
 }
 lowerClient.close();
+// --- absolute path redaction (default behaviour) -------------------------------
+// Every other client in this file runs with CODEXPRO_EXPOSE_ABSOLUTE_PATHS=1. This one
+// deliberately does not, so it exercises what a real deployment sends to ChatGPT.
+const redactedClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_EXPOSE_ABSOLUTE_PATHS: '0' }
+});
+await redactedClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-redaction-smoke', version: '0.1.0' }
+});
+redactedClient.notify('notifications/initialized');
+
+const redactedOpen = await redactedClient.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: true } });
+const redactedWs = redactedOpen.structuredContent.workspace_id;
+const redactedRead = await redactedClient.request('tools/call', { name: 'read', arguments: { workspace_id: redactedWs, path: 'demo.txt' } });
+const redactedTree = await redactedClient.request('tools/call', { name: 'tree', arguments: { workspace_id: redactedWs, path: '.' } });
+const redactedConfig = await redactedClient.request('tools/call', { name: 'server_config', arguments: {} });
+const redactedStatus = await redactedClient.request('tools/call', { name: 'git_status', arguments: { workspace_id: redactedWs } });
+
+const redactionRealTmp = await fs.realpath(tmp);
+const redactionHome = os.homedir();
+for (const [label, payload] of [
+  ['open_current_workspace', redactedOpen],
+  ['read', redactedRead],
+  ['tree', redactedTree],
+  ['server_config', redactedConfig],
+  ['git_status', redactedStatus]
+]) {
+  const serialized = JSON.stringify(payload);
+  for (const leaked of [redactionRealTmp, tmp, redactionHome]) {
+    if (serialized.includes(leaked)) {
+      throw new Error(`${label} leaked an absolute local path (${leaked}) with redaction enabled`);
+    }
+  }
+}
+if (redactedOpen.structuredContent.root !== '[workspace:' + redactedWs + ']') {
+  throw new Error(`workspace root was not replaced with its label: ${redactedOpen.structuredContent.root}`);
+}
+if (redactedConfig.structuredContent.exposeAbsolutePaths !== false) {
+  throw new Error('server_config did not report redaction as active');
+}
+if (!redactedRead.structuredContent.text?.includes('alpha')) {
+  throw new Error('redaction damaged file content');
+}
+if (redactedRead.structuredContent.path !== 'demo.txt') {
+  throw new Error(`redaction altered a workspace-relative path: ${redactedRead.structuredContent.path}`);
+}
+redactedClient.close();
+
+// The escape hatch must still hand back real paths for local tooling.
+const exposedClient = new McpStdioClient('node', ['dist/stdio.js', '--root', tmp, '--allow-root', tmp, '--bash', 'safe'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: tmp, CODEXPRO_ALLOWED_ROOTS: tmp, CODEXPRO_EXPOSE_ABSOLUTE_PATHS: '1' }
+});
+await exposedClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-exposed-smoke', version: '0.1.0' }
+});
+exposedClient.notify('notifications/initialized');
+const exposedOpen = await exposedClient.request('tools/call', { name: 'open_current_workspace', arguments: { include_tree: false } });
+if (await fs.realpath(exposedOpen.structuredContent.root) !== redactionRealTmp) {
+  throw new Error(`CODEXPRO_EXPOSE_ABSOLUTE_PATHS=1 did not return the real root: ${exposedOpen.structuredContent.root}`);
+}
+exposedClient.close();
+
 console.log('✓ smoke test passed');

--- a/scripts/stress.mjs
+++ b/scripts/stress.mjs
@@ -4,6 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 const REQUEST_TIMEOUT_MS = process.platform === 'win32' ? 45_000 : 20_000;
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 

--- a/scripts/widget-smoke.mjs
+++ b/scripts/widget-smoke.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { toolCardWidgetHtml } from "../dist/toolCardWidget.js";
 
+// These harnesses realpath and stat the paths CodexPro returns, so they need the raw
+// absolute form. Production defaults to redacted labels; see the redaction assertions
+// at the end of scripts/smoke.mjs for coverage of the default behaviour.
+process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1';
+
 const scripts = [...toolCardWidgetHtml.matchAll(/<script>([\s\S]*?)<\/script>/g)];
 const widgetScript = scripts.at(-1)?.[1];
 if (!widgetScript) throw new Error("tool-card widget script missing");

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ export interface CodexProConfig {
   codexDir: string;
   writeMode: WriteMode;
   toolMode: ToolMode;
+  exposeAbsolutePaths: boolean;
   inheritEnv: boolean;
   maxReadBytes: number;
   maxWriteBytes: number;
@@ -321,6 +322,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     codexDir: expandHome(codexDirArg || process.env.CODEXPRO_CODEX_DIR || path.join(os.homedir(), ".codex")),
     writeMode: writeModeFrom(writeArg ?? process.env.CODEXPRO_WRITE_MODE),
     toolMode: toolModeFrom(toolModeArg ?? process.env.CODEXPRO_TOOL_MODE),
+    exposeAbsolutePaths: boolFrom(process.env.CODEXPRO_EXPOSE_ABSOLUTE_PATHS, false),
     inheritEnv: process.env.CODEXPRO_INHERIT_ENV === "1",
     maxReadBytes: numberFrom(process.env.CODEXPRO_MAX_READ_BYTES, 180_000, 4_000, 2_000_000),
     maxWriteBytes: numberFrom(process.env.CODEXPRO_MAX_WRITE_BYTES, 1_000_000, 1_000, 10_000_000),

--- a/src/http.ts
+++ b/src/http.ts
@@ -20,6 +20,7 @@ import {
 } from "./profileStore.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
 import { createCodexProServer } from "./server.js";
+import { redactConfigPaths } from "./pathLabels.js";
 
 function escapeHtml(value: unknown): string {
   return String(value ?? "")
@@ -382,7 +383,10 @@ function buildProfilePayload(config: CodexProConfig, existing: WorkspaceProfile,
 function profileResponse(config: CodexProConfig): Record<string, unknown> {
   const profile = readWorkspaceProfile(config.defaultRoot);
   const runtime = readRuntimeConnection(config.defaultRoot);
-  return redactStructured({
+  // redactStructured strips secrets; redactConfigPaths additionally replaces absolute
+  // local paths with labels. The onboarding form is rendered server-side from
+  // profileValues(), not from this endpoint, so labelling here cannot corrupt a save.
+  return redactConfigPaths(config, redactStructured({
     ok: true,
     profile_path: profile.profilePath ?? profilePathForRoot(config.defaultRoot),
     exists: Boolean(profile.profilePath),
@@ -401,7 +405,7 @@ function profileResponse(config: CodexProConfig): Record<string, unknown> {
       widgetDomain: config.widgetDomain,
       authEnabled: Boolean(config.authToken)
     }
-  });
+  }), { labelUnknownPaths: true });
 }
 
 function jsonError(res: Response, status: number, code: string, message: string, issues?: unknown): void {
@@ -1624,7 +1628,7 @@ async function main(): Promise<void> {
   });
 
   app.get("/healthz", (_req, res) => {
-    res.json({
+    res.json(redactConfigPaths(config, {
       ok: true,
       name: "CodexPro",
       defaultRoot: config.defaultRoot,
@@ -1640,7 +1644,7 @@ async function main(): Promise<void> {
       contextDir: config.contextDir,
       authEnabled: Boolean(config.authToken),
       authRequired: Boolean(config.authToken)
-    });
+    }, { labelUnknownPaths: true }));
   });
 
   app.get("/admin/profile", (_req, res) => {

--- a/src/pathLabels.ts
+++ b/src/pathLabels.ts
@@ -1,0 +1,121 @@
+import os from "node:os";
+import path from "node:path";
+import type { CodexProConfig } from "./config.js";
+
+/**
+ * Absolute local paths are replaced with stable labels before anything leaves the
+ * server, so a connector client never learns the operator's directory layout.
+ *
+ * Ordering matters: entries are sorted longest-first so a workspace nested inside
+ * the home directory is labelled [workspace:...] rather than [home]/....
+ * The first label registered for a given path wins, which is why payload-derived
+ * workspace roots are collected before the config-derived fallbacks.
+ */
+export type PathRedactions = Array<[string, string]>;
+
+export function pathRedactions(config: CodexProConfig, discovered: unknown = undefined): PathRedactions {
+  const replacements = new Map<string, string>();
+  const add = (value: unknown, label: string): void => {
+    if (typeof value !== "string" || !value || !path.isAbsolute(value)) return;
+    if (!replacements.has(value)) replacements.set(value, label);
+  };
+
+  // Workspace roots come from the payload because MCP worktree ids are created at
+  // runtime and appear nowhere in config.
+  const collectWorkspaceRoots = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(collectWorkspaceRoots);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (typeof record.root === "string") {
+      add(record.root, `[workspace:${String(record.id ?? record.workspace_id ?? record.project_id ?? "current")}]`);
+    }
+    Object.values(record).forEach(collectWorkspaceRoots);
+  };
+  if (discovered !== undefined) collectWorkspaceRoots(discovered);
+
+  add(config.defaultRoot, "[workspace]");
+  for (const allowedRoot of config.allowedRoots) add(allowedRoot, "[allowed-root]");
+  add(config.codexDir, "[codex-data]");
+  add(os.homedir(), "[home]");
+  return [...replacements.entries()].sort((a, b) => b[0].length - a[0].length);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const boundaryPatterns = new Map<string, RegExp>();
+
+/**
+ * A registered path only matches at a path boundary, so /home/u/.codex never
+ * rewrites the unrelated /home/u/.codexpro into "[codex-data]pro".
+ */
+function boundaryPattern(absolutePath: string): RegExp {
+  const cached = boundaryPatterns.get(absolutePath);
+  if (cached) return cached;
+  const pattern = new RegExp(`${escapeRegExp(absolutePath)}(?![A-Za-z0-9_.-])`, "g");
+  boundaryPatterns.set(absolutePath, pattern);
+  return pattern;
+}
+
+export function redactPathsInText(value: string, ordered: PathRedactions): string {
+  let output = value;
+  for (const [absolutePath, label] of ordered) {
+    output = output.replace(boundaryPattern(absolutePath), label);
+  }
+  return output;
+}
+
+export function redactPathsDeep<T>(value: T, ordered: PathRedactions): T {
+  if (!ordered.length) return value;
+  const walk = (input: unknown): unknown => {
+    if (typeof input === "string") return redactPathsInText(input, ordered);
+    if (Array.isArray(input)) return input.map(walk);
+    if (input && typeof input === "object") {
+      return Object.fromEntries(Object.entries(input as Record<string, unknown>).map(([key, child]) => [key, walk(child)]));
+    }
+    return input;
+  };
+  return walk(value) as T;
+}
+
+// A string that is entirely one absolute filesystem path. Anchored at both ends so
+// URLs ("https://host/p"), labelled paths ("[home]/.codex") and prose that merely
+// contains a slash are never matched.
+const WHOLE_STRING_ABSOLUTE_PATH = /^(?:\/[^\0\n]*|[A-Za-z]:[\\/][^\0\n]*)$/;
+
+function mapStrings<T>(value: T, fn: (input: string) => string): T {
+  const walk = (input: unknown): unknown => {
+    if (typeof input === "string") return fn(input);
+    if (Array.isArray(input)) return input.map(walk);
+    if (input && typeof input === "object") {
+      return Object.fromEntries(Object.entries(input as Record<string, unknown>).map(([key, child]) => [key, walk(child)]));
+    }
+    return input;
+  };
+  return walk(value) as T;
+}
+
+/**
+ * Redact a config-echoing payload for the authenticated HTTP diagnostics endpoints,
+ * which are reachable with the same bearer token an MCP client holds.
+ *
+ * `labelUnknownPaths` additionally collapses any string that is still a bare absolute
+ * path into [path]. Those endpoints echo *stored* profile content, which can hold
+ * paths from an older profile that the running config knows nothing about, so the
+ * config-derived labels alone cannot cover them. It is deliberately not used for MCP
+ * tool results, where file content and command output must survive untouched.
+ */
+export function redactConfigPaths<T>(
+  config: CodexProConfig,
+  value: T,
+  options: { labelUnknownPaths?: boolean } = {}
+): T {
+  if (config.exposeAbsolutePaths) return value;
+  const redacted = redactPathsDeep(value, pathRedactions(config, value));
+  if (!options.labelUnknownPaths) return redacted;
+  return mapStrings(redacted, (input) => (WHOLE_STRING_ABSOLUTE_PATH.test(input) ? "[path]" : input));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { listCodexSessions, readCodexSession } from "./codexSessions.js";
 import { TOOL_CARD_LEGACY_URIS, TOOL_CARD_MIME_TYPE, TOOL_CARD_URI, toolCardWidgetHtml } from "./toolCardWidget.js";
 import { hasSecretValue, redactSensitiveText, redactStructured } from "./redact.js";
 import { inspectWorkspace, invalidateWorkspaceAnalysis, reviewWorkspaceChanges } from "./analysis/index.js";
+import { pathRedactions, redactPathsDeep, redactPathsInText } from "./pathLabels.js";
 
 const STRUCTURED_STRING_MAX_CHARS = 30_000;
 
@@ -103,7 +104,21 @@ function validateToolArgs(name: string, options: Record<string, unknown>, args: 
   throw new CodexProError(`Invalid arguments for ${name}: ${details}`);
 }
 
-function tagToolResult(result: any, name: string, options: Record<string, unknown>): any {
+function redactAbsolutePaths(result: any, config: CodexProConfig): void {
+  const structured = result.structuredContent;
+  const ordered = pathRedactions(config, structured && typeof structured === "object" ? structured : {});
+  if (!ordered.length) return;
+  if (structured && typeof structured === "object") result.structuredContent = redactPathsDeep(structured, ordered);
+  if (Array.isArray(result.content)) {
+    result.content = result.content.map((item: any) =>
+      item?.type === "text" && typeof item.text === "string"
+        ? { ...item, text: redactPathsInText(item.text, ordered) }
+        : item
+    );
+  }
+}
+
+function tagToolResult(result: any, name: string, options: Record<string, unknown>, config: CodexProConfig): any {
   if (!result || typeof result !== "object") return result;
   const structured = result.structuredContent;
   const base =
@@ -117,6 +132,7 @@ function tagToolResult(result: any, name: string, options: Record<string, unknow
   };
   const meta = (options._meta as Record<string, unknown> | undefined) ?? {};
   result.structuredContent = meta.ui || meta["openai/outputTemplate"] ? compactStructuredContent(tagged) : tagged;
+  if (!config.exposeAbsolutePaths) redactAbsolutePaths(result, config);
   return result;
 }
 
@@ -273,6 +289,7 @@ function assertWriteToolAllowed(config: CodexProConfig, relPath: string): void {
 }
 
 function registerToolCompat(
+  config: CodexProConfig,
   server: McpServer,
   name: string,
   options: Record<string, unknown>,
@@ -281,11 +298,11 @@ function registerToolCompat(
   const wrapped = async (args: any) => {
     const started = Date.now();
     try {
-      const result = tagToolResult(await handler(args ?? {}), name, options);
+      const result = tagToolResult(await handler(args ?? {}), name, options, config);
       logToolCall(name, result?.isError ? "error" : "ok", started);
       return result;
     } catch (error) {
-      const result = tagToolResult(errorResult(error), name, options);
+      const result = tagToolResult(errorResult(error), name, options, config);
       logToolCall(name, "error", started);
       return result;
     }
@@ -465,7 +482,7 @@ function registerCodexTool(
 ): void {
   if (!shouldRegisterTool(config, name)) return;
   const validatedHandler: CodexToolHandler = (args) => handler(validateToolArgs(name, options, args));
-  registerToolCompat(server, name, descriptorOptionsForConfig(config, name, options), validatedHandler);
+  registerToolCompat(config, server, name, descriptorOptionsForConfig(config, name, options), validatedHandler);
   rememberRegisteredTool(server, name);
   rememberRegisteredToolHandler(server, name, validatedHandler);
 }
@@ -1049,6 +1066,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         codexDir: config.codexDir,
         writeMode: config.writeMode,
         toolMode: config.toolMode,
+        exposeAbsolutePaths: config.exposeAbsolutePaths,
         toolCards: config.toolCards,
         connectionTest: config.connectionTest,
         analysisEnabled: config.analysisEnabled,


### PR DESCRIPTION
## What leaks today

Every response CodexPro sends carries the operator's real filesystem layout — including their username — to the connector client.

**MCP tool results.** `structuredContent` and text content blocks echo absolute paths verbatim:

```json
{ "workspace_id": "ws_1a2b...", "root": "/home/alice/Projects/api", "path": "src/x.ts" }
```

**The authenticated HTTP diagnostics endpoints.** `GET /healthz` and `GET /admin/profile` bypass the tool-result path entirely, and both echo config. They are reachable with the same bearer token an MCP client already holds, so they are part of the same client-visible surface. On a live deployment I measured **4** occurrences of `/home/<user>` in `/healthz` (`defaultRoot`, `allowedRoots`) and **7** in `/admin/profile` (`profile_path`, `effective.codexDir`, `runtime.defaultRoot`, …).

For a connector reached over a tunnel this is a standing disclosure of the host's directory structure — and the account name — to a third party, for no functional benefit. The model never needs the absolute prefix: every tool already addresses files workspace-relative.

## The redaction scheme

Absolute local paths are rewritten to stable labels before a response leaves the server:

```
/home/alice/Projects/api/src/x.ts  ->  [workspace:ws_1a2b.../src/x.ts]
/home/alice/.codex/sessions/a.json ->  [codex-data]/sessions/a.json
/home/alice                        ->  [home]
```

Labels on this branch are `[workspace:<id>]` (discovered from the payload, because workspace ids are assigned at runtime and appear nowhere in config), `[workspace]`, `[allowed-root]`, `[codex-data]` and `[home]`.

Two properties matter for correctness:

**Longest-match-first.** A workspace nested inside the home directory must be labelled `[workspace:...]`, not `[home]/Projects/api`. Entries are sorted by descending path length before substitution.

**Path-boundary-aware matching.** This one bit me in deployment and is worth calling out, because the naive implementation looks completely fine in testing. A plain substring replace produces:

```
/home/alice/.codexpro/profiles/x.json  ->  [codex-data]pro/profiles/x.json
```

`~/.codex` is a string prefix of `~/.codexpro`, so the Codex-data label swallowed part of an unrelated segment. Not a leak, but it misreports which directory a path belongs to. A registered path now only matches when followed by a path separator or end of string, so `~/.codex` no longer touches `~/.codexpro` or `~/.codex-backup`; those fall through to `[home]` as intended.

**One extra rule for the two diagnostics endpoints.** They echo *stored* profile content, which can contain paths from an older saved profile that the running config knows nothing about — so config-derived labels cannot cover them by construction. Any string that is still a bare absolute path after labelling collapses to `[path]`. The pattern is anchored at both ends, leaving URLs (`https://host/p`), already-labelled paths (`[home]/.codex`) and prose containing a slash untouched. This fallback is deliberately **not** applied to tool results, where file content and command output must survive intact.

Redacting `GET /admin/profile` is safe for the admin UI, which I verified before changing it: the onboarding form is rendered server-side from `profileValues()`, and the page's only `fetch` is the POST save. No labelled value can round-trip into a stored profile.

## What is not touched

Workspace-relative paths, so tool arguments and results still round-trip — `read(path: "src/x.ts")` is unaffected, as is file content, command output and diffs.

## Escape hatch

`CODEXPRO_EXPOSE_ABSOLUTE_PATHS=1` restores the previous behaviour for local debugging, and `server_config` reports which mode is active.

## Default: ON — and the honest cost

I've defaulted this to ON, on the grounds that leaking the host layout should be opt-in rather than opt-out, and that a connector talking to a hosted model is the common case.

The visible cost is that **13 smoke harnesses need `CODEXPRO_EXPOSE_ABSOLUTE_PATHS = '1'` at the top of the file**, because they `realpath()` and `stat()` the paths CodexPro returns. I chose a one-line explicit opt-out per harness over rewriting their assertions, so existing coverage keeps testing exactly what it tested before. That is 13 of the 18 changed files, and it is the main thing to weigh if you'd rather this defaulted to OFF — the code supports either, and flipping the default is a one-word change in `config.ts`.

## Verification

`npm run build` and **all 12 smoke scripts pass**.

New coverage, both written to fail against the unpatched code:

- `scripts/smoke.mjs` runs a client with redaction on and asserts five tool results contain no absolute path, that the workspace root equals its label, that relative paths and file content survive, and that the escape hatch still returns a real root.
- `scripts/http-smoke.mjs` runs a server with redaction on and asserts both endpoints are free of every local path, that `healthz` still reports labelled roots and working diagnostics, and that no label swallowed part of a path segment. It builds that server with the layout that exposed the prefix bug (`<h>/.codex` as the Codex dir, `<h>/.codexpro` as `CODEXPRO_HOME`); against the pre-fix code it fails with:

```
Error: /admin/profile produced a label that swallowed part of a path segment: [codex-data]p
```

The leak assertion names the offending JSON path rather than only the value, which is what turned the original finding into a quick diagnosis.

Beyond the test suite, this is running on a real deployment reached over a private network. Scanning the client-visible surface there — `tools/list`, `list_projects`, `open_workspace`, `read`, `tree`, `server_config`, `/healthz`, `/admin/profile` — returns **zero** absolute paths and zero malformed labels, where `/healthz` and `/admin/profile` previously returned 4 and 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
