### PR TITLE
Fix path-scoped Git in nested repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Path-scoped Git tools now resolve a nested repository beneath a wider non-Git workspace root before running status/diff operations.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1657,6 +1657,33 @@ if (!/not a git repository|git unavailable|fatal:/i.test(nonGitPayload)) {
 }
 nonGitClient.close();
 
+const wideRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-wide-root-'));
+const nestedRepo = path.join(wideRoot, 'project-b');
+await fs.mkdir(path.join(nestedRepo, 'src'), { recursive: true });
+await fs.writeFile(path.join(nestedRepo, 'src', 'file.cpp'), 'int value = 1;\n', 'utf8');
+for (const args of [['init'], ['add', 'src/file.cpp']]) {
+  const result = spawnSync('git', args, { cwd: nestedRepo, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`nested git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+}
+const nestedCommit = spawnSync('git', ['-c', 'user.email=smoke@example.com', '-c', 'user.name=Smoke Test', 'commit', '-m', 'nested fixture'], { cwd: nestedRepo, encoding: 'utf8' });
+if (nestedCommit.status !== 0) throw new Error(`nested git commit failed: ${nestedCommit.stderr || nestedCommit.stdout}`);
+await fs.writeFile(path.join(nestedRepo, 'src', 'file.cpp'), 'int value = 2;\n', 'utf8');
+const wideClient = new McpStdioClient('node', ['dist/stdio.js', '--root', wideRoot, '--allow-root', wideRoot, '--tool-mode', 'full'], {
+  cwd: path.resolve('.'),
+  env: { ...process.env, CODEXPRO_ROOT: wideRoot, CODEXPRO_ALLOWED_ROOTS: wideRoot }
+});
+await wideClient.request('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'codexpro-wide-root-smoke', version: '0.1.0' } });
+wideClient.notify('notifications/initialized');
+const nestedStatus = await wideClient.request('tools/call', { name: 'git_status', arguments: { path: 'project-b/src/file.cpp' } });
+if (nestedStatus.isError || !JSON.stringify(nestedStatus).includes('src/file.cpp')) {
+  throw new Error(`path-scoped git_status did not resolve the nested repository: ${JSON.stringify(nestedStatus)}`);
+}
+const nestedDiff = await wideClient.request('tools/call', { name: 'git_diff', arguments: { path: 'project-b/src/file.cpp' } });
+if (nestedDiff.isError || !JSON.stringify(nestedDiff).includes('int value = 2;')) {
+  throw new Error(`path-scoped git_diff did not resolve the nested repository: ${JSON.stringify(nestedDiff)}`);
+}
+wideClient.close();
+
 const lowerAgentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-lower-agents-'));
 await fs.writeFile(path.join(lowerAgentsRoot, 'agents.md'), '# Lowercase agents\n\n- Lowercase instruction file loaded.\n', 'utf8');
 await fs.mkdir(path.join(lowerAgentsRoot, 'src'));

--- a/src/gitOps.ts
+++ b/src/gitOps.ts
@@ -1,12 +1,14 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import type { CodexProConfig } from "./config.js";
 import type { Workspace } from "./guard.js";
 import { CodexProError, PathGuard } from "./guard.js";
 import { redactSensitiveText } from "./redact.js";
 
-function runGit(workspace: Workspace, args: string[], maxOutputBytes: number): string {
+function runGit(cwd: string, args: string[], maxOutputBytes: number): string {
   const result = spawnSync("git", args, {
-    cwd: workspace.root,
+    cwd,
     encoding: "utf8",
     maxBuffer: maxOutputBytes,
     env: { ...process.env, NO_COLOR: "1" }
@@ -38,38 +40,75 @@ function outputLines(output: string): string[] {
   return output.trim() === "(no output)" ? [] : output.split("\n").map((line) => line.trim()).filter(Boolean);
 }
 
+function pathIsInside(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
+function pathScopedGitContext(workspace: Workspace, guard: PathGuard, filePath: string): { cwd: string; relPath: string } {
+  const resolved = guard.resolve(workspace, filePath);
+  let start = resolved.absPath;
+  try {
+    if (!fs.statSync(start).isDirectory()) start = path.dirname(start);
+  } catch {
+    start = path.dirname(start);
+  }
+  const topLevel = spawnSync("git", ["-C", start, "rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    maxBuffer: 64_000,
+    env: { ...process.env, NO_COLOR: "1" }
+  });
+  if (!topLevel.error && topLevel.status === 0) {
+    const rawRoot = String(topLevel.stdout ?? "").trim();
+    if (rawRoot) {
+      let repoRoot = path.resolve(rawRoot);
+      try { repoRoot = fs.realpathSync.native(repoRoot); } catch {}
+      if (pathIsInside(workspace.root, repoRoot)) {
+        return { cwd: repoRoot, relPath: path.relative(repoRoot, resolved.absPath).split(path.sep).join("/") || "." };
+      }
+    }
+  }
+  return { cwd: workspace.root, relPath: resolved.relPath };
+}
+
 export function gitStatus(config: CodexProConfig, workspace: Workspace, guard?: PathGuard, filePath?: string, staged = false): string {
   const args = staged ? ["diff", "--cached", "--name-status"] : ["status", "--short", "--branch"];
+  let cwd = workspace.root;
   if (filePath?.trim()) {
     if (!guard) return "path-scoped git status requires a path guard";
-    const resolved = guard.resolve(workspace, filePath);
-    args.push("--", resolved.relPath);
+    const context = pathScopedGitContext(workspace, guard, filePath);
+    cwd = context.cwd;
+    args.push("--", context.relPath);
   }
-  return runGit(workspace, args, config.maxOutputBytes);
+  return runGit(cwd, args, config.maxOutputBytes);
 }
 
 export function gitDiff(config: CodexProConfig, guard: PathGuard, workspace: Workspace, filePath?: string, staged = false): string {
   const args = ["diff", "--no-color", "--no-ext-diff", "--no-textconv"];
   if (staged) args.push("--staged");
+  let cwd = workspace.root;
   if (filePath?.trim()) {
-    const resolved = guard.resolve(workspace, filePath);
-    args.push("--", resolved.relPath);
+    const context = pathScopedGitContext(workspace, guard, filePath);
+    cwd = context.cwd;
+    args.push("--", context.relPath);
   }
-  return runGit(workspace, args, config.maxOutputBytes);
+  return runGit(cwd, args, config.maxOutputBytes);
 }
 
 export function gitDiffStatus(config: CodexProConfig, guard: PathGuard, workspace: Workspace, filePath?: string, staged = false): string {
   const args = ["diff", "--name-status"];
   if (staged) args.push("--staged");
   const untrackedArgs = ["ls-files", "--others", "--exclude-standard"];
+  let cwd = workspace.root;
   if (filePath?.trim()) {
-    const resolved = guard.resolve(workspace, filePath);
-    args.push("--", resolved.relPath);
-    untrackedArgs.push("--", resolved.relPath);
+    const context = pathScopedGitContext(workspace, guard, filePath);
+    cwd = context.cwd;
+    args.push("--", context.relPath);
+    untrackedArgs.push("--", context.relPath);
   }
-  const diffStatus = runGit(workspace, args, config.maxOutputBytes);
+  const diffStatus = runGit(cwd, args, config.maxOutputBytes);
   if (staged || isGitFailure(diffStatus)) return diffStatus;
-  const untracked = runGit(workspace, untrackedArgs, config.maxOutputBytes);
+  const untracked = runGit(cwd, untrackedArgs, config.maxOutputBytes);
   if (isGitFailure(untracked)) return diffStatus;
   const lines = [...outputLines(diffStatus), ...outputLines(untracked).map((line) => `?? ${line}`)];
   return lines.length ? lines.join("\n") : "(no output)";
@@ -77,7 +116,7 @@ export function gitDiffStatus(config: CodexProConfig, guard: PathGuard, workspac
 
 export function gitLog(config: CodexProConfig, workspace: Workspace, maxCount = 8): string {
   const count = Math.max(1, Math.min(Math.floor(maxCount), 30));
-  return runGit(workspace, ["log", `--max-count=${count}`, "--oneline", "--decorate"], config.maxOutputBytes);
+  return runGit(workspace.root, ["log", `--max-count=${count}`, "--oneline", "--decorate"], config.maxOutputBytes);
 }
 
 export function assertGitCleanEnoughForWrite(_workspace: Workspace): void {


### PR DESCRIPTION
## Summary
- resolve the nearest Git top-level for path-scoped Git operations when it is inside the allowed workspace
- keep existing behavior for unscoped Git calls and workspaces nested inside a parent repository outside the allowed root
- add a wide non-Git root + nested repo smoke regression

Fixes the nested-Git portion of #91.

## Verification
- npm run build
- node scripts/smoke.mjs
- git diff --check