### PR TITLE
Fix self-test probe isolation and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Made `codexpro_self_test` Pro-context probing independent of the write probe and restore or remove its temporary `.ai-bridge/codexpro-self-test.md` file after diagnostics.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -451,6 +451,44 @@ if (JSON.stringify([...(selfTest.structuredContent.expected_tools ?? [])].sort()
 if (!selfTest.structuredContent.files_touched?.includes?.('.ai-bridge/codexpro-self-test.md')) {
   throw new Error('codexpro_self_test did not run the .ai-bridge write/edit probe');
 }
+try {
+  await fs.access(path.join(tmp, '.ai-bridge', 'codexpro-self-test.md'));
+  throw new Error('codexpro_self_test left its transient write probe behind');
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error;
+}
+const independentContextSelfTest = await client.request('tools/call', {
+  name: 'codexpro_self_test',
+  arguments: {
+    workspace_id: current.structuredContent.workspace_id,
+    write_probe: false,
+    bash_probe: false,
+    pro_context_probe: true,
+    include_global_skills: false,
+    max_skills: 4
+  }
+});
+const independentContextCheck = independentContextSelfTest.structuredContent.checks?.find?.((item) => item.name === 'selected-only pro context');
+if (independentContextCheck?.status !== 'pass' || /write probe/i.test(independentContextCheck.detail ?? '')) {
+  throw new Error(`codexpro_self_test pro_context_probe still depends on write_probe: ${JSON.stringify(independentContextCheck)}`);
+}
+await fs.mkdir(path.join(tmp, '.ai-bridge'), { recursive: true });
+const preExistingProbePath = path.join(tmp, '.ai-bridge', 'codexpro-self-test.md');
+await fs.writeFile(preExistingProbePath, 'pre-existing self-test content\n', 'utf8');
+await client.request('tools/call', {
+  name: 'codexpro_self_test',
+  arguments: {
+    workspace_id: current.structuredContent.workspace_id,
+    write_probe: true,
+    bash_probe: false,
+    pro_context_probe: false,
+    include_global_skills: false,
+    max_skills: 4
+  }
+});
+if (await fs.readFile(preExistingProbePath, 'utf8') !== 'pre-existing self-test content\n') {
+  throw new Error('codexpro_self_test did not restore a pre-existing probe file');
+}
 const snapshotAlias = await client.request('tools/call', {
   name: 'workspace_snapshot',
   arguments: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1147,12 +1147,35 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         check("git status", "fail", errorText(error));
       }
 
+      let probeWasWritten = false;
+      let probeOriginal: Buffer | undefined;
+      let probeOriginalMode: number | undefined;
+      let probeDirExisted = true;
+      let probeAbsPath: string | undefined;
+
       if (parseBool(args.write_probe, true)) {
         if (config.writeMode === "off") {
           check("write/edit probe", "warn", "skipped because CODEXPRO_WRITE_MODE=off");
         } else {
           try {
             assertWriteToolAllowed(config, probePath);
+            const resolvedProbe = guard.resolve(workspace, probePath, { forWrite: true });
+            probeAbsPath = resolvedProbe.absPath;
+            try {
+              const originalStat = await fsp.stat(probeAbsPath);
+              if (!originalStat.isFile()) throw new CodexProError(`${probePath} exists but is not a regular file.`);
+              probeOriginal = await fsp.readFile(probeAbsPath);
+              probeOriginalMode = originalStat.mode;
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+            }
+            try {
+              await fsp.stat(path.dirname(probeAbsPath));
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+              probeDirExisted = false;
+            }
+
             const content = [
               "# CodexPro Self Test",
               "",
@@ -1162,6 +1185,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
               ""
             ].join("\n");
             await writeTextFile(config, guard, workspace, probePath, content, { createDirs: true, overwrite: true });
+            probeWasWritten = true;
             await editTextFile(config, guard, workspace, probePath, "marker: before", "marker: after", { expectedReplacements: 1 });
             const readBack = await readTextFile(config, guard, workspace, probePath, { maxBytes: 20_000 });
             if (!readBack.text.includes("marker: after")) throw new CodexProError("self-test edit marker was not found after edit.");
@@ -1183,31 +1207,68 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
 
       if (parseBool(args.pro_context_probe, true)) {
         try {
-          if (!filesTouched.includes(probePath)) {
-            check("selected-only pro context", "warn", "skipped because write probe did not create the selected file");
-          } else {
-            const context = await buildProContext(config, guard, workspace, {
-              title: "CodexPro Self Test Context",
-              selectedPaths: [probePath],
-              includeImportantFiles: false,
-              includeChangedFiles: false,
-              includeDiff: false,
-              includeAiBridge: false,
-              maxFiles: 4,
-              maxTotalBytes: 80_000
-            });
-            const exactOnly = context.filesIncluded.length === 1 && context.filesIncluded[0] === probePath;
-            check(
-              "selected-only pro context",
-              exactOnly ? "pass" : "fail",
-              exactOnly ? `included only ${probePath}` : `included ${context.filesIncluded.join(", ") || "no files"}`
-            );
+          let selectedPath = probeWasWritten ? probePath : undefined;
+          if (!selectedPath) {
+            for (const candidate of ["AGENTS.md", "README.md", "package.json", "pyproject.toml", "Cargo.toml", "go.mod"]) {
+              try {
+                await readTextFile(config, guard, workspace, candidate, { maxBytes: 4_000 });
+                selectedPath = candidate;
+                break;
+              } catch {
+                // Keep searching for a small existing text file; an empty selection is still a valid probe.
+              }
+            }
           }
+          const context = await buildProContext(config, guard, workspace, {
+            title: "CodexPro Self Test Context",
+            selectedPaths: selectedPath ? [selectedPath] : [],
+            includeImportantFiles: false,
+            includeChangedFiles: false,
+            includeDiff: false,
+            includeAiBridge: false,
+            maxFiles: 4,
+            maxTotalBytes: 80_000
+          });
+          const exactOnly = selectedPath
+            ? context.filesIncluded.length === 1 && context.filesIncluded[0] === selectedPath
+            : context.filesIncluded.length === 0;
+          check(
+            "selected-only pro context",
+            exactOnly ? "pass" : "fail",
+            exactOnly
+              ? selectedPath
+                ? `included only ${selectedPath}`
+                : "built an empty selected-only context without requiring a write probe"
+              : `included ${context.filesIncluded.join(", ") || "no files"}`
+          );
         } catch (error) {
           check("selected-only pro context", "fail", errorText(error));
         }
       } else {
         check("selected-only pro context", "warn", "skipped by request");
+      }
+
+      if (probeWasWritten && probeAbsPath) {
+        try {
+          if (probeOriginal !== undefined) {
+            await fsp.writeFile(probeAbsPath, probeOriginal);
+            if (probeOriginalMode !== undefined) await fsp.chmod(probeAbsPath, probeOriginalMode);
+            check("write/edit cleanup", "pass", `restored pre-existing ${probePath}`);
+          } else {
+            await fsp.unlink(probeAbsPath);
+            if (!probeDirExisted) {
+              try {
+                await fsp.rmdir(path.dirname(probeAbsPath));
+              } catch (error) {
+                const code = (error as NodeJS.ErrnoException).code;
+                if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error;
+              }
+            }
+            check("write/edit cleanup", "pass", `removed transient ${probePath}`);
+          }
+        } catch (error) {
+          check("write/edit cleanup", "fail", errorText(error));
+        }
       }
 
       if (parseBool(args.bash_probe, true)) {


### PR DESCRIPTION
## Summary
- run the selected-only Pro context probe even when the write probe is disabled
- use a bounded existing workspace file, or an empty selected-only context, instead of depending on the temporary write probe
- restore a pre-existing `.ai-bridge/codexpro-self-test.md` exactly after diagnostics, or remove the transient probe and empty directory when self-test created them
- add smoke coverage for disabled write probing, transient cleanup, and pre-existing probe restoration

Fixes #104
Fixes #105

## Verification
- `npm run build`
- `node scripts/smoke.mjs`
- `git diff --check`