### PR TITLE
Fix token-protected web profile saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed the local web profile editor to reuse the captured CodexPro token as a Bearer credential after browser history cleanup, so Save profile works on token-protected setups.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -421,9 +421,9 @@ try {
     cloudflareTokenFile: path.join(root, 'stale-cloudflare-token')
   }, null, 2), 'utf8');
 
-  const profileSave = await fetch(`${baseUrl}/admin/profile?codexpro_token=${encodeURIComponent(token)}`, {
+  const profileSave = await fetch(`${baseUrl}/admin/profile`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({
       tunnel: 'ngrok',
       hostname: 'https://codexpro-http-smoke.ngrok-free.app/mcp',

--- a/scripts/http-smoke.mjs
+++ b/scripts/http-smoke.mjs
@@ -371,6 +371,9 @@ try {
   if (!homeText.includes('history.replaceState') || !homeText.includes('initialUrl.searchParams.delete("codexpro_token")')) {
     throw new Error('onboarding page did not remove query credentials from browser history');
   }
+  if (!homeText.includes('Authorization: "Bearer " + connectorToken') || homeText.includes('fetch("/admin/profile" + window.location.search')) {
+    throw new Error('onboarding profile save did not reuse the captured token as a Bearer credential');
+  }
   for (const fieldName of ['tunnelName', 'ngrokConfig', 'cloudflareConfig', 'cloudflareTokenFile', 'toolCards', 'noInstallCloudflared']) {
     if (!homeText.includes(`name="${fieldName}"`)) {
       throw new Error(`onboarding page did not include profile field ${fieldName}`);

--- a/src/http.ts
+++ b/src/http.ts
@@ -1415,9 +1415,12 @@ function onboardingPage(config: CodexProConfig): string {
         };
         if (status) status.textContent = "Saving...";
         try {
-          const response = await fetch("/admin/profile" + window.location.search, {
+          const response = await fetch("/admin/profile", {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: {
+              "content-type": "application/json",
+              ...(connectorToken ? { Authorization: "Bearer " + connectorToken } : {})
+            },
             body: JSON.stringify(payload)
           });
           const result = await response.json().catch(() => ({}));


### PR DESCRIPTION
## Problem
The 0.30.0 local web manager captures the CodexPro URL token, removes it from browser history, then POSTs /admin/profile using window.location.search. After cleanup that request is unauthenticated, so Save profile returns 401.

## Root cause
The page kept the token in connectorToken for copy actions but did not reuse it when saving the profile.

## Fix
- POST to /admin/profile directly.
- Reuse the captured token as Authorization: Bearer ...
- Keep removing query credentials from browser history.
- Add smoke coverage that requires the Bearer path and exercises an authenticated profile save without a query token.

## Verification
- npm run build
- node scripts/http-smoke.mjs
- git diff --check
- verified again in the combined local integration branch with the CSRF/security-header fix applied

Fixes #88