### PR TITLE
Fix Windows Bash runtime selection and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- On Windows, Bash now prefers Git for Windows instead of silently launching WSL, and server/self-test diagnostics report the resolved Bash, Git, and search runtimes including Node search fallback. Set `CODEXPRO_BASH_EXECUTABLE` to an absolute Bash path for an explicit override.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/FAQ.md
+++ b/FAQ.md
@@ -218,6 +218,19 @@ Use handoff mode if you want ChatGPT to write a plan only and let Codex execute 
 
 Use `CODEXPRO_WRITE_MODE=off` when you want direct `write` and `edit` tools removed from the advertised MCP tool list while still allowing bounded handoff/context files.
 
+## Which Bash does CodexPro use on Windows?
+
+For Windows-native workspaces, CodexPro prefers Git for Windows Bash when it is installed. It does not silently auto-select `C:\Windows\System32\bash.exe`, because that executable launches WSL and can expose a different Git, Node, npm, path model, and filesystem runtime from the native CodexPro process.
+
+To choose a Bash executable explicitly, set an absolute path before starting CodexPro:
+
+```powershell
+$env:CODEXPRO_BASH_EXECUTABLE = 'C:\Program Files\Git\bin\bash.exe'
+codexpro start
+```
+
+An explicit WSL launcher path is treated as an opt-in rather than an automatic fallback. `server_config` and `codexpro_self_test` report the selected Bash runtime, dedicated Git runtime, shell-visible toolchain, and whether search is using ripgrep or the Node fallback.
+
 ## Can CodexPro bind bash to a specific session id?
 
 CodexPro cannot attach to, read, or execute inside a specific Codex app conversation or terminal session.

--- a/config.example.env
+++ b/config.example.env
@@ -4,6 +4,8 @@ CODEXPRO_ALLOWED_ROOTS=/absolute/path/to/your/repo
 CODEXPRO_HOST=127.0.0.1
 CODEXPRO_PORT=8787
 CODEXPRO_BASH_MODE=safe
+# Optional exact Bash path. On Windows, auto mode prefers Git for Windows and does not silently select the WSL launcher.
+# CODEXPRO_BASH_EXECUTABLE=C:\Program Files\Git\bin\bash.exe
 # Optional hard cap for bash tool timeout_ms. Default 600000 (10m), max 900000 (15m).
 # CODEXPRO_MAX_BASH_TIMEOUT_MS=600000
 # Max bytes for import_file ChatGPT attachment downloads. Default 5000000.

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -239,6 +239,19 @@ const toolNames = tools.tools.map((tool) => tool.name);
 for (const expected of ['server_config', 'codexpro_self_test', 'codexpro_inventory', 'list_workspaces', 'open_current_workspace', 'open_workspace', 'workspace_snapshot', 'inspect_workspace', 'tree', 'search', 'load_skill', 'read', 'view_image', 'write', 'edit', 'apply_patch', 'import_file', 'bash', 'git_status', 'git_diff', 'show_changes', 'read_handoff', 'wait_for_handoff', 'codex_context', 'handoff_to_agent', 'handoff_to_codex', 'export_pro_context']) {
   if (!toolNames.includes(expected)) throw new Error(`missing tool: ${expected}`);
 }
