### PR TITLE
fix: avoid buffering full diff for stats-only git_diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Avoid materializing the full unified diff when `git_diff(include_diff=false)` requests stats only, preventing large diffs from exhausting the Git child-process output buffer while preserving additions/deletions and error diagnostics.
+
 ## 0.30.0 (2026-08-08)
 
 - Published the multi-project allowlist that was already on `main`: `codexpro settings set --project`, `--clear-projects`, session-local `open_workspace` selection, and matching FAQ guidance. npm `0.29.0` did not include those commits, which caused empty Allowed Roots reports after following current docs.

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1657,6 +1657,51 @@ if (!/not a git repository|git unavailable|fatal:/i.test(nonGitPayload)) {
 }
 nonGitClient.close();
 
+const largeDiffRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-large-diff-'));
+for (const args of [
+  ['init'],
+  ['config', 'user.email', 'codexpro-smoke@example.com'],
+  ['config', 'user.name', 'CodexPro Smoke']
+]) {
+  const result = spawnSync('git', args, { cwd: largeDiffRoot, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`large-diff git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+}
+const largeDiffPath = path.join(largeDiffRoot, 'large.txt');
+const largeDiffLines = 600;
+await fs.writeFile(largeDiffPath, Array.from({ length: largeDiffLines }, (_, i) => `before-${i}`).join('\n') + '\n', 'utf8');
+for (const args of [['add', 'large.txt'], ['commit', '-m', 'baseline']]) {
+  const result = spawnSync('git', args, { cwd: largeDiffRoot, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`large-diff git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+}
+await fs.writeFile(
+  largeDiffPath,
+  Array.from({ length: largeDiffLines }, (_, i) => `after-${i}-${'x'.repeat(32)}`).join('\n') + '\n',
+  'utf8'
+);
+const largeDiffClient = new McpStdioClient('node', ['dist/stdio.js', '--root', largeDiffRoot, '--allow-root', largeDiffRoot, '--tool-mode', 'full'], {
+  cwd: path.resolve('.'),
+  env: {
+    ...process.env,
+    CODEXPRO_ROOT: largeDiffRoot,
+    CODEXPRO_ALLOWED_ROOTS: largeDiffRoot,
+    CODEXPRO_MAX_OUTPUT_BYTES: '4000'
+  }
+});
+await largeDiffClient.request('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'codexpro-large-diff-smoke', version: '0.1.0' }
+});
+largeDiffClient.notify('notifications/initialized');
+const largeStatsOnlyDiff = await largeDiffClient.request('tools/call', { name: 'git_diff', arguments: { include_diff: false } });
+if (largeStatsOnlyDiff.structuredContent.diff_error || !largeStatsOnlyDiff.structuredContent.changed || largeStatsOnlyDiff.structuredContent.diff !== '') {
+  throw new Error(`git_diff include_diff=false materialized an oversized raw diff: ${JSON.stringify(largeStatsOnlyDiff.structuredContent)}`);
+}
+if (largeStatsOnlyDiff.structuredContent.additions !== largeDiffLines || largeStatsOnlyDiff.structuredContent.deletions !== largeDiffLines) {
+  throw new Error(`git_diff include_diff=false returned wrong large-diff stats: ${JSON.stringify(largeStatsOnlyDiff.structuredContent)}`);
+}
+largeDiffClient.close();
+
 const lowerAgentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codexpro-lower-agents-'));
 await fs.writeFile(path.join(lowerAgentsRoot, 'agents.md'), '# Lowercase agents\n\n- Lowercase instruction file loaded.\n', 'utf8');
 await fs.mkdir(path.join(lowerAgentsRoot, 'src'));

--- a/src/gitOps.ts
+++ b/src/gitOps.ts
@@ -58,6 +58,32 @@ export function gitDiff(config: CodexProConfig, guard: PathGuard, workspace: Wor
   return runGit(workspace, args, config.maxOutputBytes);
 }
 
+export function gitDiffStats(
+  config: CodexProConfig,
+  guard: PathGuard,
+  workspace: Workspace,
+  filePath?: string,
+  staged = false
+): { additions: number; deletions: number; changed: boolean; error?: string } {
+  const args = ["diff", "--numstat", "--no-ext-diff", "--no-textconv"];
+  if (staged) args.push("--staged");
+  if (filePath?.trim()) {
+    const resolved = guard.resolve(workspace, filePath);
+    args.push("--", resolved.relPath);
+  }
+  const output = runGit(workspace, args, config.maxOutputBytes);
+  if (isGitFailure(output)) return { additions: 0, deletions: 0, changed: false, error: output };
+  const lines = outputLines(output);
+  let additions = 0;
+  let deletions = 0;
+  for (const line of lines) {
+    const [added, deleted] = line.split("\t", 2);
+    if (/^\d+$/.test(added)) additions += Number(added);
+    if (/^\d+$/.test(deleted)) deletions += Number(deleted);
+  }
+  return { additions, deletions, changed: lines.length > 0 };
+}
+
 export function gitDiffStatus(config: CodexProConfig, guard: PathGuard, workspace: Workspace, filePath?: string, staged = false): string {
   const args = ["diff", "--name-status"];
   if (staged) args.push("--staged");

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { viewWorkspaceImage } from "./imageOps.js";
 import { importAttachmentFile } from "./importOps.js";
 import { searchWorkspace } from "./searchOps.js";
 import { runBash } from "./bashOps.js";
-import { gitDiff, gitDiffStatus, gitLog, gitStatus } from "./gitOps.js";
+import { gitDiff, gitDiffStats as readGitDiffStats, gitDiffStatus, gitLog, gitStatus } from "./gitOps.js";
 import { readAiBridgeContext, readCodexContext, workspaceSummary } from "./workspaceOps.js";
 import { buildProContext, exportProContext } from "./proContext.js";
 import { codexproInventory, loadSkill } from "./capabilitiesOps.js";
@@ -2124,10 +2124,20 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
     },
     async (args) => {
       const workspace = workspaces.getWorkspace(args.workspace_id);
-      const rawDiff = normalizeGitOutput(gitDiff(config, guard, workspace, args.path, parseBool(args.staged, false)));
-      const diffError = rawDiff && looksLikeGitError(rawDiff) ? rawDiff : "";
-      const stats = diffError ? { additions: 0, deletions: 0, changed: false } : diffStats(rawDiff);
+      const staged = parseBool(args.staged, false);
       const includeDiff = parseBool(args.include_diff, true);
+      let rawDiff = "";
+      let diffError = "";
+      let stats: { additions: number; deletions: number; changed: boolean };
+      if (includeDiff) {
+        rawDiff = normalizeGitOutput(gitDiff(config, guard, workspace, args.path, staged));
+        diffError = rawDiff && looksLikeGitError(rawDiff) ? rawDiff : "";
+        stats = diffError ? { additions: 0, deletions: 0, changed: false } : diffStats(rawDiff);
+      } else {
+        const statsOnly = readGitDiffStats(config, guard, workspace, args.path, staged);
+        diffError = statsOnly.error ?? "";
+        stats = { additions: statsOnly.additions, deletions: statsOnly.deletions, changed: statsOnly.changed };
+      }
       const text = diffError
         ? diffError
         : includeDiff
@@ -2137,7 +2147,7 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
             "",
             `Workspace: ${workspace.root}`,
             `Path: ${args.path ?? "workspace diff"}`,
-            `Staged: ${parseBool(args.staged, false)}`,
+            `Staged: ${staged}`,
             `Diff stats: +${stats.additions} -${stats.deletions}`,
             "",
             "Raw diff omitted by include_diff=false."
@@ -2146,13 +2156,13 @@ export function createCodexProServer(config: CodexProConfig): McpServer {
         workspace_id: workspace.id,
         root: workspace.root,
         path: args.path ?? "workspace diff",
-        staged: parseBool(args.staged, false),
+        staged,
         include_diff: includeDiff,
         diff_error: diffError || undefined,
         additions: stats.additions,
         deletions: stats.deletions,
         changed: !diffError && stats.changed,
-        diff: diffError || includeDiff ? rawDiff : ""
+        diff: diffError || (includeDiff ? rawDiff : "")
       });
     }
   );


### PR DESCRIPTION
## Problem

`git_diff(include_diff=false)` is documented as a stats-only path, but it still materializes the full unified diff before discarding it. Large diffs can therefore exceed the Git child-process output buffer and return `spawnSync git ENOBUFS` even when raw diff output was explicitly disabled.

## Fix

- Use `git diff --numstat` for the stats-only path instead of generating the unified diff.
- Preserve additions, deletions, changed state, path scoping, staged mode, and Git error diagnostics.
- Keep the existing unified-diff path unchanged when `include_diff=true`.

## Regression coverage

The smoke test creates an isolated Git repository with a diff larger than a 4 KB `CODEXPRO_MAX_OUTPUT_BYTES` limit. The test fails on the current upstream implementation with `spawnSync git ENOBUFS` and passes with this change while reporting the expected `+600 / -600` stats and an empty raw diff.

## Verification

- `npm run build`
- `npm run smoke`
- `git diff --check`

Security impact: none expected. This remains a read-only Git operation and keeps the existing path guard and `--no-ext-diff` / `--no-textconv` restrictions.
