### PR TITLE
fix: keep open_workspace ids resolvable across MCP sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Kept HTTP `open_workspace` ids resolvable across independent MCP sessions by sharing a process-wide workspace registry while leaving selection session-local. Explicit unknown ids still fail closed and never fall back to the launch workspace. Nested allowed worktrees now survive the next ChatGPT tool call.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/FAQ.md
+++ b/FAQ.md
@@ -350,7 +350,7 @@ codexpro settings show
 codexpro start
 ```
 
-Confirm `Projects` lists the extra roots, then restart the connector so the admin page Allowed Roots list refreshes. Ask ChatGPT to open an allowed project. `open_workspace` makes it the selected project for that MCP session, and later tools can omit `workspace_id`. `open_current_workspace` switches back to the launch project.
+Confirm `Projects` lists the extra roots, then restart the connector so the admin page Allowed Roots list refreshes. Ask ChatGPT to open an allowed project. `open_workspace` returns a `workspace_id` that stays valid for later tool calls on this CodexPro process, including a later MCP session. It also becomes the selected project for the current MCP session, so tools in that same session may omit `workspace_id`. `open_current_workspace` switches the session selection back to the launch project without invalidating other ids. Unknown `workspace_id` values fail closed and never fall back to the launch project.
 
 `--clear-projects` removes the saved extra roots from that launch workspace profile:
 
@@ -358,7 +358,7 @@ Confirm `Projects` lists the extra roots, then restart the connector so the admi
 codexpro settings set --clear-projects
 ```
 
-Workspace selection is isolated between MCP sessions created by the client. A ChatGPT conversation is not guaranteed to map one-to-one to an MCP session, so use separate CodexPro processes when strict isolation matters.
+Workspace selection is isolated between MCP sessions created by the client. Registered `workspace_id` values are process-wide, so an explicit id from `open_workspace` still resolves after the client opens a new session. A ChatGPT conversation is not guaranteed to map one-to-one to an MCP session, so pass `workspace_id` on later tool calls. Use separate CodexPro processes when you need separate allowlists or public endpoints.
 
 For separate processes, two ChatGPT accounts, or two ngrok domains on one machine, run two CodexPro processes with different local ports and different public hostnames:
 
@@ -371,7 +371,7 @@ Run `codexpro setup` in each repo and save a profile per workspace. Do not reuse
 
 ## How do multiple ChatGPT sessions avoid overwriting each other?
 
-Workspace selection is session-local. For shared files, read the file first and pass its returned SHA-256 as `expected_sha256` to `write` or `edit`. CodexPro rejects the operation if the file changed after that read. New files use atomic replacement; existing files are updated in place to retain inode-bound metadata and hard links.
+Workspace selection is session-local. Explicit `workspace_id` values are not: they resolve from the process workspace registry and never fall back to another root. For shared files, read the file first and pass its returned SHA-256 as `expected_sha256` to `write` or `edit`. CodexPro rejects the operation if the file changed after that read. New files use atomic replacement; existing files are updated in place to retain inode-bound metadata and hard links.
 
 This protects against stale file content. It does not turn CodexPro into a collaborative merge server, so separate worktrees remain the stronger choice for large overlapping changes.
 

--- a/FAQ_ZH.md
+++ b/FAQ_ZH.md
@@ -281,7 +281,7 @@ codexpro settings show
 codexpro start
 ```
 
-确认输出里的 `Projects` 列出了额外根目录，然后重启 connector，管理页 Allowed Roots 才会刷新。让 ChatGPT 打开已允许的项目。`open_workspace` 会把它设为当前 MCP session 的选择，之后其他工具可以省略 `workspace_id`。`open_current_workspace` 会切回启动时的主项目。
+确认输出里的 `Projects` 列出了额外根目录，然后重启 connector，管理页 Allowed Roots 才会刷新。让 ChatGPT 打开已允许的项目。`open_workspace` 返回的 `workspace_id` 在整个 CodexPro 进程内保持有效，即使客户端随后开启新的 MCP session。当前 MCP session 会把该项目设为选择，因此同一 session 里后续工具可以省略 `workspace_id`。`open_current_workspace` 只把 session 选择切回启动项目，不会让其他 id 失效。未知 `workspace_id` 会失败，绝不会静默回退到启动仓库。
 
 清除已保存的额外项目：
 
@@ -289,7 +289,7 @@ codexpro start
 codexpro settings set --clear-projects
 ```
 
-项目选择按 MCP session 隔离，但 ChatGPT conversation 不保证和 MCP session 一一对应。需要严格隔离、两个 ChatGPT 账号、或两个 ngrok 域名时，请跑两个 CodexPro 进程，并用不同本地端口和不同公网 hostname：
+项目选择按 MCP session 隔离，但已打开的 `workspace_id` 属于进程级注册表。ChatGPT conversation 不保证和 MCP session 一一对应，因此后续工具调用应带上 `workspace_id`。需要独立 allowlist 或独立公网入口时，请跑两个 CodexPro 进程，并用不同本地端口和不同公网 hostname：
 
 ```text
 repo A: port 8787, hostname A, ChatGPT plugin URL A

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ codexpro settings show
 codexpro start
 ```
 