+const diagnosticConfig = await client.request('tools/call', { name: 'server_config', arguments: {} });
+if (!diagnosticConfig.structuredContent.bashRuntime?.runtime || !diagnosticConfig.structuredContent.bashRuntime?.executable) {
+  throw new Error(`server_config omitted bash runtime diagnostics: ${JSON.stringify(diagnosticConfig.structuredContent)}`);
+}
+if (!diagnosticConfig.structuredContent.gitRuntime?.version) {
+  throw new Error(`server_config omitted dedicated Git diagnostics: ${JSON.stringify(diagnosticConfig.structuredContent)}`);
+}
+if (!diagnosticConfig.structuredContent.searchBackend?.backend) {
+  throw new Error(`server_config omitted search backend diagnostics: ${JSON.stringify(diagnosticConfig.structuredContent)}`);
+}
+if (process.platform === 'win32' && diagnosticConfig.structuredContent.bashRuntime.runtime === 'wsl' && diagnosticConfig.structuredContent.bashRuntime.source !== 'configured') {
+  throw new Error(`server_config silently auto-selected WSL: ${JSON.stringify(diagnosticConfig.structuredContent.bashRuntime)}`);
+}
 const toolCardUri = 'ui://widget/codexpro-tool-card-v10.html';
 const toolsByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
 function hasWidgetMeta(name) {
@@ -450,6 +463,14 @@ if (JSON.stringify([...(selfTest.structuredContent.expected_tools ?? [])].sort()
 }
 if (!selfTest.structuredContent.files_touched?.includes?.('.ai-bridge/codexpro-self-test.md')) {
   throw new Error('codexpro_self_test did not run the .ai-bridge write/edit probe');
+}
+for (const diagnosticCheck of ['bash runtime', 'git runtime', 'search backend']) {
+  if (!selfTest.structuredContent.checks?.some?.((item) => item.name === diagnosticCheck)) {
+    throw new Error(`codexpro_self_test omitted ${diagnosticCheck} diagnostics: ${JSON.stringify(selfTest.structuredContent.checks)}`);
+  }
+}
+if (!selfTest.structuredContent.bash_runtime?.runtime || !selfTest.structuredContent.git_runtime?.version || !selfTest.structuredContent.search_backend?.backend) {
+  throw new Error(`codexpro_self_test omitted structured runtime diagnostics: ${JSON.stringify(selfTest.structuredContent)}`);
 }
 const snapshotAlias = await client.request('tools/call', {
   name: 'workspace_snapshot',

--- a/src/bashOps.ts
+++ b/src/bashOps.ts
@@ -7,6 +7,27 @@ import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
 import { redactSensitiveText } from "./redact.js";
 
+export type BashRuntimeKind = "native-bash" | "wsl" | "unix-bash" | "unavailable";
+
+export interface BashRuntimeInfo {
+  available: boolean;
+  executable: string | null;
+  runtime: BashRuntimeKind;
+  source: "configured" | "git-for-windows" | "path" | "system" | "unavailable";
+  error?: string;
+}
+
+export interface BashToolInfo {
+  path: string | null;
+  version: string | null;
+}
+
+export interface BashToolchainInfo {
+  runtime: BashRuntimeInfo;
+  cwd: string | null;
+  tools: Record<"node" | "npm" | "npx" | "git" | "rg", BashToolInfo>;
+}
+
 export interface BashResult {
   command: string;
   cwd: string;
@@ -16,6 +37,9 @@ export interface BashResult {
   stdout: string;
   stderr: string;
   truncated: boolean;
+  bashExecutable: string;
+  bashRuntime: BashRuntimeKind;
+  bashRuntimeSource: BashRuntimeInfo["source"];
   bashSessionId?: string;
 }
 
@@ -235,8 +259,130 @@ function makeEnv(config: CodexProConfig): NodeJS.ProcessEnv {
   return makeRestrictedBashEnv(config);
 }
 
-function bashExecutable(): string {
-  return fs.existsSync("/bin/bash") ? "/bin/bash" : "bash";
+function usableExecutableFile(candidate: string | undefined): string | undefined {
+  if (!candidate) return undefined;
+  try {
+    const resolved = path.resolve(candidate);
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) return undefined;
+    return fs.realpathSync.native(resolved);
+  } catch {
+    return undefined;
+  }
+}
+
+function commandPaths(command: string): string[] {
+  const lookup = process.platform === "win32"
+    ? spawnSync("where.exe", [command], { encoding: "utf8", windowsHide: true })
+    : spawnSync("/bin/sh", ["-lc", `command -v ${command}`], { encoding: "utf8" });
+  if (lookup.error || lookup.status !== 0) return [];
+  return String(lookup.stdout ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isWindowsWslLauncher(executable: string, env: NodeJS.ProcessEnv): boolean {
+  const normalized = path.win32.normalize(executable).toLowerCase();
+  const systemRoot = path.win32.normalize(env.SystemRoot || env.WINDIR || "C:\\Windows").toLowerCase();
+  return (
+    normalized === path.win32.join(systemRoot, "System32", "bash.exe").toLowerCase() ||
+    normalized === path.win32.join(systemRoot, "Sysnative", "bash.exe").toLowerCase() ||
+    normalized.includes("\\windowsapps\\bash.exe")
+  );
+}
+
+function gitForWindowsBashCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = [];
+  for (const gitPath of commandPaths("git")) {
+    const parent = path.win32.dirname(gitPath);
+    const parentName = path.win32.basename(parent).toLowerCase();
+    if (parentName === "cmd" || parentName === "bin") {
+      candidates.push(path.win32.join(path.win32.dirname(parent), "bin", "bash.exe"));
+    }
+  }
+  for (const base of [env.ProgramW6432, env.ProgramFiles, env["ProgramFiles(x86)"]]) {
+    if (base) candidates.push(path.win32.join(base, "Git", "bin", "bash.exe"));
+  }
+  return [...new Set(candidates)];
+}
+
+export function resolveBashRuntime(config: CodexProConfig, env: NodeJS.ProcessEnv = process.env): BashRuntimeInfo {
+  if (config.bashExecutable) {
+    const executable = usableExecutableFile(config.bashExecutable);
+    if (!executable) {
+      return {
+        available: false,
+        executable: null,
+        runtime: "unavailable",
+        source: "configured",
+        error: `Configured Bash executable is unavailable: ${config.bashExecutable}`
+      };
+    }
+    return {
+      available: true,
+      executable,
+      runtime: process.platform === "win32" && isWindowsWslLauncher(executable, env) ? "wsl" : process.platform === "win32" ? "native-bash" : "unix-bash",
+      source: "configured"
+    };
+  }
+
+  if (process.platform === "win32") {
+    for (const candidate of gitForWindowsBashCandidates(env)) {
+      const executable = usableExecutableFile(candidate);
+      if (executable) return { available: true, executable, runtime: "native-bash", source: "git-for-windows" };
+    }
+    for (const candidate of commandPaths("bash")) {
+      const executable = usableExecutableFile(candidate);
+      if (!executable || isWindowsWslLauncher(executable, env)) continue;
+      return { available: true, executable, runtime: "native-bash", source: "path" };
+    }
+    const wslLauncher = commandPaths("bash")
+      .map((candidate) => usableExecutableFile(candidate))
+      .find((candidate): candidate is string => Boolean(candidate && isWindowsWslLauncher(candidate, env)));
+    return {
+      available: false,
+      executable: null,
+      runtime: "unavailable",
+      source: "unavailable",
+      error: wslLauncher
+        ? "Only the Windows WSL bash launcher was found. CodexPro does not auto-select WSL for a Windows-native workspace; install Git for Windows or set CODEXPRO_BASH_EXECUTABLE explicitly to opt in."
+        : "No Bash executable was found. Install Git for Windows or set CODEXPRO_BASH_EXECUTABLE to an absolute Bash path."
+    };
+  }
+
+  const systemBash = usableExecutableFile("/bin/bash");
+  if (systemBash) return { available: true, executable: systemBash, runtime: "unix-bash", source: "system" };
+  const pathBash = commandPaths("bash").map((candidate) => usableExecutableFile(candidate)).find(Boolean);
+  if (pathBash) return { available: true, executable: pathBash, runtime: "unix-bash", source: "path" };
+  return { available: false, executable: null, runtime: "unavailable", source: "unavailable", error: "No Bash executable was found." };
+}
+
+function probeThroughBash(runtime: BashRuntimeInfo, cwd: string, env: NodeJS.ProcessEnv, command: string): string | null {
+  if (!runtime.available || !runtime.executable) return null;
+  const result = spawnSync(runtime.executable, ["-lc", command], {
+    cwd,
+    env,
+    encoding: "utf8",
+    timeout: 2_000,
+    maxBuffer: 32_000,
+    windowsHide: true
+  });
+  if (result.error || result.status !== 0) return null;
+  return String(result.stdout ?? "").split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? null;
+}
+
+export function probeBashToolchain(config: CodexProConfig, workspace: Workspace): BashToolchainInfo {
+  const runtime = resolveBashRuntime(config);
+  const env = makeEnv(config);
+  const tools = {} as BashToolchainInfo["tools"];
+  const cwd = probeThroughBash(runtime, workspace.root, env, "pwd");
+  for (const tool of ["node", "npm", "npx", "git", "rg"] as const) {
+    tools[tool] = {
+      path: probeThroughBash(runtime, workspace.root, env, `command -v ${tool}`),
+      version: probeThroughBash(runtime, workspace.root, env, `${tool} --version`)
+    };
+  }
+  return { runtime, cwd, tools };
 }
 
 function trimOutput(value: string, maxBytes: number): { value: string; truncated: boolean } {
@@ -278,9 +424,14 @@ export async function runBash(
   const cwd = cwdResolved.absPath;
   const timeoutMs = Math.max(1_000, Math.min(options.timeoutMs ?? 30_000, config.maxBashTimeoutMs));
   const start = Date.now();
+  const bashRuntime = resolveBashRuntime(config);
+  if (!bashRuntime.available || !bashRuntime.executable) {
+    throw new CodexProError(bashRuntime.error || "Bash is unavailable.");
+  }
+  const bashExecutable = bashRuntime.executable;
 
   return new Promise((resolve, reject) => {
-    const child = spawn(bashExecutable(), ["-lc", command], {
+    const child = spawn(bashExecutable, ["-lc", command], {
       cwd,
       env: makeEnv(config),
       stdio: ["ignore", "pipe", "pipe"],
@@ -349,6 +500,9 @@ export async function runBash(
         stdout: out.value,
         stderr: err.value,
         truncated: out.truncated || err.truncated,
+        bashExecutable,
+        bashRuntime: bashRuntime.runtime,
+        bashRuntimeSource: bashRuntime.source,
         ...(bashSessionId ? { bashSessionId } : {})
       });
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface CodexProConfig {
   authToken?: string;
   requireHttpToken: boolean;
   bashMode: BashMode;
+  bashExecutable?: string;
   bashTranscript: BashTranscriptMode;
   bashSessionId?: string;
   requireBashSession: boolean;
@@ -157,6 +158,20 @@ function numberFrom(value: string | undefined, fallback: number, min: number, ma
 function bashModeFrom(value: string | undefined): BashMode {
   if (value === "off" || value === "safe" || value === "full") return value;
   return "safe";
+}
+
+function bashExecutableFrom(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+  const expanded = expandHome(raw);
+  if (!path.isAbsolute(expanded) && !path.win32.isAbsolute(expanded)) {
+    throw new Error("CODEXPRO_BASH_EXECUTABLE must be an absolute path to a Bash executable.");
+  }
+  const resolved = path.resolve(expanded);
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+    throw new Error(`CODEXPRO_BASH_EXECUTABLE does not point to a file: ${resolved}`);
+  }
+  return fs.realpathSync.native(resolved);
 }
 
 function bashTranscriptFrom(value: string | undefined): BashTranscriptMode {
@@ -314,6 +329,7 @@ export function loadConfig(argv = process.argv.slice(2)): CodexProConfig {
     authToken,
     requireHttpToken,
     bashMode: bashModeFrom(bashArg ?? process.env.CODEXPRO_BASH_MODE),
+    bashExecutable: bashExecutableFrom(process.env.CODEXPRO_BASH_EXECUTABLE),
     bashTranscript: bashTranscriptFrom(bashTranscriptArg ?? process.env.CODEXPRO_BASH_TRANSCRIPT),
     bashSessionId,
     requireBashSession,

--- a/src/gitOps.ts
+++ b/src/gitOps.ts
@@ -4,6 +4,41 @@ import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
 import { redactSensitiveText } from "./redact.js";
 
+export interface GitRuntimeInfo {
+  available: boolean;
+  executable: string | null;
+  version: string | null;
+  error?: string;
+}
+
+function resolveGitExecutable(): string | null {
+  const lookup = process.platform === "win32"
+    ? spawnSync("where.exe", ["git"], { encoding: "utf8", windowsHide: true })
+    : spawnSync("/bin/sh", ["-lc", "command -v git"], { encoding: "utf8" });
+  if (lookup.error || lookup.status !== 0) return null;
+  return String(lookup.stdout ?? "").split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? null;
+}
+
+export function gitRuntimeInfo(): GitRuntimeInfo {
+  const executable = resolveGitExecutable();
+  const versionResult = executable
+    ? spawnSync(executable, ["--version"], { encoding: "utf8", windowsHide: true })
+    : spawnSync("git", ["--version"], { encoding: "utf8", windowsHide: true });
+  if (versionResult.error || versionResult.status !== 0) {
+    return {
+      available: false,
+      executable,
+      version: null,
+      error: versionResult.error?.message || String(versionResult.stderr ?? "").trim() || `git exited with status ${versionResult.status}`
+    };
+  }
+  return {
+    available: true,
+    executable,
+    version: String(versionResult.stdout ?? "").trim() || null
+  };
+}
+
 function runGit(workspace: Workspace, args: string[], maxOutputBytes: number): string {
   const result = spawnSync("git", args, {
     cwd: workspace.root,

--- a/src/searchOps.ts
+++ b/src/searchOps.ts
@@ -1,6 +1,6 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
@@ -26,6 +26,46 @@ export interface SearchResult {
   truncated: boolean;
   used: "ripgrep" | "node";
   analysis?: StructuredSearchResult;
+}
+
+export interface SearchBackendInfo {
+  backend: "ripgrep" | "node";
+  ripgrepAvailable: boolean;
+  ripgrepPath: string | null;
+  ripgrepVersion: string | null;
+  reason: string;
+}
+
+function commandPath(command: string): string | null {
+  const lookup = process.platform === "win32"
+    ? spawnSync("where.exe", [command], { encoding: "utf8", windowsHide: true })
+    : spawnSync("/bin/sh", ["-lc", `command -v ${command}`], { encoding: "utf8" });
+  if (lookup.error || lookup.status !== 0) return null;
+  return String(lookup.stdout ?? "").split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? null;
+}
+
+export function searchBackendInfo(): SearchBackendInfo {
+  const ripgrepPath = commandPath("rg");
+  if (!ripgrepPath) {
+    return {
+      backend: "node",
+      ripgrepAvailable: false,
+      ripgrepPath: null,
+      ripgrepVersion: null,
+      reason: "ripgrep unavailable; literal search uses the Node fallback"
+    };
+  }
+  const versionResult = spawnSync(ripgrepPath, ["--version"], { encoding: "utf8", windowsHide: true });
+  const ripgrepVersion = versionResult.error || versionResult.status !== 0
+    ? null
+    : String(versionResult.stdout ?? "").split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? null;
+  return {
+    backend: "ripgrep",
+    ripgrepAvailable: true,
+    ripgrepPath,
+    ripgrepVersion,
+    reason: "ripgrep available"
+  };
 }
 
 function commandExists(command: string): Promise<boolean> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,9 +9,9 @@ import { WorkspaceManager, PathGuard, CodexProError, type Workspace } from "./gu
 import { repoTree, readTextFile, writeTextFile, editTextFile, ensureAiBridge, withFileWriteLocks } from "./fsOps.js";
 import { viewWorkspaceImage } from "./imageOps.js";
 import { importAttachmentFile } from "./importOps.js";
-import { searchWorkspace } from "./searchOps.js";
-import { runBash } from "./bashOps.js";
-import { gitDiff, gitDiffStatus, gitLog, gitStatus } from "./gitOps.js";
+import { searchWorkspace, searchBackendInfo } from "./searchOps.js";
+import { probeBashToolchain, resolveBashRuntime, runBash } from "./bashOps.js";
+import { gitDiff, gitDiffStatus, gitLog, gitRuntimeInfo, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./workspaceOps.js";
 import { buildProContext, exportProContext } from "./proContext.js";
 import { codexproInventory, loadSkill } from "./capabilitiesOps.js";
@@ -1034,6 +1034,9 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       }
     },
     async () => {
+      const bashRuntime = resolveBashRuntime(config);
+      const gitRuntime = gitRuntimeInfo();
+      const searchBackend = searchBackendInfo();
       const safeConfig = {
         defaultRoot: config.defaultRoot,
         allowedRoots: config.allowedRoots,
@@ -1042,6 +1045,9 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         widgetDomain: config.widgetDomain,
         authEnabled: Boolean(config.authToken),
         bashMode: config.bashMode,
+        bashRuntime,
+        gitRuntime,
+        searchBackend,
         bashTranscript: config.bashTranscript,
         bashSessionId: config.bashSessionId ?? null,
         requireBashSession: config.requireBashSession,
@@ -1059,6 +1065,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         maxWriteBytes: config.maxWriteBytes,
         maxImportBytes: config.maxImportBytes,
         maxOutputBytes: config.maxOutputBytes,
+        maxBashTimeoutMs: config.maxBashTimeoutMs,
         maxSearchResults: config.maxSearchResults,
         blockedGlobs: config.blockedGlobs,
         registeredTools: registeredToolNames(server),
@@ -1097,6 +1104,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       const checks: Array<{ name: string; status: "pass" | "warn" | "fail"; detail: string }> = [];
       const filesTouched: string[] = [];
       const probePath = `${config.contextDir}/codexpro-self-test.md`;
+      const bashRuntime = resolveBashRuntime(config);
+      const gitRuntime = gitRuntimeInfo();
+      const searchBackend = searchBackendInfo();
+      let bashToolchain: ReturnType<typeof probeBashToolchain> | undefined;
 
       const check = (name: string, status: "pass" | "warn" | "fail", detail: string) => {
         checks.push({ name, status, detail: cleanOneLine(detail, detail, 260) });
@@ -1106,6 +1117,31 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
       check("tool mode", config.toolMode === "full" ? "pass" : "warn", `${config.toolMode}; expected tools: ${toolNamesForMode(config).length}`);
       check("write mode", config.writeMode === "off" ? "warn" : "pass", config.writeMode);
       check("bash mode", config.bashMode === "full" ? "warn" : "pass", config.bashMode);
+      check(
+        "bash runtime",
+        config.bashMode !== "off" && !bashRuntime.available
+          ? "fail"
+          : bashRuntime.runtime === "wsl"
+            ? "warn"
+            : "pass",
+        bashRuntime.available
+          ? `${bashRuntime.runtime} via ${bashRuntime.source}: ${bashRuntime.executable}`
+          : bashRuntime.error || "bash unavailable"
+      );
+      check(
+        "git runtime",
+        gitRuntime.available ? "pass" : "warn",
+        gitRuntime.available
+          ? `${gitRuntime.version || "unknown version"} via ${gitRuntime.executable || "PATH"}`
+          : gitRuntime.error || "git unavailable"
+      );
+      check(
+        "search backend",
+        searchBackend.backend === "ripgrep" ? "pass" : "warn",
+        searchBackend.backend === "ripgrep"
+          ? `${searchBackend.ripgrepVersion || "ripgrep"} via ${searchBackend.ripgrepPath || "PATH"}`
+          : searchBackend.reason
+      );
       check(
         "http auth",
         "pass",
@@ -1215,6 +1251,28 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
           if (config.bashMode === "off") {
             check("bash policy", "warn", "bash disabled");
           } else {
+            bashToolchain = probeBashToolchain(config, workspace);
+            const toolSummary = (["node", "npm", "npx", "git", "rg"] as const)
+              .map((name) => {
+                const tool = bashToolchain?.tools[name];
+                return `${name}=${tool?.version || tool?.path || "unavailable"}`;
+              })
+              .join("; ");
+            const inconsistentNodeToolchain = !bashToolchain.tools.node.path && Boolean(bashToolchain.tools.npm.path || bashToolchain.tools.npx.path);
+            check(
+              "bash toolchain",
+              inconsistentNodeToolchain ? "warn" : "pass",
+              `${bashToolchain.cwd || "cwd unavailable"}; ${toolSummary}`
+            );
+            const shellGit = bashToolchain.tools.git;
+            if (gitRuntime.available) {
+              const aligned = Boolean(shellGit.version && gitRuntime.version && shellGit.version === gitRuntime.version);
+              check(
+                "git toolchain alignment",
+                aligned ? "pass" : "warn",
+                `dedicated=${gitRuntime.version || "unavailable"} (${gitRuntime.executable || "PATH"}); shell=${shellGit.version || "unavailable"} (${shellGit.path || "unavailable"})`
+              );
+            }
             const bashProbeOptions = { timeoutMs: 10_000, sessionId: config.bashSessionId };
             const pwd = await runBash(config, guard, workspace, "pwd", bashProbeOptions);
             if (config.bashMode === "safe") {
@@ -1277,6 +1335,10 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         registered_tools: actualTools,
         registered_tool_count: actualTools.length,
         bash_mode: config.bashMode,
+        bash_runtime: bashRuntime,
+        bash_toolchain: bashToolchain ?? null,
+        git_runtime: gitRuntime,
+        search_backend: searchBackend,
         bash_session_id: config.bashSessionId ?? null,
         require_bash_session: config.requireBashSession,
         write_mode: config.writeMode,


### PR DESCRIPTION
## Summary
- prefer Git for Windows Bash for Windows-native workspaces instead of silently launching the WSL `bash.exe` shim
- add `CODEXPRO_BASH_EXECUTABLE` as an explicit absolute-path override, including explicit WSL opt-in
- expose resolved Bash, dedicated Git, shell toolchain, and search backend diagnostics in `server_config` / `codexpro_self_test`
- warn when search falls back to the Node scanner because ripgrep is unavailable
- report shell/dedicated Git divergence before it causes inconsistent repository behavior

Fixes #98
Fixes #99
Fixes #100
Fixes #106

## Windows verification
Before this fix, `where bash` resolved `C:\Windows\System32\bash.exe` first while dedicated Git resolved `C:\Program Files\Git\cmd\git.exe`.

After the fix on the same machine:
- auto Bash: `C:\Program Files\Git\bin\bash.exe` (`native-bash`, `git-for-windows`)
- shell Git: `git version 2.51.0.windows.1`
- dedicated Git: `git version 2.51.0.windows.1`
- Node/npm/npx are visible inside the selected Bash runtime
- missing native `rg` is reported as `backend=node` with an explicit fallback reason
- explicitly configuring `C:\Windows\System32\bash.exe` is classified as `wsl` with source `configured`

## Verification
- `npm run build`
- `node scripts/smoke.mjs`
- direct Bash runtime/toolchain probes on Windows
- `git diff --check`