### PR TITLE
Fix apply_patch in nested workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed `apply_patch` in workspaces that are subdirectories of a parent Git repository by applying workspace-relative patches under the Git prefix and rejecting Git's zero-exit `Skipped patch` result.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -82,6 +82,9 @@ await fs.writeFile(path.join(alternateWorkspace, 'selected.txt'), 'alternate wor
 await fs.writeFile(path.join(tmp, 'demo.txt'), 'alpha\nread\nread\nomega\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'other.txt'), 'keep\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'patch-race.txt'), 'patch race initial\n', 'utf8');
+const nestedWorkspace = path.join(tmp, 'projects', 'nested');
+await fs.mkdir(nestedWorkspace, { recursive: true });
+await fs.writeFile(path.join(nestedWorkspace, 'delete-me.txt'), 'temporary', 'utf8');
 await fs.writeFile(path.join(tmp, 'config.txt'), 'OPENAI_API_KEY=sk-realSecretValue123\n', 'utf8');
 await fs.writeFile(path.join(tmp, 'AGENTS.md'), '# Smoke Agents\n\n- Preserve demo.txt.\n', 'utf8');
 const codexHistoryDir = path.join(tmp, 'codex-history');
@@ -486,6 +489,32 @@ const inventory = await client.request('tools/call', { name: 'codexpro_inventory
 if (inventory.structuredContent.codexpro_tool !== 'codexpro_inventory') throw new Error('inventory result was not tagged for widget rendering');
 const opened = await client.request('tools/call', { name: 'open_workspace', arguments: { root: tmp, include_tree: true } });
 const ws = opened.structuredContent.workspace_id;
+const nestedOpened = await client.request('tools/call', { name: 'open_workspace', arguments: { root: nestedWorkspace, include_tree: false } });
+const nestedPatch = await client.request('tools/call', {
+  name: 'apply_patch',
+  arguments: {
+    workspace_id: nestedOpened.structuredContent.workspace_id,
+    patch: [
+      'diff --git a/delete-me.txt b/delete-me.txt',
+      'deleted file mode 100644',
+      '--- a/delete-me.txt',
+      '+++ /dev/null',
+      '@@ -1 +0,0 @@',
+      '-temporary',
+      '\\ No newline at end of file'
+    ].join('\n') + '\n'
+  }
+});
+if (!nestedPatch.structuredContent.changed) {
+  throw new Error(`apply_patch did not report a nested-workspace deletion: ${JSON.stringify(nestedPatch.structuredContent)}`);
+}
+try {
+  await fs.access(path.join(nestedWorkspace, 'delete-me.txt'));
+  throw new Error('apply_patch reported success but left the nested-workspace file on disk');
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error;
+}
+await client.request('tools/call', { name: 'open_workspace', arguments: { root: tmp, include_tree: false } });
 const viewedImage = await client.request('tools/call', { name: 'view_image', arguments: { workspace_id: ws, path: 'pixel.png' } });
 const imagePart = viewedImage.content?.find?.((part) => part.type === 'image');
 if (!imagePart?.data || imagePart.mimeType !== 'image/png' || viewedImage.structuredContent.width !== 1 || viewedImage.structuredContent.height !== 1) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -638,6 +638,30 @@ function patchTouchedPaths(patch: string): string[] {
   return [...paths];
 }
 
+function gitApplyWorkspaceContext(workspace: Workspace, maxOutputBytes: number): { cwd: string; directoryArgs: string[] } {
+  const options = {
+    cwd: workspace.root,
+    encoding: "utf8" as const,
+    maxBuffer: maxOutputBytes,
+    env: { ...process.env, NO_COLOR: "1" }
+  };
+  const topLevel = spawnSync("git", ["rev-parse", "--show-toplevel"], options);
+  const prefixResult = spawnSync("git", ["rev-parse", "--show-prefix"], options);
+  if (topLevel.error || topLevel.status !== 0 || prefixResult.error || prefixResult.status !== 0) {
+    return { cwd: workspace.root, directoryArgs: [] };
+  }
+  const cwd = topLevel.stdout.trim();
+  const prefix = prefixResult.stdout.trim().replace(/\/+$/, "");
+  if (!cwd || prefix.startsWith("../") || path.posix.isAbsolute(prefix)) {
+    return { cwd: workspace.root, directoryArgs: [] };
+  }
+  return { cwd, directoryArgs: prefix ? [`--directory=${prefix}`] : [] };
+}
+
+function gitApplyWasSkipped(result: ReturnType<typeof spawnSync>): boolean {
+  return /(?:^|[\r\n])Skipped patch ['"]/i.test(`${result.stdout ?? ""}\n${result.stderr ?? ""}`);
+}
+
 async function applyWorkspacePatch(
   config: CodexProConfig,
   guard: PathGuard,
@@ -669,26 +693,33 @@ async function applyWorkspacePatch(
       assertWriteToolAllowed(config, touchedPath);
     }
 
-    const check = spawnSync("git", ["apply", "--check", "--whitespace=nowarn"], {
-      cwd: workspace.root,
+    const gitApply = gitApplyWorkspaceContext(workspace, config.maxOutputBytes);
+    const check = spawnSync("git", ["apply", "--check", "--verbose", "--whitespace=nowarn", ...gitApply.directoryArgs], {
+      cwd: gitApply.cwd,
       input: patch,
       encoding: "utf8",
       maxBuffer: config.maxOutputBytes,
       env: { ...process.env, NO_COLOR: "1" }
     });
-    if (check.error || check.status !== 0) {
-      throw new CodexProError(redactSensitiveText(check.stderr?.trim() || check.stdout?.trim() || check.error?.message || "git apply --check failed"));
+    if (check.error || check.status !== 0 || gitApplyWasSkipped(check)) {
+      throw new CodexProError(
+        redactSensitiveText(
+          check.stderr?.trim() || check.stdout?.trim() || check.error?.message || "git apply --check failed or skipped a workspace path"
+        )
+      );
     }
 
-    const applied = spawnSync("git", ["apply", "--whitespace=nowarn"], {
-      cwd: workspace.root,
+    const applied = spawnSync("git", ["apply", "--verbose", "--whitespace=nowarn", ...gitApply.directoryArgs], {
+      cwd: gitApply.cwd,
       input: patch,
       encoding: "utf8",
       maxBuffer: config.maxOutputBytes,
       env: { ...process.env, NO_COLOR: "1" }
     });
-    if (applied.error || applied.status !== 0) {
-      throw new CodexProError(redactSensitiveText(applied.stderr?.trim() || applied.stdout?.trim() || applied.error?.message || "git apply failed"));
+    if (applied.error || applied.status !== 0 || gitApplyWasSkipped(applied)) {
+      throw new CodexProError(
+        redactSensitiveText(applied.stderr?.trim() || applied.stdout?.trim() || applied.error?.message || "git apply failed or skipped a workspace path")
+      );
     }
 
     const diff = redactSensitiveText(patch.trimEnd());


### PR DESCRIPTION
## Problem
`apply_patch` can report `changed=true` while Git prints `Skipped patch` and leaves the filesystem unchanged when the selected workspace is a subdirectory of a parent Git repository.

## Root cause
`git apply` interprets patch paths from the parent repository root even though CodexPro patches are workspace-relative. The existing code also treated exit code 0 as sufficient proof of application.

## Fix
- Detect the workspace's Git top-level and prefix.
- Apply validated workspace-relative patches with `--directory=<workspace-prefix>` when nested.
- Run `git apply` verbosely and reject any zero-exit `Skipped patch` result.
- Add a regression that opens a nested workspace, deletes a file through `apply_patch`, and verifies the file is physically gone.

## Tests
- `npm run build`
- `node scripts/smoke.mjs`
- `git diff --check`

Fixes #111