-Ask ChatGPT to `open_workspace` on an allowed project. `open_current_workspace` returns to the launch repo.
+Ask ChatGPT to `open_workspace` on an allowed project. Pass the returned `workspace_id` on later tool calls; it stays valid for the lifetime of this CodexPro process even if the client starts a new MCP session. `open_current_workspace` returns to the launch repo. Omitting `workspace_id` uses the session-local selection only.
 
 For two ChatGPT accounts or hard isolation, run two CodexPro processes on different ports and Server URLs.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -91,7 +91,7 @@ codexpro settings show
 codexpro start
 ```
 
-让 ChatGPT 对已允许项目执行 `open_workspace`。`open_current_workspace` 切回启动仓库。
+让 ChatGPT 对已允许项目执行 `open_workspace`，并在后续工具调用中传入返回的 `workspace_id`；该 id 在整个 CodexPro 进程内保持有效。`open_current_workspace` 切回启动仓库。省略 `workspace_id` 时只使用当前 MCP session 的选择。
 
 两个 ChatGPT 账号或需要硬隔离时，用不同端口和 Server URL 跑两个 CodexPro 进程。
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "start:http": "node dist/http.js",
     "dev:stdio": "tsx src/stdio.ts",
     "dev:http": "tsx src/http.ts",
-    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/import-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
+    "smoke": "node scripts/analysis-smoke.mjs && node scripts/analysis-cli-smoke.mjs && node scripts/smoke.mjs && node scripts/skill-precedence-smoke.mjs && node scripts/import-smoke.mjs && node scripts/workspace-registry-smoke.mjs && node scripts/http-smoke.mjs && node scripts/widget-smoke.mjs && node scripts/pro-smoke.mjs && node scripts/doctor-smoke.mjs && node scripts/settings-smoke.mjs && node scripts/execute-handoff-smoke.mjs && node scripts/release-guard-smoke.mjs",
     "stress": "npm run build && node scripts/stress.mjs",
     "analysis:smoke": "npm run build && node scripts/analysis-smoke.mjs",
     "analysis:cli-smoke": "npm run build && node scripts/analysis-cli-smoke.mjs",

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -207,6 +207,22 @@ function postToolsListWithSession(baseUrl, token, sessionId) {
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-smoke-'));
 const alternateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-alternate-'));
 await fs.writeFile(path.join(alternateRoot, 'selected.txt'), 'http alternate workspace\n', 'utf8');
+const nestedARoot = path.join(root, 'nested-worktree-a');
+const nestedBRoot = path.join(root, 'nested-worktree-b');
+await fs.mkdir(nestedARoot, { recursive: true });
+await fs.mkdir(nestedBRoot, { recursive: true });
+await fs.writeFile(path.join(nestedARoot, 'known-file.txt'), 'nested http workspace a\n', 'utf8');
+await fs.writeFile(path.join(nestedBRoot, 'known-file.txt'), 'nested http workspace b\n', 'utf8');
+for (const nestedRoot of [nestedARoot, nestedBRoot]) {
+  for (const args of [
+    ['init'],
+    ['add', 'known-file.txt'],
+    ['-c', 'user.email=smoke@example.com', '-c', 'user.name=Smoke Test', 'commit', '-m', 'nested worktree']
+  ]) {
+    const result = spawnSync('git', args, { cwd: nestedRoot, encoding: 'utf8' });
+    if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed in ${nestedRoot}: ${result.stderr || result.stdout}`);
+  }
+}
 const profileHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-http-profile-home-'));
 await fs.mkdir(path.join(root, '.codex', 'skills', 'http-smoke-skill'), { recursive: true });
 await fs.writeFile(path.join(root, '.codex', 'skills', 'http-smoke-skill', 'SKILL.md'), [
@@ -679,17 +695,99 @@ try {
 
     await withClient(mcpUrl, async (secondClient) => {
       const secondList = await callTool(secondClient, 'list_workspaces');
-      if (
-        secondList.structuredContent.selected_workspace_id === alternate.structuredContent.workspace_id
-        || secondList.structuredContent.workspaces.some((workspace) => workspace.root === alternateRoot)
-      ) {
+      if (secondList.structuredContent.selected_workspace_id === alternate.structuredContent.workspace_id) {
         throw new Error(`HTTP workspace selection leaked between MCP sessions: ${JSON.stringify(secondList.structuredContent)}`);
+      }
+      const secondExplicit = await callTool(secondClient, 'read', {
+        workspace_id: alternate.structuredContent.workspace_id,
+        path: 'selected.txt'
+      });
+      const secondExplicitText = secondExplicit.content?.find?.((part) => part.type === 'text')?.text ?? '';
+      if (!secondExplicitText.includes('http alternate workspace')) {
+        throw new Error(`explicit workspace_id from another MCP session did not resolve: ${secondExplicitText}`);
+      }
+      const secondDefault = await callTool(secondClient, 'read', { path: 'session-checkpoint.txt' });
+      const secondDefaultText = secondDefault.content?.find?.((part) => part.type === 'text')?.text ?? '';
+      if (!secondDefaultText.includes('checkpoint changed') || secondDefaultText.includes('http alternate workspace')) {
+        throw new Error(`second HTTP session omit-id did not stay on the launch workspace: ${secondDefaultText}`);
       }
     });
 
     const firstList = await callTool(firstClient, 'list_workspaces');
     if (firstList.structuredContent.selected_workspace_id !== alternate.structuredContent.workspace_id) {
       throw new Error(`first HTTP session lost its workspace selection: ${JSON.stringify(firstList.structuredContent)}`);
+    }
+  });
+
+  const nestedOpened = await withClient(mcpUrl, async (client) => {
+    const openedA = await callTool(client, 'open_workspace', { root: nestedARoot, include_tree: false });
+    const openedB = await callTool(client, 'open_workspace', { root: nestedBRoot, include_tree: false });
+    if (openedA.structuredContent.workspace_id === openedB.structuredContent.workspace_id) {
+      throw new Error('distinct nested worktrees received the same workspace_id');
+    }
+    await callTool(client, 'open_current_workspace', { include_tree: false });
+    return {
+      a: openedA.structuredContent,
+      b: openedB.structuredContent
+    };
+  });
+
+  await withClient(mcpUrl, async (client) => {
+    const readA = await callTool(client, 'read', {
+      workspace_id: nestedOpened.a.workspace_id,
+      path: 'known-file.txt'
+    });
+    const readAText = readA.content?.find?.((part) => part.type === 'text')?.text ?? '';
+    if (!readAText.includes('nested http workspace a') || readA.structuredContent.root !== nestedOpened.a.root) {
+      throw new Error(`dynamic nested workspace did not survive the next MCP session: ${JSON.stringify(readA.structuredContent)}`);
+    }
+
+    const bashA = await callTool(client, 'bash', {
+      workspace_id: nestedOpened.a.workspace_id,
+      command: 'git rev-parse --show-toplevel'
+    });
+    const bashAOut = `${bashA.structuredContent.stdout ?? ''}\n${bashA.structuredContent.cwd ?? ''}`;
+    if (!bashAOut.includes(nestedOpened.a.root) || bashA.structuredContent.root !== nestedOpened.a.root) {
+      throw new Error(`bash did not resolve dynamic nested workspace: ${JSON.stringify(bashA.structuredContent)}`);
+    }
+
+    const readB = await callTool(client, 'read', {
+      workspace_id: nestedOpened.b.workspace_id,
+      path: 'known-file.txt'
+    });
+    const readBText = readB.content?.find?.((part) => part.type === 'text')?.text ?? '';
+    if (!readBText.includes('nested http workspace b')) {
+      throw new Error(`second nested workspace was lost: ${readBText}`);
+    }
+
+    await callTool(client, 'open_workspace', { root: nestedBRoot, include_tree: false });
+    const readAWhileBSelected = await callTool(client, 'read', {
+      workspace_id: nestedOpened.a.workspace_id,
+      path: 'known-file.txt'
+    });
+    const readAWhileBText = readAWhileBSelected.content?.find?.((part) => part.type === 'text')?.text ?? '';
+    if (!readAWhileBText.includes('nested http workspace a')) {
+      throw new Error('explicit nested workspace_id lost to selected workspace');
+    }
+
+    const changes = await callTool(client, 'show_changes', {
+      workspace_id: nestedOpened.a.workspace_id,
+      include_diff: false
+    });
+    if (changes.structuredContent.workspace_id !== nestedOpened.a.workspace_id || changes.structuredContent.root !== nestedOpened.a.root) {
+      throw new Error(`show_changes did not stay on the dynamic nested workspace: ${JSON.stringify(changes.structuredContent)}`);
+    }
+
+    const unknown = await client.callTool({
+      name: 'read',
+      arguments: { workspace_id: 'ws_does_not_exist', path: 'session-checkpoint.txt' }
+    });
+    const unknownText = unknown.content?.find?.((part) => part.type === 'text')?.text ?? JSON.stringify(unknown.structuredContent);
+    if (!unknown.isError || !/Unknown workspace_id: ws_does_not_exist/.test(unknownText)) {
+      throw new Error(`unknown workspace_id must fail closed, got: ${unknownText}`);
+    }
+    if (unknownText.includes('checkpoint changed') || unknownText.includes('nested http workspace')) {
+      throw new Error(`unknown workspace_id must not read another workspace: ${unknownText}`);
     }
   });
 

--- a/scripts/workspace-registry-smoke.mjs
+++ b/scripts/workspace-registry-smoke.mjs
@@ -1,0 +1,127 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const { loadConfig } = await import(pathToFileURL(path.join(path.resolve('.'), 'dist', 'config.js')).href);
+const { CodexProError, WorkspaceManager, WorkspaceRegistry } = await import(
+  pathToFileURL(path.join(path.resolve('.'), 'dist', 'guard.js')).href
+);
+
+function expect(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function expectError(fn, pattern, message) {
+  try {
+    fn();
+  } catch (error) {
+    const text = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+    if (pattern.test(text)) return text;
+    throw new Error(`${message}: unexpected error ${text}`);
+  }
+  throw new Error(message);
+}
+
+const parent = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'codexpro-ws-parent-'));
+const nestedA = path.join(parent, 'worktree-a');
+const nestedB = path.join(parent, 'worktree-b');
+await fs.promises.mkdir(nestedA);
+await fs.promises.mkdir(nestedB);
+await fs.promises.writeFile(path.join(parent, 'known-file.txt'), 'parent workspace\n', 'utf8');
+await fs.promises.writeFile(path.join(nestedA, 'known-file.txt'), 'worktree a\n', 'utf8');
+await fs.promises.writeFile(path.join(nestedB, 'known-file.txt'), 'worktree b\n', 'utf8');
+
+const escapeLink = path.join(parent, 'escape-link');
+await fs.promises.symlink('/etc', escapeLink);
+
+const previousRoot = process.env.CODEXPRO_ROOT;
+const previousAllowed = process.env.CODEXPRO_ALLOWED_ROOTS;
+const previousAllowHome = process.env.CODEXPRO_ALLOW_HOME;
+delete process.env.CODEXPRO_ROOT;
+delete process.env.CODEXPRO_ALLOWED_ROOTS;
+delete process.env.CODEXPRO_ALLOW_HOME;
+
+try {
+  const config = loadConfig(['--root', parent, '--allow-root', parent, '--bash', 'off']);
+  const registry = new WorkspaceRegistry();
+  const sessionA = new WorkspaceManager(config, { registry });
+  const sessionB = new WorkspaceManager(config, { registry });
+  const isolated = new WorkspaceManager(config);
+
+  const openedA = sessionA.openWorkspace(nestedA);
+  const openedAAgain = sessionA.openWorkspace(nestedA);
+  expect(openedA.id === openedAAgain.id, 'same nested root should reuse a stable workspace_id');
+  expect(openedA.root === fs.realpathSync.native(nestedA), `opened A root was ${openedA.root}`);
+
+  const openedB = sessionA.openWorkspace(nestedB);
+  expect(openedA.id !== openedB.id, 'distinct nested roots must receive distinct ids');
+
+  const resolvedFromB = sessionB.getWorkspace(openedA.id);
+  expect(resolvedFromB.root === openedA.root, 'shared registry must resolve a dynamic id from another manager');
+  expect(resolvedFromB.id === openedA.id, 'shared registry must not remap a resolved id');
+
+  const selectedOnB = sessionB.getWorkspace();
+  expect(selectedOnB.root === config.defaultRoot, `session B omit-id must stay on default, got ${selectedOnB.root}`);
+  expect(selectedOnB.id !== openedA.id, 'opening a workspace in session A must not select it in session B');
+
+  sessionB.openWorkspace(nestedB);
+  const explicitAWhileBSelected = sessionB.getWorkspace(openedA.id);
+  expect(explicitAWhileBSelected.root === openedA.root, 'explicit id must beat session-local selection');
+
+  sessionB.selectDefaultWorkspace();
+  const stillA = sessionB.getWorkspace(openedA.id);
+  expect(stillA.root === openedA.root, 'open_current/default must not unregister a dynamic workspace');
+
+  const againA = sessionB.getWorkspace(openedA.id);
+  expect(againA.root === openedA.root, 'dynamic workspace must remain after resolving another workspace');
+
+  const isolatedLookup = expectError(
+    () => isolated.getWorkspace(openedA.id),
+    /Unknown workspace_id/,
+    'private registry must not see another manager\'s dynamic workspace'
+  );
+  expect(!isolatedLookup.includes(parent), 'unknown-id error must not include another workspace root');
+
+  const unknown = expectError(
+    () => sessionB.getWorkspace('ws_does_not_exist'),
+    /Unknown workspace_id: ws_does_not_exist/,
+    'unknown workspace_id must fail closed'
+  );
+  expect(!unknown.toLowerCase().includes(path.basename(parent).toLowerCase()), 'unknown-id error must not resolve the default workspace');
+  expect(sessionB.getWorkspace().root === config.defaultRoot, 'failed unknown-id lookup must not change the selected workspace');
+
+  expectError(
+    () => sessionA.openWorkspace('/tmp'),
+    /outside allowed roots/,
+    '/tmp must remain outside allowedRoots'
+  );
+  expectError(
+    () => sessionA.openWorkspace(os.homedir()),
+    /outside allowed roots/,
+    'home directory must remain outside allowedRoots'
+  );
+  expectError(
+    () => sessionA.openWorkspace('/etc'),
+    /outside allowed roots/,
+    '/etc must remain outside allowedRoots'
+  );
+  expectError(
+    () => sessionA.openWorkspace(escapeLink),
+    /outside allowed roots/,
+    'symlink escaping allowedRoots must be rejected after canonicalization'
+  );
+
+  const listed = sessionB.listWorkspaces().map((workspace) => workspace.id);
+  expect(listed.includes(openedA.id) && listed.includes(openedB.id), 'shared registry list must keep both dynamic workspaces');
+} finally {
+  if (previousRoot === undefined) delete process.env.CODEXPRO_ROOT;
+  else process.env.CODEXPRO_ROOT = previousRoot;
+  if (previousAllowed === undefined) delete process.env.CODEXPRO_ALLOWED_ROOTS;
+  else process.env.CODEXPRO_ALLOWED_ROOTS = previousAllowed;
+  if (previousAllowHome === undefined) delete process.env.CODEXPRO_ALLOW_HOME;
+  else process.env.CODEXPRO_ALLOW_HOME = previousAllowHome;
+  await fs.promises.rm(parent, { recursive: true, force: true });
+}
+
+console.log('✓ workspace registry smoke test passed');

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -40,6 +40,26 @@ function workspaceIdForRoot(realRoot: string): string {
   return `ws_${createHash("sha256").update(realRoot).digest("hex").slice(0, 24)}`;
 }
 
+export class WorkspaceRegistry {
+  private readonly workspaces = new Map<string, Workspace>();
+
+  get(id: string): Workspace | undefined {
+    return this.workspaces.get(id);
+  }
+
+  findByRoot(root: string): Workspace | undefined {
+    return [...this.workspaces.values()].find((workspace) => workspace.root === root);
+  }
+
+  set(workspace: Workspace): void {
+    this.workspaces.set(workspace.id, workspace);
+  }
+
+  values(): Workspace[] {
+    return [...this.workspaces.values()];
+  }
+}
+
 function maybeRealpath(existingPath: string): string | undefined {
   try {
     return fs.realpathSync.native(existingPath);
@@ -59,13 +79,15 @@ function closestExistingParent(absPath: string): string {
 }
 
 export class WorkspaceManager {
-  private readonly workspaces = new Map<string, Workspace>();
+  private readonly registry: WorkspaceRegistry;
   private selectedWorkspaceId?: string;
 
-  constructor(private readonly config: CodexProConfig) {}
+  constructor(private readonly config: CodexProConfig, options: { registry?: WorkspaceRegistry } = {}) {
+    this.registry = options.registry ?? new WorkspaceRegistry();
+  }
 
   defaultWorkspace(): Workspace {
-    const existing = [...this.workspaces.values()].find((workspace) => workspace.root === this.config.defaultRoot);
+    const existing = this.registry.findByRoot(this.config.defaultRoot);
     return existing ?? this.openWorkspace(this.config.defaultRoot, { select: false });
   }
 
@@ -93,7 +115,7 @@ export class WorkspaceManager {
       );
     }
 
-    const existing = [...this.workspaces.values()].find((workspace) => workspace.root === realRoot);
+    const existing = this.registry.findByRoot(realRoot);
     if (existing) {
       if (options.select !== false) this.selectedWorkspaceId = existing.id;
       return existing;
@@ -101,7 +123,7 @@ export class WorkspaceManager {
 
     const id = workspaceIdForRoot(realRoot);
     const workspace = { id, root: realRoot, openedAt: new Date().toISOString() };
-    this.workspaces.set(id, workspace);
+    this.registry.set(workspace);
     if (options.select !== false) this.selectedWorkspaceId = id;
     return workspace;
   }
@@ -109,24 +131,20 @@ export class WorkspaceManager {
   getWorkspace(id?: string): Workspace {
     if (!id) {
       if (this.selectedWorkspaceId) {
-        const selected = this.workspaces.get(this.selectedWorkspaceId);
+        const selected = this.registry.get(this.selectedWorkspaceId);
         if (selected) return selected;
       }
       return this.selectDefaultWorkspace();
     }
-    const workspace = this.workspaces.get(id);
-    if (!workspace) {
-      const configuredRoot = this.config.allowedRoots.find((allowedRoot) => workspaceIdForRoot(allowedRoot) === id);
-      if (configuredRoot) return this.openWorkspace(configuredRoot, { select: false });
-    }
-    if (!workspace) {
-      throw new CodexProError(`Unknown workspace_id: ${id}. Call open_workspace first.`);
-    }
-    return workspace;
+    const workspace = this.registry.get(id);
+    if (workspace) return workspace;
+    const configuredRoot = this.config.allowedRoots.find((allowedRoot) => workspaceIdForRoot(allowedRoot) === id);
+    if (configuredRoot) return this.openWorkspace(configuredRoot, { select: false });
+    throw new CodexProError(`Unknown workspace_id: ${id}. Call open_workspace first.`);
   }
 
   listWorkspaces(): Workspace[] {
-    return [...this.workspaces.values()];
+    return this.registry.values();
   }
 
   currentWorkspaceId(): string {

--- a/src/http.ts
+++ b/src/http.ts
@@ -19,6 +19,7 @@ import {
   type WorkspaceProfile
 } from "./profileStore.js";
 import { redactSensitiveText, redactStructured } from "./redact.js";
+import { WorkspaceRegistry } from "./guard.js";
 import { createCodexProServer } from "./server.js";
 
 function escapeHtml(value: unknown): string {
@@ -1454,6 +1455,7 @@ async function main(): Promise<void> {
   }
 
   const app = express();
+  const workspaceRegistry = new WorkspaceRegistry();
   const logRequests = process.env.CODEXPRO_LOG_REQUESTS === "1";
   const authFailureWindow = new Map<string, { count: number; resetAt: number }>();
   const authFailureLimit = 10;
@@ -1699,7 +1701,7 @@ async function main(): Promise<void> {
           if (closedSessionId) transports.delete(closedSessionId);
         };
 
-        const server = createCodexProServer(config);
+        const server = createCodexProServer(config, { workspaceRegistry });
         await server.connect(transport);
       } else {
         sendSessionError(res, sessionId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CodexProConfig } from "./config.js";
-import { WorkspaceManager, PathGuard, CodexProError, type Workspace } from "./guard.js";
+import { WorkspaceManager, WorkspaceRegistry, PathGuard, CodexProError, type Workspace } from "./guard.js";
 import { repoTree, readTextFile, writeTextFile, editTextFile, ensureAiBridge, withFileWriteLocks } from "./fsOps.js";
 import { viewWorkspaceImage } from "./imageOps.js";
 import { importAttachmentFile } from "./importOps.js";
@@ -488,7 +488,7 @@ function serverInstructions(config: CodexProConfig): string {
     "CodexPro connects ChatGPT to explicitly allowed local development workspaces.",
     "",
     "Preferred workflow:",
-    "1. Start with open_current_workspace. Use open_workspace only when the user gives a different allowed root or asks to switch projects; that selection stays active for this MCP session.",
+    "1. Start with open_current_workspace. Use open_workspace only when the user gives a different allowed root or asks to switch projects. Pass the returned workspace_id on later tool calls; selection is only a convenience if this MCP session is reused.",
     "2. Follow any AGENTS.md-style instructions returned by the workspace open call before editing files.",
     "3. Inspect with tree, search, and read. Do not use bash for git status, git diff, cat, sed, grep, rg, find, ls, or file reading.",
     editInstruction,
@@ -926,8 +926,12 @@ const LOCAL_WRITE_ANNOTATIONS = { readOnlyHint: false, openWorldHint: false, des
 const BASH_ANNOTATIONS = { readOnlyHint: false, openWorldHint: true, destructiveHint: true, idempotentHint: false };
 const HANDOFF_WRITE_ANNOTATIONS = { readOnlyHint: false, openWorldHint: false, destructiveHint: false, idempotentHint: false };
 
-export function createCodexProServer(config: CodexProConfig): McpServer {
-  const workspaces = new WorkspaceManager(config);
+export interface CreateCodexProServerOptions {
+  workspaceRegistry?: WorkspaceRegistry;
+}
+
+export function createCodexProServer(config: CodexProConfig, options: CreateCodexProServerOptions = {}): McpServer {
+  const workspaces = new WorkspaceManager(config, { registry: options.workspaceRegistry });
   const reviewCheckpoints = new Map<string, string>();
   const guard = new PathGuard(config);
   const server = new McpServer({ name: "CodexPro", version: "0.30.0" }, { instructions: serverInstructions(config) });
@@ -1077,7 +1081,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Run one controlled, local-only CodexPro diagnostic. It checks modes, expected tools, workspace access, skills, git, safe bash policy, selected-only Pro context, and optional .ai-bridge write/edit probe without touching source files.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         write_probe: z.boolean().optional().describe("Create/edit only .ai-bridge/codexpro-self-test.md. Default: true."),
         bash_probe: z.boolean().optional().describe("Check bash policy with safe local commands only. Default: true."),
         pro_context_probe: z.boolean().optional().describe("Build a selected-only Pro context bundle in memory without writing pro-context.md. Default: true."),
@@ -1303,7 +1307,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "List CodexPro modes plus discovered skill names and configured MCP server names. Use this early when planning needs local agent capabilities.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         include_global_skills: z.boolean().optional().describe("Include user and plugin skill folders. Default: true."),
         include_mcp_servers: z.boolean().optional().describe("Include configured MCP server names from safe config files. Default: true."),
         max_skills: z.number().int().min(1).max(500).optional().describe("Maximum skills to list. Default: 120.")
@@ -1346,7 +1350,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Load the bounded SKILL.md body for a discovered workspace, user, or plugin skill by name. Does not accept arbitrary paths; use after open_current_workspace/open_workspace shows skill_inventory.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         name: z.string().describe("Exact skill name from skill_inventory or codexpro_inventory."),
         source: z.enum(["workspace", "user", "plugin", "other"]).optional().describe("Optional source override. Without it, the highest-precedence skill is loaded."),
         path: z.string().optional().describe("Optional exact sanitized path override for diagnostics or an explicitly selected suppressed duplicate."),
@@ -1396,7 +1400,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     "list_workspaces",
     {
       title: "List Workspaces",
-      description: "List workspaces opened in this MCP session and identify the currently selected workspace.",
+      description: "List workspaces registered on this CodexPro server and identify the currently selected workspace for this MCP session.",
       inputSchema: {},
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
@@ -1474,7 +1478,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     {
       title: "Open Workspace",
       description:
-        "Open and select an allowed local project for this MCP session. Later tool calls may omit workspace_id to use this selection.",
+        "Open an allowed local project and return a stable workspace_id. That id stays valid for later tool calls on this server, including other MCP sessions. Also selects the project for this MCP session so later calls may omit workspace_id while the session lasts.",
       inputSchema: {
         root: z.string().optional().describe("Project directory to open. Omit to use CODEXPRO_ROOT/current working directory. Supports ~/ paths."),
         path: z.string().optional().describe("Alias for root. Useful for clients that naturally send path instead of root."),
@@ -1531,7 +1535,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Workspace Snapshot",
       description: "Return git status, recent commits, .ai-bridge context, and a compact tree for an opened workspace.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         max_depth: z.number().int().min(1).max(8).optional().describe("Tree depth. Default: 3."),
         max_files: z.number().int().min(1).max(3000).optional().describe("Alias for maximum tree entries. Default: 500."),
         include_skills: z.boolean().optional().describe("Discover repo-local skills. Default: false for speed."),
@@ -1581,7 +1585,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Inspect Workspace",
       description: "Build a bounded repository map with languages, project types, entrypoints, areas, symbols, relationships, and coverage warnings.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().optional().describe("Optional workspace-relative area to emphasize. Default: entire workspace."),
         max_files: z.number().int().min(1).max(100000).optional().describe("Maximum returned file records. Default: 300."),
         include_symbols: z.boolean().optional().describe("Include symbols in structured output. Default: true."),
@@ -1667,7 +1671,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "File Tree",
       description: "List files and directories inside the workspace, excluding blocked paths.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().optional().describe("Directory relative to workspace root. Default: ."),
         max_depth: z.number().int().min(1).max(12).optional().describe("Maximum depth. Default: 4."),
         include_hidden: z.boolean().optional().describe("Include dotfiles/dotfolders that are not blocked. Default: false."),
@@ -1700,7 +1704,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Search Files",
       description: "Use this for targeted verification or code lookup. Prefer one specific final search instead of repeated broad verification searches.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         query: z.string().describe("Text or regex to search for."),
         regex: z.boolean().optional().describe("Treat query as a regular expression. Requires ripgrep. Default: false."),
         path: z.string().optional().describe("Directory or file relative to workspace root. Default: ."),
@@ -1751,7 +1755,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Read File",
       description: "Read a specific text file with line numbers. Avoid rereading files after write/edit/apply_patch unless exact final content is needed.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().describe("File path relative to workspace root."),
         start_line: z.number().int().min(1).optional().describe("First line to read. Default: 1."),
         end_line: z.number().int().min(1).optional().describe("Last line to read. Default: end of file."),
@@ -1784,7 +1788,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "View Image",
       description: "Inspect a PNG, JPEG, GIF, or WebP image from the active workspace. Returns native MCP image content plus dimensions and SHA-256.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().describe("Image path relative to workspace root."),
         max_bytes: z.number().int().min(4096).max(2000000).optional().describe("Maximum image bytes. Default: at least 1 MB, capped at 2 MB.")
       },
@@ -1824,7 +1828,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Write File",
       description: "Create or overwrite a meaningful text file inside the workspace. New files use an atomic rename; existing files retain their inode and metadata. Returns a unified diff; pass the SHA from read when overwriting shared files.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().describe("File path relative to workspace root."),
         content: z.string().describe("Complete file contents to write."),
         create_dirs: z.boolean().optional().describe("Create parent directories if missing. Default: true."),
@@ -1871,7 +1875,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Edit File",
       description: "Apply a targeted exact text replacement while retaining the existing file inode and metadata. Returns a unified diff; pass the SHA from read to reject stale multi-session edits.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().describe("File path relative to workspace root."),
         old_text: z.string().describe("Exact text to replace. Must match once unless replace_all=true."),
         new_text: z.string().describe("Replacement text."),
@@ -1920,7 +1924,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Apply one unified diff patch inside the workspace. Paths are validated before applying. Prefer edit for tiny replacements and apply_patch for multi-file diffs.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         patch: z.string().describe("Unified diff patch to apply. File paths must stay inside the workspace and avoid blocked paths.")
       },
       annotations: LOCAL_WRITE_ANNOTATIONS,
@@ -1965,7 +1969,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Import a ChatGPT Apps SDK attachment into the workspace. Accepts only a platform file object with download_url and file_id. Not a general URL downloader. Overwrite is off by default.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         file: z
           .object({
             download_url: z.string().describe("Temporary HTTPS download URL provided by ChatGPT."),
@@ -2035,7 +2039,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Run one allowlisted verification command in the workspace, such as tests, build, lint, typecheck, or a project script. Do not use for git status/diff or file inspection; use show_changes, tree, search, and read instead. Do not chain commands with &&, pipes, redirects, or shell file readers.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         command: z.string().describe("Command to run."),
         session_id: z.string().optional().describe(config.requireBashSession && config.bashSessionId ? `Required bash session id for this server: ${config.bashSessionId}.` : "Optional bash session id. If configured on the server, a provided value must match it."),
         cwd: z.string().optional().describe("Working directory relative to workspace root. Default: ."),
@@ -2074,7 +2078,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Git Status",
       description: "Show git branch and changed files for the workspace.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().optional().describe("Optional file path relative to workspace root.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
@@ -2110,7 +2114,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Git Diff",
       description: "Show current unstaged or staged git diff, optionally scoped to a file.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().optional().describe("Optional file path relative to workspace root."),
         staged: z.boolean().optional().describe("Show staged diff. Default: false."),
         include_diff: z.boolean().optional().describe("Include the raw unified diff in the response. Default: true. Set false for stats-only checks.")
@@ -2165,7 +2169,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Show Changes",
       description: "Summarize the current workspace changes in one review-oriented result with git status, diff stats, and optional diff. Use this instead of bash git status, bash git diff, git_status, or git_diff when reviewing work.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         path: z.string().optional().describe("Optional file path relative to workspace root."),
         staged: z.boolean().optional().describe("Show staged diff. Default: false."),
         include_diff: z.boolean().optional().describe("Include the unified diff. Default: true."),
@@ -2282,7 +2286,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       title: "Read Handoff",
       description: "Read the shared .ai-bridge planning files used for ChatGPT-to-agent coordination.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session.")
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session.")
       },
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: {
@@ -2313,7 +2317,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Read-only long-poll of the local handoff run state so ChatGPT can stay the planner/reviewer while a local executor runs. Reads .ai-bridge/handoff-run-state.json and returns the run status plus status/diff/log/test excerpts. It never starts processes or runs shell commands; it only observes local handoff state written by execute-handoff/watch-handoff/loop-handoff.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         plan_hash: z.string().optional().describe("Expected current-plan.md hash. If set, only a terminal run with this plan_hash counts as completed."),
         since_iteration: z.number().int().min(0).optional().describe("Only treat a run with iteration greater than this as the awaited completion."),
         max_wait_seconds: z.number().int().min(1).max(60).optional().describe("Maximum seconds to long-poll before returning the current state. Default: 20."),
@@ -2482,7 +2486,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Load Codex-style workspace context in one call: AGENTS instructions for a target path, .ai-bridge handoff files, and optional git status/diff.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         target_path: z.string().optional().describe("Workspace-relative file or directory whose AGENTS instruction chain should be loaded. Default: ."),
         include_ai_bridge: z.boolean().optional().describe("Include .ai-bridge plan, agent status, diff, decisions, questions, and execution log. Default: true."),
         include_git: z.boolean().optional().describe("Include git status. Default: true."),
@@ -2527,7 +2531,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Create .ai-bridge/pro-context.md with repo tree, git state, selected files, and handoff context for high-context ChatGPT planning without live MCP tool calls.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         title: z.string().optional().describe("Markdown title for the context bundle."),
         selected_paths: z.array(z.string()).optional().describe("Specific workspace-relative files to include."),
         extra_globs: z.array(z.string()).optional().describe("Additional workspace-relative glob patterns to include, for example src/**/*.ts."),
@@ -2678,7 +2682,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       description:
         "Write .ai-bridge/current-plan.md for Codex, OpenCode, Pi, or another local implementation agent. This only creates handoff files; it does not execute local agent commands.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         agent: z.string().optional().describe("Target agent id, for example codex, opencode, pi, or custom. Default: custom."),
         agent_name: z.string().optional().describe("Human-readable agent name for custom agents."),
         model: z.string().optional().describe("Optional model identifier to include in the handoff plan."),
@@ -2745,7 +2749,7 @@ ${result.prompt}
       title: "Handoff To Codex",
       description: "Compatibility wrapper for handoff_to_agent with agent=codex.",
       inputSchema: {
-        workspace_id: z.string().optional().describe("Workspace id from open_workspace. Omit to use the workspace selected for this MCP session."),
+        workspace_id: z.string().optional().describe("Workspace id from open_workspace. An explicit id is resolved from the process registry and does not depend on the current selection. Omit to use the workspace selected for this MCP session."),
         title: z.string().optional().describe("Short task title."),
         plan: z.string().describe("Detailed implementation plan for Codex."),
         append: z.boolean().optional().describe("Append to existing current-plan.md instead of overwriting. Default: false.")


### PR DESCRIPTION
## Summary
- ChatGPT often starts a new HTTP MCP session per tool call. Nested worktrees under an allowed parent got a `workspace_id` from `open_workspace`, then the next tool (`bash`/`read`/…) failed with `Unknown workspace_id`.
- Share a process-wide workspace registry across MCP sessions. Session-local selection stays isolated. Explicit unknown IDs still fail closed and never fall back to the launch workspace.
- Add cross-session HTTP smoke coverage plus a registry unit smoke so this cannot regress to “helpful” default-root fallback.

## Test plan
- [x] `npm run build`
- [x] `node scripts/workspace-registry-smoke.mjs`
- [x] `node scripts/http-smoke.mjs`
- [x] `npm run smoke`
- [x] Disposable HTTP server + independent MCP initialize per tool against a nested allowed worktree
- [x] Live 8788 after LaunchAgent restart: `open_workspace(worktree)` then `bash(workspace_id, git rev-parse --show-toplevel)` on a new session


Made with [Cursor](https://cursor.com)